### PR TITLE
Add ANF, symbolization, and alpha equality

### DIFF
--- a/coreppl/anf.mc
+++ b/coreppl/anf.mc
@@ -1,0 +1,25 @@
+include "ast.mc"
+include "mexpr/anf.mc"
+
+lang PPLCore = PPLCore + MExprANF
+
+  sem isValue =
+  | TmWeight _ -> false
+  | TmSampleExp _ -> false
+  | TmSampleBern _ -> false
+  | TmResample _ -> false
+
+  sem normalize (k : Expr -> Expr) =
+  | TmWeight { arg = arg } ->
+    normalizeName (lam arg. bind k (TmWeight { arg = arg })) arg
+
+  | TmSampleExp { a = a } ->
+    normalizeName (lam a. bind k (TmSampleExp { a = a })) a
+
+  | TmSampleBern { p = p } ->
+    normalizeName (lam p. bind k (TmSampleBern { p = p })) p
+
+  | TmResample {} -> k (TmResample {})
+
+end
+

--- a/coreppl/ast-builder.mc
+++ b/coreppl/ast-builder.mc
@@ -1,11 +1,12 @@
 -- Convenience functions for manually constructing ASTs
 
 include "ast.mc"
+include "mexpr/ast-builder.mc"
 
-let weight_ = use PPLCoreAst in lam arg. TmWeight {arg = arg}
+let weight_ = use PPLCore in lam arg. TmWeight {arg = arg}
 
-let sampleExp_ = use PPLCoreAst in lam a. TmSampleExp {a = a}
+let sampleExp_ = use PPLCore in lam a. TmSampleExp {a = a}
 
-let sampleBern_ = use PPLCoreAst in lam p. TmSampleBern {p = p}
+let sampleBern_ = use PPLCore in lam p. TmSampleBern {p = p}
 
-let resample_ = use PPLCoreAst in TmResample {}
+let resample_ = use PPLCore in TmResample {}

--- a/coreppl/ast.mc
+++ b/coreppl/ast.mc
@@ -2,7 +2,7 @@
 
 include "mexpr/ast.mc"
 
-lang PPLCoreAst = MExprAst
+lang PPLCore = MExprAst
 
   syn Expr =
   | TmWeight { arg: Expr }

--- a/coreppl/crbd.mc
+++ b/coreppl/crbd.mc
@@ -132,6 +132,22 @@ let crbd =
   ]
 in
 
+-- let t0 = wallTimeMs () in
+-- let r1 = symbolize crbd in
+-- let t1 = wallTimeMs () in
+-- let r2 = normalizeTerm r1 in
+-- let t2 = wallTimeMs () in
+-- let r3 = expr2str r2 in
+-- let t3 = wallTimeMs () in
+
+-- let _ = print "\nSymbolize time: " in
+-- let _ = printLn (float2string (subf t1 t0)) in
+-- let _ = print "ANF time: " in
+-- let _ = printLn (float2string (subf t2 t1)) in
+-- let _ = print "expr2str time: " in
+-- let _ = printLn (float2string (subf t3 t2)) in
+-- expr2str is really slow (3.697662 seconds)
+
 let _ = printLn "--- BEFORE ANF ---" in
 let _ = printLn (expr2str crbd) in
 let _ = printLn "\n--- AFTER SYMBOLIZE AND ANF ---" in

--- a/coreppl/crbd.mc
+++ b/coreppl/crbd.mc
@@ -131,4 +131,4 @@ let crbd =
   ]
 in
 
-printLn (pprintCode 0 crbd)
+printLn (expr2str crbd)

--- a/coreppl/crbd.mc
+++ b/coreppl/crbd.mc
@@ -8,6 +8,7 @@ include "ast.mc"
 include "symbolize.mc"
 include "ast-builder.mc"
 include "pprint.mc"
+include "anf.mc"
 
 mexpr
 use PPLCore in
@@ -131,4 +132,8 @@ let crbd =
   ]
 in
 
-printLn (expr2str crbd)
+let _ = printLn "--- BEFORE ANF ---" in
+let _ = printLn (expr2str crbd) in
+let _ = printLn "\n--- AFTER SYMBOLIZE AND ANF ---" in
+let _ = printLn (expr2str (normalizeTerm (symbolize crbd))) in
+()

--- a/coreppl/eq.mc
+++ b/coreppl/eq.mc
@@ -1,0 +1,24 @@
+include "ast.mc"
+include "mexpr/eq.mc"
+
+lang PPLCore = PPLCore + MExprEq
+
+  sem eqExprH (env : Env) (free : Env) (lhs : Expr) =
+  | TmWeight { arg = arg2 } ->
+    match lhs with TmWeight { arg = arg1 } then
+      eqExprH env free arg1 arg2
+    else None ()
+
+  | TmSampleExp { a = a2 } ->
+    match lhs with TmSampleExp { a = a1 } then
+      eqExprH env free a1 a2
+    else None ()
+
+  | TmSampleBern { p = p2 } ->
+    match lhs with TmSampleBern { p = p1 } then
+      eqExprH env free p1 p2
+    else None ()
+
+  | TmResample {} ->
+
+end

--- a/coreppl/pprint.mc
+++ b/coreppl/pprint.mc
@@ -3,18 +3,18 @@
 include "ast.mc"
 include "mexpr/pprint.mc"
 
-lang PPLCorePrettyPrint = PPLCoreAst + MExprPrettyPrint
+lang PPLCore = PPLCore + MExprPrettyPrint
 
   sem pprintCode (indent : Int) =
   | TmWeight t ->
     let arg = pprintCode indent t.arg in
-    strJoin "" ["weight(", arg, ")"]
+    join ["weight(", arg, ")"]
   | TmSampleExp t ->
     let a = pprintCode indent t.a in
-    strJoin "" ["sampleExp(", a, ")"]
+    join ["sampleExp(", a, ")"]
   | TmSampleBern t ->
     let p = pprintCode indent t.p in
-    strJoin "" ["sampleBern(", p, ")"]
+    join ["sampleBern(", p, ")"]
   | TmResample _ -> "resample"
 
 end

--- a/coreppl/pprint.mc
+++ b/coreppl/pprint.mc
@@ -5,16 +5,19 @@ include "mexpr/pprint.mc"
 
 lang PPLCore = PPLCore + MExprPrettyPrint
 
-  sem pprintCode (indent : Int) =
+  sem pprintCode (indent : Int) (env: Env) =
   | TmWeight t ->
-    let arg = pprintCode indent t.arg in
-    join ["weight(", arg, ")"]
+    match printParen (incr indent) env t.arg with (env,arg) then
+      (env, join ["weight", newline (incr indent), arg])
+    else never
   | TmSampleExp t ->
-    let a = pprintCode indent t.a in
-    join ["sampleExp(", a, ")"]
+    match printParen (incr indent) env t.a with (env,a) then
+      (env,join ["sampleExp", newline (incr indent), a])
+    else never
   | TmSampleBern t ->
-    let p = pprintCode indent t.p in
-    join ["sampleBern(", p, ")"]
-  | TmResample _ -> "resample"
+    match printParen (incr indent) env t.p with (env,p) then
+      (env,join ["sampleBern", newline (incr indent), p])
+    else never
+  | TmResample _ -> (env,"resample")
 
 end

--- a/coreppl/symbolize.mc
+++ b/coreppl/symbolize.mc
@@ -3,8 +3,8 @@ include "mexpr/symbolize.mc"
 
 lang PPLCore = PPLCore + MExprSym
   sem symbolizeExpr (env : Env) =
-  | TmWeight { arg = expr } -> TmWeight { arg = symbolize env expr }
-  | TmSampleExp { a = expr } -> TmSampleExp { a = symbolize env expr}
-  | TmSampleBern { p = expr } -> TmSampleBern { p = symbolize env expr}
+  | TmWeight { arg = expr } -> TmWeight { arg = symbolizeExpr env expr }
+  | TmSampleExp { a = expr } -> TmSampleExp { a = symbolizeExpr env expr}
+  | TmSampleBern { p = expr } -> TmSampleBern { p = symbolizeExpr env expr}
   | TmResample {} -> TmResample {}
 end

--- a/coreppl/symbolize.mc
+++ b/coreppl/symbolize.mc
@@ -1,0 +1,9 @@
+include "mexpr/symbolize.mc"
+
+lang PPLCore = PPLCore + MExprSym
+  sem symbolize (env : Env) =
+  | TmWeight { arg = expr } -> TmWeight { arg = symbolize env expr }
+  | TmSampleExp { a = expr } -> TmSampleExp { a = symbolize env expr}
+  | TmSampleBern { p = expr } -> TmSampleBern { p = symbolize env expr}
+  | TmResample {} -> TmResample {}
+end

--- a/coreppl/symbolize.mc
+++ b/coreppl/symbolize.mc
@@ -1,7 +1,8 @@
+include "ast.mc"
 include "mexpr/symbolize.mc"
 
 lang PPLCore = PPLCore + MExprSym
-  sem symbolize (env : Env) =
+  sem symbolizeExpr (env : Env) =
   | TmWeight { arg = expr } -> TmWeight { arg = symbolize env expr }
   | TmSampleExp { a = expr } -> TmSampleExp { a = symbolize env expr}
   | TmSampleBern { p = expr } -> TmSampleBern { p = symbolize env expr}


### PR DESCRIPTION
Update CorePPL after changes to main Miking repository. Mainly, add support for ANF transformation, symbolization, and (alpha) equality checking of terms.