### PR TITLE
Add parallel CPU implementation with Open MP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,32 @@ Before building RootPPL programs, a C++/CUDA compiler is required. RootPPL works
 order to build for GPU, CUDA must be installed. See
 CUDA installation guides: [Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/ "CUDA Installation Guide Linux"), 
 [Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html "CUDA Installation Guide Windows"), 
-[Mac](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html "CUDA Installation Guide Mac") 
+[Mac](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html "CUDA Installation Guide Mac").
+
+To run the CPU version in parallel, [OpenMP](https://www.openmp.org/resources/openmp-compilers-tools/) must be installed. 
+OpenMP comes with recent gcc versions. However, OpenMP is not necessary if one does not want to execute programs in parallel on the CPU.
 
 ### Build
 To build the program, clone this repository and change directory to the rootppl folder. Then to compile the model:
 ```
-make MODEL=path/to/model.cu
+make model=path/to/model.cu
 ```
 This will compile the model along with the inference framework for CPU. To compile it for GPU, add your GPU:s compute capability to the arch variable.
 You can find your GPU:s compute capability in the [Wikipedia table](https://en.wikipedia.org/wiki/CUDA#GPUs_supported).
 Here is an example that will compile the airplane example for a GPU with a minimum compute capability of 7.5
 (simply remove `arch=75` to compile for CPU):
 ```
-make MODEL=models/airplane/airplane.cu arch=75 -j5
+make model=models/airplane/airplane.cu arch=75 -j5
+```
+
+The corresponding parallel CPU (OpenMP) example is:
+```
+make model=models/airplane/airplane.cu omp -j5
 ```
 
 The first `make` will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run make with the `-j numThreads` to use multiple threads when building). 
-__Note that if the inference framework is compiled for GPU, and then the model is compiled for CPU, there will be errors. So always perform a `make clean` before switching between CPU and GPU.__
+__Note that if the inference framework is compiled for GPU, and then the model is compiled for CPU, 
+there will be errors. So always perform a `make clean` before switching between CPU and GPU. The same goes for switching to/from OpenMP.__
 
 This should generate an executable named `program`. Execute it with either `make run N=num_particles` or `./program num_particles`. For example:
 ```
@@ -44,7 +53,7 @@ An example out of this:
 ```
 ./program 1000
 Num particles close to target: 96.5%, MinX: 63.1558, MaxX: 84.4023
--119.270143
+log normalization constant = -119.270143
 ```
 First is the command that is executed from the Makefile, it executes the executable `program` with program argument 1000.
 The second row comes from a print statement within the model. Lastly, the log normalization constant approximated by the inference is printed. 
@@ -135,7 +144,7 @@ This example can be found in
 [rootppl/models/simple-examples/coin_flip_mean.cu](rootppl/models/simple-examples/coin_flip_mean.cu)
 and, being in the rootppl directory, compiled with:
 ```
-make MODEL=models/simple-examples/coin_flip_mean.cu
+make model=models/simple-examples/coin_flip_mean.cu
 ```
 
 Then it can be executed with the executable followed by the
@@ -144,7 +153,7 @@ number of particles, for example: `./program 1000`.
 An example output is then:
 ```
 Sample mean: 0.608000
-0.000000
+log normalization constant = 0.000000
 ```
 
 First we see our callback function's output. Then on the next line, is the logarithm of the

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The corresponding parallel CPU (OpenMP) example is:
 make model=models/airplane/airplane.cu omp -j5
 ```
 
-The first `make` will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run make with the `-j numThreads` to use multiple threads when building). 
+The first `make` will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run make with the `-j numThreads` to use multiple threads and speed up the build). 
 __Note that if the inference framework is compiled for GPU, and then the model is compiled for CPU, 
 there will be errors. So always perform a `make clean` before switching between CPU and GPU. The same goes for switching to/from OpenMP.__
 

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -14,8 +14,8 @@
 
 ifdef arch
 # GPU
-CC=/usr/local/cuda-11.0/bin/nvcc
-# CC=nvcc
+# CC=/usr/local/cuda-11.0/bin/nvcc
+CC=nvcc
 FLAGS=-I. -std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -3,21 +3,26 @@
 
 # endef
 
-# ifndef MODEL
-# $(error MODEL argument needs to be set with e.g.: $(\n)make MODEL=path/to/model.cu$(\n))
+# ifndef model
+# $(error model argument needs to be set with e.g.: $(\n)make model=path/to/model.cu$(\n))
 # endif
+
+# ifdef ompthreads
+# OMP = -fopenmp
+# endif
+
 
 ifdef arch
 # GPU
-# CC=/usr/local/cuda-11.0/bin/nvcc
-CC=nvcc
+CC=/usr/local/cuda-11.0/bin/nvcc
+# CC=nvcc
 FLAGS=-I. -std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else
 # CPU
 CC=g++
-FLAGS=-I. -xc++ -std=c++14 -O3
-FLAGS_LINK=-std=c++14 -O3
+FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
+FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif
 
 EXEC_NAME=program
@@ -31,8 +36,8 @@ MISC_SRC=utils/misc.cu
 MATH_SRC=utils/math.cu
 SMC_KERNELS_SRC=inference/smc/smc_kernels.cu
 SYSTEMATIC_COMMON_SRC=inference/smc/resample/systematic/common.cu
-SYSTEMATIC_SEQ_SRC=inference/smc/resample/systematic/sequential.cu
-SYSTEMATIC_PARALLEL_SRC=inference/smc/resample/systematic/parallel.cu
+SYSTEMATIC_SEQ_SRC=inference/smc/resample/systematic/systematic_cpu.cu
+SYSTEMATIC_PARALLEL_SRC=inference/smc/resample/systematic/systematic_gpu.cu
 SYSTEMATIC_KERNELS_SRC=inference/smc/resample/systematic/kernels.cu
 
 OBJDIR=out
@@ -53,17 +58,25 @@ $(EXEC_NAME): $(OBJDIR) $(OBJDIR)/model.o $(OBJ_FILES_FRAMEWORK)
 	rm $(OBJDIR)/model.o
 
 # Compile model, which is always recompiled as it is deleted after the executable is created.
-$(OBJDIR)/model.o: $(MODEL)
-	$(CC) -c $(FLAGS) $(MODEL) -o $@
-# $(CC) -c $(FLAGS) $(MODEL) -o model.o
+$(OBJDIR)/model.o: $(model)
+	$(CC) -c $(FLAGS) $(model) -o $@
+# $(CC) -c $(FLAGS) $(model) -o model.o
 
 $(OBJDIR):
 	mkdir $(OBJDIR)
 
-
 # Compile only framework
 .PHONY: framework
 framework: $(OBJDIR) $(OBJ_FILES_FRAMEWORK)
+
+.PHONY: ompframework
+ompframework: openmpflag $(OBJDIR) $(OBJ_FILES_FRAMEWORK)
+
+.PHONY: omp openmpflag
+omp: openmpflag $(EXEC_NAME)
+
+openmpflag:
+	$(eval OMP = -fopenmp)
 
 # $(OBJ_FILES_FRAMEWORK): $(FRAMEWORK_FILES)
 	# $(CC) -c $(FLAGS) $< -o $@

--- a/rootppl/dists/dists.cu
+++ b/rootppl/dists/dists.cu
@@ -49,7 +49,6 @@ std::normal_distribution<floating_t> normalDist(0, 1);
 void initGen() {
     #ifdef _OPENMP
     int maxThreads = omp_get_max_threads();
-    printf("maxNumThreads: %d\n", maxThreads);
     // generatorDists = new std::default_random_engine[maxThreads];
     genWrappers = new generator_wrapper[maxThreads];
     for(int i = 0; i < maxThreads; i++) {

--- a/rootppl/dists/dists.cuh
+++ b/rootppl/dists/dists.cuh
@@ -20,10 +20,15 @@
  * This curandState will be present in the BBLOCK and BBLOCK_HELPER functions. 
  */
 
- /**
-  * Should be called before inference starts. Done in MAIN macro.
-  */
- void initGen();
+/**
+ * Initializes the generator(s) used on CPU. Should be called before inference starts. Done in MAIN macro.
+ */
+void initGen();
+
+/**
+ * Frees the generator(s) used on CPU. Should be called after inference is done. Done in MAIN macro.
+ */
+void freeGen();
 
  /**
  * Returns a sample from the Uniform distribution on the interval (min, max]

--- a/rootppl/dists/dists_cpu.cuh
+++ b/rootppl/dists/dists_cpu.cuh
@@ -5,6 +5,10 @@
  * File dists_cpu.cuh contains primitive distributions specific for the CPU. 
  */
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 
 /**
  * Returns a sample from the Uniform distribution on the interval [min, max)
@@ -14,7 +18,13 @@
  * @return U[min, max)
  */
 floating_t uniform(floating_t min, floating_t max) {
-    return (uniformDist(generatorDists) * (max - min)) + min;
+    floating_t u;
+    #ifdef _OPENMP
+    u = uniformDist(genWrappers[omp_get_thread_num()].gen);
+    #else
+    u = uniformDist(gen);
+    #endif
+    return (u * (max - min)) + min;
 }
 
 /**
@@ -25,7 +35,13 @@ floating_t uniform(floating_t min, floating_t max) {
  * @return N(mean, std^2)
  */
 floating_t normal(floating_t mean, floating_t std) {
-    return (normalDist(generatorDists) * std) + mean;
+    floating_t n;
+    #ifdef _OPENMP
+    n = normalDist(genWrappers[omp_get_thread_num()].gen);
+    #else
+    n = normalDist(gen);
+    #endif
+    return (n * std) + mean;
 }
 
 /**
@@ -37,7 +53,11 @@ floating_t normal(floating_t mean, floating_t std) {
 unsigned int poisson(double lambda) {
     // Reuse distribution object when possible? However, does not seem to be that expensive to create dist object
     std::poisson_distribution<unsigned int> poissonDist(lambda);
-    return poissonDist(generatorDists);
+    #ifdef _OPENMP
+    return poissonDist(genWrappers[omp_get_thread_num()].gen);
+    #else
+    return poissonDist(gen);
+    #endif
 }
 
 #endif

--- a/rootppl/inference/smc/resample/systematic/common.cu
+++ b/rootppl/inference/smc/resample/systematic/common.cu
@@ -10,12 +10,16 @@
 #include "utils/misc.cuh"
 #include "inference/smc/particles_memory_handler.cuh"
 
+#ifdef __NVCC__
 std::default_random_engine generatorRes;
 std::uniform_real_distribution<floating_t> uniformCPU(0.0, 1.0);
+#endif
 
 resampler_t initResampler(int numParticles, size_t progStateSize) {
 
+    #ifdef __NVCC__
     generatorRes.seed(time(NULL) * 3); // Multiply by 3 to avoid same seed as distributions. 
+    #endif
     resampler_t resampler;
 
     allocateMemory<int>(&resampler.ancestor, numParticles);

--- a/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
@@ -2,21 +2,20 @@
 #define RESAMPLE_CPU_INCLUDED
 
 /*
- * File sequential.cuh contains the sequential implementation of the systematic resampling. 
+ * File systematic_cpu.cuh contains the CPU implementation of the systematic resampling. 
  */
 
 #include "common.cuh"
 
 /**
- * Calculates the log weight prefix sums safely according to the identity in the appendix of 
- * the paper "Parallel resampling in the particle filter", L. M. Murray et. al. 
+ * Calculates the log weight prefix sums. 
  * 
  * @param w the weight array.
  * @param resampler the resampler struct.
  * @param numParticles the number of particles used in SMC.
  * @return the logarithm of the total weight sum. 
  */
-HOST DEV floating_t calcLogWeightSumSeq(floating_t* w, resampler_t resampler, int numParticles);
+HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t resampler, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 
@@ -26,7 +25,7 @@ HOST DEV floating_t calcLogWeightSumSeq(floating_t* w, resampler_t resampler, in
  * @param u a sample from the standard uniform distribution. 
  * @param numParticles the number of particles used in SMC.
  */
-HOST DEV void systematicCumulativeOffspringSeq(floating_t* prefixSum, int* cumulativeOffspring, floating_t u, int numParticles);
+HOST DEV void systematicCumulativeOffspringCpu(floating_t* prefixSum, int* cumulativeOffspring, floating_t u, int numParticles);
 
 /**
  * Uses the cumulative offspring to assign the ancestor indices used for resample propagation. 
@@ -35,7 +34,7 @@ HOST DEV void systematicCumulativeOffspringSeq(floating_t* prefixSum, int* cumul
  * @param ancestor the array to store the result in. 
  * @param numParticles the number of particles used in SMC.
  */
-HOST DEV void cumulativeOffspringToAncestorSeq(int* cumulativeOffspring, int* ancestor, int numParticles);
+HOST DEV void cumulativeOffspringToAncestorCpu(int* cumulativeOffspring, int* ancestor, int numParticles);
 
 /**
  * Propagates the particles. Copies them from the ancestor to the new particles. 
@@ -44,16 +43,16 @@ HOST DEV void cumulativeOffspringToAncestorSeq(int* cumulativeOffspring, int* an
  * @param resampler the resampler struct reference.
  * @param numParticles the number of particles used in SMC.
  */
-HOST DEV void copyStatesSeq(particles_t& particles, resampler_t& resampler, int numParticles);
+HOST DEV void copyStatesCpu(particles_t& particles, resampler_t& resampler, int numParticles);
 
 /**
- * Performs sequential resampling. Used in both top-level and nested SMC. 
+ * Performs CPU resampling. Used in both top-level and nested SMC. 
  * 
  * @param takes a curandState as argument if it runs on the GPU (nested SMC).
  * @param particles the particles struct reference.
  * @param resampler the resampler struct reference.
  * @param numParticles the number of particles used in SMC.
  */
-DEV void resampleSystematicSeq(RAND_STATE_DECLARE particles_t& particles, resampler_t& resampler, int numParticles);
+DEV void resampleSystematicCpu(RAND_STATE_DECLARE particles_t& particles, resampler_t& resampler, int numParticles);
 
 #endif

--- a/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
@@ -2,7 +2,7 @@
 #define RESAMPLE_GPU_INCLUDED
 
 /*
- * File parallel.cuh contains the parallel implementation of the systematic resampling. 
+ * File systematic_gpu.cuh contains the GPU implementation of the systematic resampling. 
  */
 
 #ifdef __NVCC__
@@ -21,7 +21,7 @@ HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numPartic
  * @param numThreadsPerBlock kernel launch setting.
  * @return the logarithm of the total weight sum. 
  */
-HOST DEV floating_t calcLogWeightSumPar(floating_t* w, resampler_t resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
+HOST DEV floating_t calcLogWeightSumGpu(floating_t* w, resampler_t resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
 
 /**
  * Calculates the cumulative offsprings and then uses it to calculate the ancestor indices. 
@@ -47,7 +47,7 @@ HOST DEV void decideAncestors(resampler_t& resampler, floating_t u, int numParti
 HOST DEV void postUniform(particles_t& particles, resampler_t& resampler, floating_t u, int numParticles, int numBlocks, int numThreadsPerBlock);
 
 /**
- * Performs parallel resampling. Uses CUDA Dynamic Parallelism (launches kernels within kernels). Used in nested inference.
+ * Performs GPU resampling. Uses CUDA Dynamic Parallelism (launches kernels within kernels). Used in nested inference.
  * 
  * @param randState the curandState used to draw a random uniform sample on the GPU. 
  * @param particles the particles struct reference.
@@ -55,17 +55,17 @@ HOST DEV void postUniform(particles_t& particles, resampler_t& resampler, floati
  * @param numParticles the number of particles used in SMC.
  * @param numBlocks kernel launch setting.
  */
-DEV void resampleSystematicParNested(curandState* randState, particles_t& particles, resampler_t& resampler, int numParticles, int numBlocks);
+DEV void resampleSystematicGpuNested(curandState* randState, particles_t& particles, resampler_t& resampler, int numParticles, int numBlocks);
 
 /**
- * Performs parallel resampling. Uses CUDA Dynamic Parallelism (launches kernels within kernels). Used in top-level inference. 
+ * Performs GPU resampling. Uses CUDA Dynamic Parallelism (launches kernels within kernels). Used in top-level inference. 
  * 
  * @param particles the particles struct reference.
  * @param resampler the resampler struct reference.
  * @param numParticles the number of particles used in SMC.
  * @param numBlocks kernel launch setting.
  */
-void resampleSystematicPar(particles_t& particles, resampler_t& resampler, int numParticles, int numBlocks);
+void resampleSystematicGpu(particles_t& particles, resampler_t& resampler, int numParticles, int numBlocks);
 
 #endif
 

--- a/rootppl/inference/smc/smc.cu
+++ b/rootppl/inference/smc/smc.cu
@@ -6,26 +6,32 @@
  */
 
 #include <iostream>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #include "macros/macros.cuh"
 #include "smc.cuh"
 #include "dists/dists.cuh"
 #include "particles_memory_handler.cuh"
-#include "resample/systematic/sequential.cuh"
+#include "resample/systematic/systematic_cpu.cuh"
 // #include "smc_include.cuh"
 
 #ifdef __NVCC__
 #include <curand_kernel.h>
 // #include "cuda_profiler_api.h"
 #include "utils/cuda_error_utils.cuh"
-#include "resample/systematic/parallel.cuh"
+#include "resample/systematic/systematic_gpu.cuh"
 #include "smc_kernels.cuh"
 #endif
 
-
-double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int particlesPerThread, 
+ 
+double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int ompThreads, const int particlesPerThread,
                 size_t progStateSize, callbackFunc_t callback, void* arg) {
 
+    #ifdef _OPENMP
+    omp_set_num_threads(ompThreads);
+    #endif
     floating_t logNormConstant = 0;
 
     particles_t particles = allocateParticles(numParticles, progStateSize, false);
@@ -54,23 +60,28 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
         execFuncs<<<NUM_BLOCKS_EXEC, NUM_THREADS_PER_BLOCK>>>(randStates, particles, bblocks, numParticles, numThreads, arg);
         cudaDeviceSynchronize();
         cudaCheckError();
-        floating_t logWeightSum = calcLogWeightSumPar(particles.weights, resampler, numParticles, NUM_BLOCKS, NUM_THREADS_PER_BLOCK);
+        floating_t logWeightSum = calcLogWeightSumGpu(particles.weights, resampler, numParticles, NUM_BLOCKS, NUM_THREADS_PER_BLOCK);
         #else
 
+        #pragma omp parallel for
         for(int i = 0; i < numParticles; i++) {
+            /*if (tid == 0) {
+                int nthreads = omp_get_num_threads(); 
+                printf("Number of threads = %d\n", nthreads); 
+            }*/
             int pc = particles.pcs[i];
             if(pc < numBblocks && pc >= 0)
                 bblocks[pc](particles, i, arg);
         }
-        floating_t logWeightSum = calcLogWeightSumSeq(particles.weights, resampler, numParticles);
+        floating_t logWeightSum = calcLogWeightSumCpu(particles.weights, resampler, numParticles);
         #endif
 
         logNormConstant += logWeightSum - log(numParticles);
         
         #ifdef __NVCC__
-        resampleSystematicPar(particles, resampler, numParticles, NUM_BLOCKS);
+        resampleSystematicGpu(particles, resampler, numParticles, NUM_BLOCKS);
         #else
-        resampleSystematicSeq(particles, resampler, numParticles);
+        resampleSystematicCpu(particles, resampler, numParticles);
         #endif
         
         // This last resample increases variance perhaps? But convenient to not have to consider weights when extracting distribution. 

--- a/rootppl/inference/smc/smc.cu
+++ b/rootppl/inference/smc/smc.cu
@@ -30,7 +30,8 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
                 size_t progStateSize, callbackFunc_t callback, void* arg) {
 
     #ifdef _OPENMP
-    omp_set_num_threads(ompThreads);
+    if(ompThreads > 0)
+        omp_set_num_threads(ompThreads);
     #endif
     floating_t logNormConstant = 0;
 
@@ -52,7 +53,6 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
 
     resampler_t resampler = initResampler(numParticles, progStateSize);
 
-    // cudaProfilerStart();
     // Run program/inference
     while(true) {
 
@@ -65,10 +65,6 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
 
         #pragma omp parallel for
         for(int i = 0; i < numParticles; i++) {
-            /*if (tid == 0) {
-                int nthreads = omp_get_num_threads(); 
-                printf("Number of threads = %d\n", nthreads); 
-            }*/
             int pc = particles.pcs[i];
             if(pc < numBblocks && pc >= 0)
                 bblocks[pc](particles, i, arg);
@@ -89,7 +85,6 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
             break;
         
     }
-    // cudaProfilerStop();
 
     if(callback != NULL)
         callback(particles, numParticles, NULL);

--- a/rootppl/inference/smc/smc.cuh
+++ b/rootppl/inference/smc/smc.cuh
@@ -77,13 +77,14 @@ using callbackFunc_t = void (*)(particles_t&, int, void*);
  * @param bblocks the array of functions that will be executed by SMC.
  * @param numBblocks the size of the bblocks array.
  * @param numParticles number of particles to be used in SMC.
+ * @param ompThreads controls the maximum number of threads used by Open MP on the CPU variant. 
  * @param particlesPerThread indirectly determines how many CUDA threads will be necessary. Not used in CPU variant.
  * @param progStateSize The size of the program state used by each particle. 
  * @param callback optional function that should be called with the resulting particles after inference.
  * @param arg optional argument to be passed to the bblocks (global data is often used instead for top-level SMC).
  * @return the logged normalization constant.
  */
-double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int particlesPerThread, 
+double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int ompThreads, const int particlesPerThread,
     size_t progStateSize, callbackFunc_t callback = NULL, void* arg = NULL);
 
     

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -110,7 +110,7 @@ int main(int argc, char** argv) { \
     int bbIdx = 0; \
     double res = 0; \
     body \
-    printf("%f\n", res); \
+    printf("log normalization constant = %f\n", res); \
     return 0; \
 }
 
@@ -153,9 +153,13 @@ int numParticles = 10000; \
 if(argc > 1) { \
     numParticles = atoi(argv[1]); \
 } \
-int particlesPerThread = 1; \
+int ompThreads = 4; \
 if(argc > 2) { \
-    particlesPerThread = atoi(argv[2]); \
+    ompThreads = atoi(argv[2]); \
+} \
+int particlesPerThread = 1; \
+if(argc > 3) { \
+    particlesPerThread = atoi(argv[3]); \
 } \
 int numBblocks = bbIdx; \
 configureMemSizeGPU(); \
@@ -164,7 +168,7 @@ pplFunc_t* bblocksArrCudaManaged; \
 ALLOC_TYPE(&bblocksArrCudaManaged, pplFunc_t, numBblocks); \
 for(int i = 0; i < numBblocks; i++) \
     bblocksArrCudaManaged[i] = bblocksArr[i]; \
-res = runSMC(bblocksArrCudaManaged, numBblocks, numParticles, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
+res = runSMC(bblocksArrCudaManaged, numBblocks, numParticles, ompThreads, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
 FREE(bblocksArrCudaManaged)
 
 // freeMemory<pplFunc_t>(bblocksArrCudaManaged);

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -111,6 +111,7 @@ int main(int argc, char** argv) { \
     double res = 0; \
     body \
     printf("log normalization constant = %f\n", res); \
+    freeGen(); \
     return 0; \
 }
 
@@ -153,7 +154,7 @@ int numParticles = 10000; \
 if(argc > 1) { \
     numParticles = atoi(argv[1]); \
 } \
-int ompThreads = 4; \
+int ompThreads = -1; \
 if(argc > 2) { \
     ompThreads = atoi(argv[2]); \
 } \

--- a/rootppl/models/phylogenetics/bamm/bamm.cu
+++ b/rootppl/models/phylogenetics/bamm/bamm.cu
@@ -265,7 +265,6 @@ CALLBACK(callback, {
 })
 
 MAIN({
-    initGen();
 
     ADD_BBLOCK(simBAMM)
     ADD_BBLOCK(simTree)

--- a/rootppl/models/phylogenetics/clads2/clads2.cu
+++ b/rootppl/models/phylogenetics/clads2/clads2.cu
@@ -225,7 +225,6 @@ CALLBACK(callback, {
 })
 
 MAIN({
-    initGen();
 
     ADD_BBLOCK(simClaDS2);
     ADD_BBLOCK(simTree);


### PR DESCRIPTION
Adds an Open MP parallel implementation to the CPU version of SMC. To get correct results an array of random number generators are created, one for each thread. The readme got some fixes and added sections about the phylogenetic models and the architecture of SMC. 