### PR TITLE
Fix bug: CPU did not save max log weight to resampler struct, update lgss example model

### DIFF
--- a/rootppl/inference/smc/resample/systematic/systematic_cpu.cu
+++ b/rootppl/inference/smc/resample/systematic/systematic_cpu.cu
@@ -9,7 +9,7 @@
 
 #include <math.h>
 
-HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t resampler, int numParticles) {
+HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t& resampler, int numParticles) {
     floating_t maxLogWeight;
     #ifdef _OPENMP
     maxLogWeight = -INFINITY;
@@ -21,6 +21,7 @@ HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t resampler, in
     #else
     maxLogWeight = maxNaive(w, numParticles);
     #endif
+    resampler.maxLogWeight = maxLogWeight;
 
     // Corresponds to ExpWeightsKernel used in the parallel implementation
     #pragma omp parallel for

--- a/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
@@ -15,7 +15,7 @@
  * @param numParticles the number of particles used in SMC.
  * @return the logarithm of the total weight sum. 
  */
-HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t resampler, int numParticles);
+HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t& resampler, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 

--- a/rootppl/models/simple-examples/lgss.cu
+++ b/rootppl/models/simple-examples/lgss.cu
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <cstring>
+#include <math.h>
 
 #include "inference/smc/smc.cuh"
 
@@ -35,7 +36,8 @@ BBLOCK(lgss, progState_t, {
     floating_t* dataP = DATA_POINTER(data);
     
     PSTATE.x = SAMPLE(normal, PSTATE.x + 2.0, 1);
-    WEIGHT(normalScore(dataP[PSTATE.t], PSTATE.x, 1.0));
+    // WEIGHT(normalScore(dataP[PSTATE.t], PSTATE.x, 1.0));
+    OBSERVE(normal, PSTATE.x, 1.0, dataP[PSTATE.t]);
 
     if(++PSTATE.t == NUM_OBS)
         PC++;
@@ -44,12 +46,11 @@ BBLOCK(lgss, progState_t, {
 
 CALLBACK(callback, {
     
-    floating_t xSum = 0;
+    floating_t weightedSum = 0;
     for (int i = 0; i < N; i++)
-        xSum += PSTATES[i].x;
-    int i = N / 2;
-    printf("Mean x: %f, Median x: %f\n", xSum / N, PSTATES[i].x);
-    
+        weightedSum += PSTATES[i].x * exp(WEIGHTS[i]);
+        
+    printf("Estimated Mean x: %f\n", weightedSum);
 })
 
 void setup() {


### PR DESCRIPTION
- resampler struct passed by reference to modify its max log weight
- update the resampler's max log weight
- replace WEIGHT with OBSERVE in lgss, and use normalized log weights to extract results correctly