### PR TITLE
SMC updates and distributions

### DIFF
--- a/rootppl/.gitignore
+++ b/rootppl/.gitignore
@@ -6,3 +6,8 @@ __pycache__/
 out/
 program
 parameterData
+parameterDataImmediate
+parameterDataDelayed
+inference_result.txt
+ess.txt
+log_norm_const.txt

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -21,7 +21,7 @@ FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else
 # CPU
 CC=g++
-FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP) -g -Wfatal-errors
+FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
 FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif
 

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -21,7 +21,7 @@ FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else
 # CPU
 CC=g++
-FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
+FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP) -g -Wfatal-errors
 FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif
 
@@ -35,14 +35,15 @@ PARTICLES_MEMORY_HANDLER_SRC=inference/smc/particles_memory_handler.cu
 MISC_SRC=utils/misc.cu
 MATH_SRC=utils/math.cu
 SMC_KERNELS_SRC=inference/smc/smc_kernels.cu
-SYSTEMATIC_COMMON_SRC=inference/smc/resample/systematic/common.cu
+SYSTEMATIC_COMMON_SRC=inference/smc/resample/common.cu
 SYSTEMATIC_SEQ_SRC=inference/smc/resample/systematic/systematic_cpu.cu
 SYSTEMATIC_PARALLEL_SRC=inference/smc/resample/systematic/systematic_gpu.cu
 SYSTEMATIC_KERNELS_SRC=inference/smc/resample/systematic/kernels.cu
+FILE_HANDLER_SRC=inference/smc/file_handler.cu
 
 OBJDIR=out
 _OBJ_FILES_FRAMEWORK=smc.o smc_nested.o dists.o scores.o particles_memory_handler.o misc.o math.o \
-	smc_kernels.o systematic_common.o systematic_seq.o systematic_parallel.o systematic_kernels.o
+	smc_kernels.o systematic_common.o systematic_seq.o systematic_parallel.o systematic_kernels.o file_handler.o
 OBJ_FILES_FRAMEWORK=$(patsubst %.o, $(OBJDIR)/%.o, $(_OBJ_FILES_FRAMEWORK))
 
 # SMC_DEPS = $(wildcard inference/smc/*.cuh) $(wildcard inference/smc/resample/*/*.cuh) $(wildcard macros/*.cuh) dists/dists.cuh utils/cuda_error_utils.cuh utils/misc.cuh utils/math.cuh
@@ -129,6 +130,9 @@ $(OBJDIR)/systematic_parallel.o: $(FRAMEWORK_FILES)
 # $(OBJDIR)/systematic_kernels.o: $(SYSTEMATIC_KERNELS_SRC) inference/smc/smc.cuh
 $(OBJDIR)/systematic_kernels.o: $(FRAMEWORK_FILES)
 	$(CC) -c $(FLAGS) $(SYSTEMATIC_KERNELS_SRC) -o $@
+
+$(OBJDIR)/file_handler.o: $(FRAMEWORK_FILES)
+	$(CC) -c $(FLAGS) $(FILE_HANDLER_SRC) -o $@
 
 .PHONY: clean
 clean:

--- a/rootppl/dists/dists.cu
+++ b/rootppl/dists/dists.cu
@@ -195,3 +195,12 @@ DEV void multivariateStandardNormal(RAND_STATE_DECLARE int n, floating_t* ret) {
     }
 }
 
+DEV floating_t lomax(RAND_STATE_DECLARE floating_t lambda, floating_t alpha) {
+    floating_t u = SAMPLE(uniform, 0, 1);
+    return lambda*(pow(u, -1.0/alpha) - 1.0);
+}
+
+DEV int negativeBinomial(RAND_STATE_DECLARE floating_t p, int n) {
+    return n - SAMPLE(binomial, p, n);
+}
+

--- a/rootppl/dists/dists.cuh
+++ b/rootppl/dists/dists.cuh
@@ -123,6 +123,15 @@ DEV floating_t gamma(RAND_STATE_DECLARE floating_t k, floating_t theta);
 DEV floating_t laplace(RAND_STATE_DECLARE floating_t loc, floating_t scale);
 
 /**
+ * Returns a sample from the Lomax distribution.
+ *
+ * @param lambda parameter of the lomax distribution
+ * @param alpha parameter of the lomax distribution
+ * @return Lomax(lambda, alpha)
+ */
+DEV floating_t lomax(RAND_STATE_DECLARE floating_t lambda, floating_t alpha);
+
+/**
  * Returns a sample from the Multinomial distribution. The number of successes for each "bin".
  * 
  * @param ps the success probabilities.
@@ -148,6 +157,15 @@ DEV void multivariateStandardNormal(RAND_STATE_DECLARE int n, floating_t* ret);
  * @return N(mean, std^2)
  */
 DEV floating_t normal(RAND_STATE_DECLARE floating_t mean, floating_t std);
+
+/**
+ * Returns a sample from the Negative Binomial distribution.
+ * 
+ * @param p the success probability.
+ * @param n the number of trials.
+ * @return the number of failures over n independent trials with success probability p. 
+ */
+ DEV int negativeBinomial(RAND_STATE_DECLARE floating_t p, int n);
 
 /**
  * Returns a sample from the Poisson distribution. 

--- a/rootppl/dists/scores.cu
+++ b/rootppl/dists/scores.cu
@@ -9,6 +9,8 @@
 
 #include <math.h>
 #include <stdio.h>
+// V: for assert
+#include <cassert>
 
 #include "macros/macros.cuh"
 #include "utils/math.cuh"
@@ -187,4 +189,25 @@ HOST DEV floating_t uniformScore(floating_t min, floating_t max, floating_t x) {
         return -INFINITY;
     else
         return -log(max - min);
+}
+
+// V: Score function for the negative binomial distribution
+// Implementation inspired by Birch
+// see https://github.com/lawmurray/Birch/blob/master/libraries/Standard/src/math/logpdf.birch
+// It makes use of log() and log1p() which should be in <math.h>
+// and lchoose, which I have implemented in 
+// - x: The variate (number of failures).
+// - k: Number of successes before the experiment is stopped. must be > 0
+// - p: Probability of success. must be in [0, 1]
+// Returns: the log probability mass.
+HOST DEV floating_t negativeBinomialScore(floating_t x, floating_t k, floating_t p) {
+    assert(0 < k);
+    assert(0.0 <= p && p <= 1.0);
+  
+    if (x >= 0) {
+      return k*log(p) + x*log1p(-p) + lchoose(x + k - 1, x);
+    } else {
+      return -INFINITY;
+    }
+    
 }

--- a/rootppl/dists/scores.cu
+++ b/rootppl/dists/scores.cu
@@ -157,6 +157,10 @@ HOST DEV floating_t laplaceScore(floating_t loc, floating_t scale, floating_t x)
     return -1 * (log(2 * scale) + abs(x - loc) / scale);
 }
 
+HOST DEV floating_t lomaxScore(floating_t x, floating_t lambda, floating_t alpha) {
+    return log(alpha) - log(lambda) - (alpha + 1) * log(1 + x / lambda);
+}
+
 // multinomial
 
 // multiVariateNormal

--- a/rootppl/dists/scores.cuh
+++ b/rootppl/dists/scores.cuh
@@ -43,6 +43,8 @@ HOST DEV floating_t gammaScore(floating_t k, floating_t theta, floating_t x);
 
 HOST DEV floating_t laplaceScore(floating_t loc, floating_t scale, floating_t x);
 
+HOST DEV floating_t lomaxScore(floating_t x, floating_t lambda, floating_t alpha);
+
 // multinomial
 
 // multiVariateNormal

--- a/rootppl/dists/scores.cuh
+++ b/rootppl/dists/scores.cuh
@@ -54,4 +54,7 @@ HOST DEV floating_t normalScore(floating_t mean, floating_t std, floating_t x);
 // The range differs on CPU and GPU unfortunately, should that affect this? Is it negligible?
 HOST DEV floating_t uniformScore(floating_t min, floating_t max, floating_t x);
 
+// V: negative binomial score signature
+HOST DEV floating_t negativeBinomialScore(floating_t x, floating_t k, floating_t p);
+
 #endif

--- a/rootppl/inference/smc/file_handler.cu
+++ b/rootppl/inference/smc/file_handler.cu
@@ -1,0 +1,56 @@
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <list> 
+#include <iterator> 
+
+#include "file_handler.cuh"
+
+
+void prepareFile(std::string fileName, bool truncate) {
+    std::ofstream resFile (fileName, (truncate ? std::ofstream::out | std::ofstream::trunc : std::ios_base::app));
+    resFile << "[";
+    resFile.close();
+}
+
+void finishFile(std::string fileName, bool removeLast) {
+    std::ifstream resFile1 (fileName);
+    std::stringstream buffer;
+    buffer << resFile1.rdbuf();
+    std::string contents = buffer.str();
+    resFile1.close();
+    if(removeLast)
+        contents.pop_back();
+    contents += "]\n";
+    std::ofstream resFile2 (fileName,  std::ofstream::out | std::ofstream::trunc);
+    resFile2 << contents;
+    resFile2.close();
+}
+
+void writeLogNormConstToFile(double logNormConstant) {
+    // std::ofstream resFile (fileName);
+    std::ofstream resFile (Z_FILE_NAME, std::ios_base::app); // If append to file is wanted
+    if(resFile.is_open()) {
+
+        resFile << logNormConstant << ",";
+        resFile.close();
+    } else {
+        printf("Could not open file %s\n", Z_FILE_NAME.c_str());
+    }
+}
+
+
+void writeESSToFile(std::list<double> essList) {
+    // std::ofstream resFile (fileName);
+    std::ofstream resFile (ESS_FILE_NAME, std::ios_base::app); // If append to file is wanted
+    if(resFile.is_open()) {
+        resFile << "[";
+        std::list <double> :: iterator it;
+        for(it = essList.begin(); it != essList.end(); ++it) 
+            resFile << *it << " ";
+        resFile << "],\n";
+        resFile.close();
+    } else {
+        printf("Could not open file %s\n", ESS_FILE_NAME.c_str());
+    }
+}

--- a/rootppl/inference/smc/file_handler.cuh
+++ b/rootppl/inference/smc/file_handler.cuh
@@ -1,0 +1,44 @@
+#ifndef FILE_HANDLER_INCLUDED
+#define FILE_HANDLER_INCLUDED
+
+#include <string>
+#include <list> 
+
+const std::string Z_FILE_NAME = "log_norm_const.txt";
+const std::string ESS_FILE_NAME = "ess.txt";
+
+
+/**
+ * Optionally clears the file, and writes an opening bracket to it. 
+ *
+ * @param fileName the name of the file to save to. 
+ * @param truncate if the file should be cleared first.
+ */
+void prepareFile(std::string fileName, bool truncate);
+
+
+/**
+ * Optionally removes the last character of the file, and writes a closing bracket and new line to it. 
+ *
+ * @param fileName the name of the file to save to. 
+ * @param removeLast if the last character of the file should be deleted before closing it. 
+ */
+void finishFile(std::string fileName, bool removeLast);
+
+/**
+ * Writes the approximated log normalization constant to file. The file is cleared before the 
+ * program starts and if multiple runs is performed, the values from each run is appended to this file. 
+ *
+ * @param logNormConstant
+ */
+void writeLogNormConstToFile(double logNormConstant);
+
+/**
+ * Writes the effective sample size (ESS) to file. The file is cleared before the program
+ * starts. 
+ * 
+ * @param ess
+ */
+void writeESSToFile(std::list<double> essList);
+
+#endif

--- a/rootppl/inference/smc/resample/common.cuh
+++ b/rootppl/inference/smc/resample/common.cuh
@@ -20,6 +20,7 @@ extern std::uniform_real_distribution<floating_t> uniformCPU;
  * prefixSum: Array used to store the inclusive prefix sum. 
  * auxParticles: Particles structure used to copy particles in resample propagation. Required as the propagation is not in-place. 
  * progStateSize: the size of the program state
+ * wSquared: the array that will contain the squared weights, necessary for GPU (done in-place on the CPU)
  */
 struct resampler_t {
 
@@ -29,6 +30,9 @@ struct resampler_t {
     particles_t auxParticles;
     size_t progStateSize;
     floating_t maxLogWeight;
+    #ifdef __NVCC__
+    floating_t* wSquared;
+    #endif
 };
 
 /**
@@ -78,5 +82,16 @@ HOST DEV void destResamplerNested(resampler_t resampler);
  * @param srcIdx the index in particlesSrc to read from. 
  */
 HOST DEV void copyParticle(particles_t particlesDst, const particles_t particlesSrc, int dstIdx, int srcIdx, size_t progStateSize);
+
+
+/**
+ * Samples an ancestor from the categorical distribution defined by the weights. 
+ * 
+ * @param w the particle weight array.
+ * @param logWeightSum the sum of log weights.
+ * @param numParticles the number of particles used in the inference.
+ * @return the index of the ancestor particle.
+ */
+DEV int sampleAncestor(RAND_STATE_DECLARE const floating_t* w, const floating_t logWeightSum, const int numParticles);
 
 #endif

--- a/rootppl/inference/smc/resample/systematic/kernels.cuh
+++ b/rootppl/inference/smc/resample/systematic/kernels.cuh
@@ -17,14 +17,25 @@
 __global__ void expWeightsKernel(floating_t* w, int numParticles, floating_t maxLogWeight);
 
 /**
- * Takes the logarithm of the prefixSum belonging to the current particle then scales back. 
+ * Takes the logarithm of the prefixSum and weight belonging to the current particle then scales back. 
  * This is used when calculating the weight sums safely. 
  * 
+ * @param w the weight array.
  * @param prefixSum the calculated inclusive prefix sums which should be logged and scaled back. 
  * @param numParticles the number of particles used in SMC.
  * @param maxLogWeight the log of the maximum weight. 
  */
-__global__ void renormaliseSumsKernel(floating_t* prefixSum, int numParticles, floating_t maxLogWeight);
+__global__ void renormaliseKernel(floating_t* w, floating_t* prefixSum, int numParticles, floating_t maxLogWeight);
+
+/**
+ *  Calculate the array of squared weights. 
+ * 
+ * @param w the input log-weight array.
+ * @param w the squared weight array too store the result in.
+ * @param maxLogWeight the maximum log weight.
+ * @param numParticles the number of particles used in SMC.
+ */
+__global__ void expSquareWeightsKernel(floating_t* w, floating_t* wSquared, floating_t maxLogWeight, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 
@@ -57,14 +68,13 @@ __global__ void copyStatesKernel(particles_t particlesDst, const particles_t par
 
 
 /**
- * Takes the log of the exponentiated log weight, scales back with the maximum log weight and subtracts with the logarithm of the sum of weights. 
+ * Takes the log of the exponentiated log weight and subtracts with the logarithm of the sum of weights. 
  * 
  * @param w the scaled particle weights
- * @param maxLogWeight the maximum log weight
  * @param logWeightSum the logarithm of the sum of weights
  * @param numParticles the number of particles used in SMC. 
  */
-__global__ void logAndRenormaliseWeightsKernel(floating_t* w, floating_t maxLogWeight, floating_t logWeightSum, int numParticles);
+__global__ void normaliseWeightsKernel(floating_t* w, floating_t logWeightSum, int numParticles);
 
 
 #endif

--- a/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
@@ -5,7 +5,7 @@
  * File systematic_cpu.cuh contains the CPU implementation of the systematic resampling. 
  */
 
-#include "common.cuh"
+ #include "inference/smc/resample/common.cuh"
 
 /**
  * Calculates the log weight prefix sums. 
@@ -16,6 +16,16 @@
  * @return the logarithm of the total weight sum. 
  */
 HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t& resampler, int numParticles);
+
+/**
+ * Calculates the ESS (effective sample size). 
+ *
+ * @param w the array of particle weights
+ * @param logWeightSum the logarithm of the sum of weights. 
+ * @param numParticles the number of particles used in SMC.
+ * @return the effective sample size.
+ */
+HOST DEV floating_t calcESSCpu(floating_t* w, floating_t logWeightSum, resampler_t resampler, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 
@@ -56,13 +66,13 @@ HOST DEV void copyStatesCpu(particles_t& particles, resampler_t& resampler, int 
 DEV void resampleSystematicCpu(RAND_STATE_DECLARE particles_t& particles, resampler_t& resampler, int numParticles);
 
 /**
- * Takes the log of the exponentiated log weight, scales back with the maximum log weight and subtracts with the logarithm of the sum of weights. 
+ * Takes the log-weights and subtracts the logarithm of the sum of weights. 
  *
  * @param w the array of scaled particle weights
- * @param resampler the resampler struct.
  * @param logWeightSum the logarithm of the sum of weights. 
  * @param numParticles the number of particles used in SMC.
  */
- DEV void logAndRenormaliseWeightsCpu(floating_t* w, resampler_t resampler, floating_t logWeightSum, int numParticles);
+ DEV void normaliseWeightsCpu(floating_t* w, floating_t logWeightSum, int numParticles);
+
 
 #endif

--- a/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
@@ -7,7 +7,7 @@
 
 #ifdef __NVCC__
 
-#include "common.cuh"
+#include "inference/smc/resample/common.cuh"
 
 HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numParticles);
 /**
@@ -22,6 +22,19 @@ HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numPartic
  * @return the logarithm of the total weight sum. 
  */
 HOST DEV floating_t calcLogWeightSumGpu(floating_t* w, resampler_t& resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
+
+/**
+ * Calculates the ESS (effective sample size).  
+ * 
+ * @param w the weight array.
+ * @param logWeightSum the logarithm of the sum of weights. 
+ * @param resampler the resampler struct.
+ * @param numParticles the number of particles used in SMC.
+ * @param numBlocks kernel launch setting.
+ * @param numThreadsPerBlock kernel launch setting.
+ * @return the effective sample size.
+ */
+HOST DEV floating_t calcESSGpu(floating_t* w, floating_t logWeightSum, resampler_t resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
 
 /**
  * Calculates the cumulative offsprings and then uses it to calculate the ancestor indices. 
@@ -69,16 +82,15 @@ void resampleSystematicGpu(particles_t& particles, resampler_t& resampler, int n
 
 
 /**
- * Takes the log of the exponentiated log weight, scales back with the maximum log weight and subtracts with the logarithm of the sum of weights. 
+ * Takes the log-weights and subtracts the logarithm of the sum of weights. 
  *
  * @param w the array of scaled particle weights
- * @param resampler the resampler struct.
  * @param logWeightSum the logarithm of the sum of weights. 
  * @param numParticles the number of particles used in SMC.
  * @param numBlocks kernel launch setting.
  * @param numThreadsPerBlock kernel launch setting.
  */
-void logAndRenormaliseWeightsGpu(floating_t* w, resampler_t resampler, floating_t logWeightSum, int numParticles, int numBlocks, int numThreadsPerBlock);
+void normaliseWeightsGpu(floating_t* w, floating_t logWeightSum, int numParticles, int numBlocks, int numThreadsPerBlock);
 
 #endif
 

--- a/rootppl/inference/smc/smc.cu
+++ b/rootppl/inference/smc/smc.cu
@@ -32,7 +32,7 @@
 #include "smc_kernels.cuh"
 #endif
 
-// Resample if ESS < RESAMPLE_THRESHOLD * N (default threshold in Birch is 0.7) 
+// Resample if relative ESS < RESAMPLE_THRESHOLD * N (default threshold in Birch is 0.7) 
 const floating_t RESAMPLE_THRESHOLD = 0.7;
  
 double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int ompThreads, const int particlesPerThread,
@@ -72,6 +72,7 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
         cudaCheckError();
         floating_t logWeightSum = calcLogWeightSumGpu(particles.weights, resampler, numParticles, NUM_BLOCKS, NUM_THREADS_PER_BLOCK);
         floating_t ess = calcESSGpu(particles.weights, logWeightSum, resampler, numParticles, NUM_BLOCKS, NUM_THREADS_PER_BLOCK);
+        cudaDeviceSynchronize();
         #else
 
         #pragma omp parallel for

--- a/rootppl/inference/smc/smc.cuh
+++ b/rootppl/inference/smc/smc.cuh
@@ -87,6 +87,18 @@ using callbackFunc_t = void (*)(particles_t&, int, void*);
 double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, const int ompThreads, const int particlesPerThread,
     size_t progStateSize, callbackFunc_t callback = NULL, void* arg = NULL);
 
+
+/**
+ * Called on program start, before inference starts. Called once per program, even if SMC is executed many times. 
+ * This will call configureMemSizeGPU and set up result files. 
+ */
+void prepareSMC();
+
+/*
+ * Called before terminating the program. 
+ */
+void finishFilesSMC();
+
     
 /**
  * This is an attempt to make most of the GPU memory available 
@@ -95,8 +107,6 @@ double runSMC(const pplFunc_t* bblocks, int numBblocks, const int numParticles, 
  * be tweaked to prioritize the memory type required by the program
  */
 void configureMemSizeGPU();
-
-
 
 
 /**

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -16,7 +16,8 @@
  * - Result (currently only normalizationConstant) available through local variable "res" in MAIN
  */
 
-#include <stdlib.h>
+#include <fstream>
+#include <string>
 // #include "utils/misc.cuh"
 #include "macros_adaptive.cuh"
 
@@ -113,7 +114,6 @@ int main(int argc, char** argv) { \
     int bbIdx = 0; \
     double res = 0; \
     body \
-    printf("log normalization constant = %f\n", res); \
     freeGen(); \
     return 0; \
 }
@@ -157,22 +157,28 @@ int numParticles = 10000; \
 if(argc > 1) { \
     numParticles = atoi(argv[1]); \
 } \
-int ompThreads = -1; \
+int numRuns = 1; \
 if(argc > 2) { \
-    ompThreads = atoi(argv[2]); \
+    numRuns = atoi(argv[2]); \
+} \
+int ompThreads = -1; \
+if(argc > 3) { \
+    ompThreads = atoi(argv[3]); \
 } \
 int particlesPerThread = 1; \
-if(argc > 3) { \
-    particlesPerThread = atoi(argv[3]); \
+if(argc > 4) { \
+    particlesPerThread = atoi(argv[4]); \
 } \
 int numBblocks = bbIdx; \
-configureMemSizeGPU(); \
+prepareSMC(); \
 COPY_DATA_GPU(bblocksArr, pplFunc_t, numBblocks) \
 pplFunc_t* bblocksArrCudaManaged; \
 ALLOC_TYPE(&bblocksArrCudaManaged, pplFunc_t, numBblocks); \
 for(int i = 0; i < numBblocks; i++) \
     bblocksArrCudaManaged[i] = bblocksArr[i]; \
-res = runSMC(bblocksArrCudaManaged, numBblocks, numParticles, ompThreads, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
+for(int i = 0; i < numRuns; i++) \
+    res = runSMC(bblocksArrCudaManaged, numBblocks, numParticles, ompThreads, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
+finishFilesSMC(); \
 FREE(bblocksArrCudaManaged)
 
 // freeMemory<pplFunc_t>(bblocksArrCudaManaged);

--- a/rootppl/models/phylogenetics/crbd/crbd_delayed.cu
+++ b/rootppl/models/phylogenetics/crbd/crbd_delayed.cu
@@ -1,0 +1,346 @@
+/*
+ * Delayed version of CRBD model.
+ * Both parameters are delayed.
+ *
+ * This model traverses the tree with a pre-computed DFS path (defined by the next 
+ * pointer in the tree) that corresponds to the recursive calls in the original model. 
+ */
+
+#include <stdio.h>
+#include <string>
+#include <fstream>
+#include <math.h>
+
+#include "inference/smc/smc.cuh"
+#include "../tree-utils/tree_utils.cuh"
+#include "utils/math.cuh"
+
+typedef short treeIdx_t;
+// V: changed the progstate to add delayed mu
+struct progState_t {
+    floating_t mu;
+    floating_t kLambda;
+    floating_t thetaLambda;
+    floating_t kMu;
+    floating_t thetaMu;
+    floating_t lambda;
+    treeIdx_t treeIdx;
+};
+ 
+struct ret_delayed_t {
+    floating_t res;
+    floating_t k;
+    floating_t theta;
+
+    DEV ret_delayed_t(){};
+    DEV ret_delayed_t(floating_t res_, floating_t k_, floating_t theta_) {
+        res = res_;
+        k = k_;
+        theta = theta_;
+    }
+};
+ 
+ // V: I am introducing this new structure for the return type of crbdGoesUndetectedDelayed
+struct ret_delayed_t_bothways {
+    floating_t res;
+    floating_t kLambda;
+    floating_t thetaLambda;
+    floating_t kMu;
+    floating_t thetaMu;
+
+    DEV ret_delayed_t_bothways(){};
+    DEV ret_delayed_t_bothways(floating_t res_, floating_t k_lambda, floating_t theta_lambda, floating_t k_mu, floating_t theta_mu) {
+        res = res_;
+        kLambda = k_lambda;
+        thetaLambda = theta_lambda;
+        kMu = k_mu;
+        thetaMu = theta_mu;
+    }
+};
+ 
+ 
+ 
+typedef bisse32_tree_t tree_t;
+// typedef primate_tree_t tree_t;
+// typedef moth_div_tree_t tree_t;
+
+// const int MAX_DIV = 5;
+// const int MAX_LAM = 5;
+
+#define NUM_BBLOCKS 3
+INIT_MODEL(progState_t, NUM_BBLOCKS)
+
+// V: This seemed to be correct; returning four floats, two for each parameter and the bool value, no change needed.
+BBLOCK_HELPER_DECLARE(crbdGoesUndetectedDelayed, ret_delayed_t_bothways, floating_t, floating_t, floating_t, floating_t, floating_t, floating_t);
+
+BBLOCK_DATA(tree, tree_t, 1)
+
+BBLOCK_DATA_CONST(rho, floating_t, 1.0)
+
+BBLOCK_HELPER(delayedSample, {
+    floating_t t = SAMPLE(lomax, 1/theta, k);
+    ret_delayed_t ret(t, k+1, theta / (1 + t * theta));
+    return ret;
+
+}, ret_delayed_t, floating_t k, floating_t theta)
+
+
+BBLOCK_HELPER(delayedObserve, {
+    ret_delayed_t ret(lomaxScore(x, 1/theta, k), k+1, theta / (1 + x * theta));
+    return ret;
+
+}, ret_delayed_t, floating_t x, floating_t k, floating_t theta)
+ 
+
+// V: we  need a new delayed observe BBLOCK to observe from a poisson
+// See Jan's thesis, page 60
+// x: the value
+// t: how much time the poisson process runs
+// k: delay paramater
+// theta: delay parameter
+BBLOCK_HELPER(delayedObservePoisson, {
+    ret_delayed_t ret(negativeBinomialScore(x, k, 1/(1 + t*theta)),
+            k,
+            theta / (1 + t * theta));
+    return ret;
+
+}, ret_delayed_t, floating_t x, floating_t t, floating_t k, floating_t theta)
+ 
+ 
+/*
+BBLOCK_HELPER(M_crbdGoesUndetected, {
+
+    if(maxM == 0) {
+        printf("Aborting crbdGoesUndetected simulation, too deep!\n");
+        return 1; // What do return instead of NaN?
+    }
+
+    if(! BBLOCK_CALL(crbdGoesUndetected, startTime, lambda, mu, rho) && ! BBLOCK_CALL(crbdGoesUndetected, startTime, lambda, mu, rho))
+        return 1;
+    else
+        return 1 + BBLOCK_CALL(M_crbdGoesUndetected, startTime, maxM - 1, lambda, mu, rho);
+
+}, int, floating_t startTime, int maxM, floating_t lambda, floating_t mu, floating_t rho)
+*/
+  
+BBLOCK_HELPER(crbdGoesUndetectedDelayed, {
+
+    ret_delayed_t ret0 = BBLOCK_CALL(delayedSample, kLambda, thetaLambda);
+    floating_t tLambda = ret0.res;
+
+    // floating_t t = SAMPLE(exponential, lambda + mu);
+    // floating_t tMu = SAMPLE(exponential, mu);
+
+    // V: Introduce delayed sampling for mu
+    ret_delayed_t mu_ret0 = BBLOCK_CALL(delayedSample, kMu, thetaMu);
+    floating_t tMu = mu_ret0.res;
+
+    floating_t t = MIN(tLambda, tMu);
+
+    bool speciation = tLambda < tMu;
+    
+    floating_t currentTime = startTime - t;
+    if(currentTime < 0) {
+        if (SAMPLE(bernoulli, 1 - rho))
+            // V: return type is now ret_delayed_t_bothways
+            return ret_delayed_t_bothways(true, ret0.k, ret0.theta, mu_ret0.k, mu_ret0.theta);
+        else
+            // V: return type is now ret_delayed_t_bothways
+            return ret_delayed_t_bothways(false, ret0.k, ret0.theta, mu_ret0.k, mu_ret0.theta);
+    }
+    
+    bool extinction = !speciation;
+    if (extinction)
+        // V: return type is now ret_delayed_t_bothways
+        return ret_delayed_t_bothways(true, ret0.k, ret0.theta, mu_ret0.k, mu_ret0.theta);
+
+    // V: the recursive call now has the new return type
+    ret_delayed_t_bothways ret1 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret0.k, ret0.theta, mu_ret0.k, mu_ret0.theta, rho);
+
+    bool leftDetection = !ret1.res;
+
+    if (leftDetection)
+        return ret1;
+
+    // V: same, but ret1 now has both of the delayed parameters
+    ret_delayed_t_bothways ret2 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret1.kLambda, ret1.thetaLambda, ret1.kMu, ret1.thetaMu, rho); 
+
+    return ret2;
+    // V: I am not sure if the return type is the first argument after the }. I think all the subsequent arguments are the input values?
+    // I asuming the first argument after the } is the return type, so I changed it from ret_delayed_t to ret_delayed_t_bothways
+
+}, ret_delayed_t_bothways, floating_t startTime, floating_t kLambda, floating_t thetaLambda, floating_t kMu, floating_t thetaMu, floating_t rho)
+ 
+ 
+BBLOCK_HELPER(simBranch, {
+
+    ret_delayed_t ret0 = BBLOCK_CALL(delayedSample, kLambda, thetaLambda);
+    floating_t t = ret0.res;
+
+    floating_t currentTime = startTime - t;
+
+    if(currentTime <= stopTime) {
+        // V: changed the return type to incorporate delayed mu
+        return ret_delayed_t_bothways(0.0, ret0.k, ret0.theta, kMu, thetaMu);
+    }
+
+    // V: mu is now delayed as well; also crbdGoesUndetectedDelayed returns ret_delayed_t_bothways
+    ret_delayed_t_bothways ret1 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret0.k, ret0.theta, kMu, thetaMu, rho);
+
+    bool sideDetection = !ret1.res;
+    if(sideDetection) {
+        // V: need to change the return here to delay mu
+        return ret_delayed_t_bothways(-INFINITY, ret1.kLambda, ret1.thetaLambda, ret1.kMu, ret1.thetaMu);
+    }
+
+    // V: change the return type and delay mu
+    ret_delayed_t_bothways ret2 = BBLOCK_CALL(simBranch, currentTime, stopTime, ret1.kLambda, ret1.thetaLambda, ret1.kMu, ret1.thetaMu, rho);
+    floating_t newProb = ret2.res + log(2.0);
+
+    // V: delay mu and return type 
+    return ret_delayed_t_bothways(newProb, ret2.kLambda, ret2.thetaLambda, ret2.kMu, ret2.thetaMu );
+
+// V: changed the function signature to reflect new input types and return type
+}, ret_delayed_t_bothways, floating_t startTime, floating_t stopTime, floating_t kLambda, floating_t thetaLambda, floating_t kMu, floating_t thetaMu, floating_t rho)
+ 
+ 
+BBLOCK(simTree, {
+
+    tree_t* treeP = DATA_POINTER(tree);
+    int treeIdx = PSTATE.treeIdx;
+
+    // floating_t lambdaLocal = PSTATE.lambda;
+    // V: mu is now delayed, so we cannot rely on muLocal
+    //floating_t muLocal = PSTATE.mu;
+    // floating_t kLambdaLocal = PSTATE.kLambda;
+    // floating_t thetaLambdaLocal = PSTATE.thetaLambda;
+    // floating_t rhoLocal = *DATA_POINTER(rho);
+    floating_t rhoLocal = DATA_CONST(rho);
+
+    int indexParent = treeP->idxParent[treeIdx];
+    
+    floating_t parentAge = treeP->ages[indexParent];
+    floating_t age = treeP->ages[treeIdx];
+
+    // V: instead of using muLocal, we use the Poisson observe
+    //floating_t lnProb1 = - muLocal * (parentAge - age);
+    // ret_delayed_t my_ret_0;
+    ret_delayed_t mu_ret_0 = BBLOCK_CALL(delayedObservePoisson, 0, parentAge - age, PSTATE.kMu, PSTATE.thetaMu);
+    floating_t lnProb1 = mu_ret_0.res;
+                    
+
+    // Interior if at least one child
+    bool interiorNode = treeP->idxLeft[treeIdx] != -1 || treeP->idxRight[treeIdx] != -1;
+    // floating_t lnProb2 = interiorNode ? log(lambdaLocal) : log(rhoLocal);
+
+    ret_delayed_t ret0;
+    if (interiorNode)
+        ret0 = BBLOCK_CALL(delayedObserve, 0, PSTATE.kLambda, PSTATE.thetaLambda);
+    else
+        ret0 = ret_delayed_t(log(rho), PSTATE.kLambda, PSTATE.thetaLambda);
+
+    floating_t lnProb2 = ret0.res;
+
+    // V: this now includes the delay of mu as well
+    ret_delayed_t_bothways ret1 = BBLOCK_CALL(simBranch, parentAge, age, ret0.k, ret0.theta, mu_ret_0.k, mu_ret_0.theta, rhoLocal);
+    floating_t lnProb3 = ret1.res;
+
+    WEIGHT(lnProb1 + lnProb2 + lnProb3);
+
+    // V: Changed the states to reflect that both are delayed
+    PSTATE.kLambda = ret1.kLambda;
+    PSTATE.thetaLambda = ret1.thetaLambda;
+    PSTATE.kMu = ret1.kMu;
+    PSTATE.thetaMu = ret1.thetaMu;
+
+    // Instead of recurring, use pre-processed traversal order
+    int nextIdx = treeP->idxNext[treeIdx];
+    PSTATE.treeIdx = nextIdx;
+
+    if(nextIdx == -1)
+        PC++;
+})
+ 
+  
+BBLOCK(simCRBD, {
+
+    // PSTATE.lambda = SAMPLE(gamma, 1.0, 1.0);
+    // PSTATE.lambda = 0.2;
+    floating_t epsilon = SAMPLE(uniform, 0.0, 1.0);
+    // floating_t epsilon = 0.5;
+    // PSTATE.mu = epsilon * PSTATE.lambda;
+
+    // V: Instead of fixing mu, we draw it from gamma now
+    //PSTATE.mu = 0.1;
+    PSTATE.kMu = 1;
+    PSTATE.thetaMu = 0.1;
+    
+    // floating_t k_lambda = 1;
+    // floating_t theta_lambda = 0.2;
+    PSTATE.kLambda = 1;
+    PSTATE.thetaLambda = 0.2;
+
+
+    tree_t* treeP = DATA_POINTER(tree);
+
+    PSTATE.treeIdx = treeP->idxLeft[ROOT_IDX];
+
+    int numLeaves = countLeaves(treeP->idxLeft, treeP->idxRight, treeP->NUM_NODES);
+    floating_t corrFactor = (numLeaves - 1) * log(2.0) - lnFactorial(numLeaves);
+    WEIGHT(corrFactor);
+
+    PC++;
+    BBLOCK_CALL(DATA_POINTER(bblocksArr)[PC], NULL);
+})
+
+/*
+BBLOCK(survivorshipBias, {
+    floating_t age = DATA_POINTER(tree)->ages[ROOT_IDX];
+    int MAX_M = 10000;
+    int M = BBLOCK_CALL(M_crbdGoesUndetected, age, MAX_M, PSTATE.lambda, PSTATE.mu, DATA_CONST(rho));
+    WEIGHT(LOG(M));
+    PC++;
+})
+*/
+
+BBLOCK(sampleFinalLambda, {
+    PSTATE.lambda = SAMPLE(gamma, PSTATE.kLambda, PSTATE.thetaLambda);
+    PSTATE.mu = SAMPLE(gamma, PSTATE.kMu, PSTATE.thetaMu);
+    PC++;
+})
+
+// Write particle data to file. 
+CALLBACK(saveResults, {
+    
+    std::string fileName = "parameterDataDelayed";
+    std::ofstream resFile (fileName);
+    if(resFile.is_open()) {
+
+        for(int i = 0; i < N; i++)
+            resFile << PSTATES[i].lambda << " " << PSTATES[i].mu << " " << exp(WEIGHTS[i]) << "\n";
+
+        resFile.close();
+    } else {
+        printf("Could not open file %s\n", fileName.c_str());
+    }
+    
+})
+
+
+MAIN(
+    
+    ADD_BBLOCK(simCRBD)
+    ADD_BBLOCK(simTree)
+    // ADD_BBLOCK(survivorshipBias)
+    ADD_BBLOCK(sampleFinalLambda)
+    
+    SMC(saveResults)
+)
+  
+  
+ 
+ 
+ 
+ 
+ 
+   

--- a/rootppl/models/phylogenetics/crbd/crbd_delayed_lambda.cu
+++ b/rootppl/models/phylogenetics/crbd/crbd_delayed_lambda.cu
@@ -1,0 +1,266 @@
+/*
+ * File crbd_webppl.cu defines the constant rate birth death model 
+ * as defined in WebPPL in the script linked to below. 
+ * 
+ * https://github.com/phyppl/probabilistic-programming/blob/master/webppl/phywppl/models/crbd.wppl
+ *
+ * This model traverses the tree with a pre-computed DFS path (defined by the next 
+ * pointer in the tree) that corresponds to the recursive calls in the original model. 
+ */
+
+#include <stdio.h>
+#include <string>
+#include <fstream>
+#include <math.h>
+
+#include "inference/smc/smc.cuh"
+#include "../tree-utils/tree_utils.cuh"
+#include "utils/math.cuh"
+
+typedef short treeIdx_t;
+struct progState_t {
+    floating_t mu;
+    floating_t kLambda;
+    floating_t thetaLambda;
+    floating_t lambda;
+    treeIdx_t treeIdx;
+};
+
+struct ret_delayed_t {
+    floating_t res;
+    floating_t k;
+    floating_t theta;
+
+    DEV ret_delayed_t(){};
+    DEV ret_delayed_t(floating_t res_, floating_t k_, floating_t theta_) {
+        res = res_;
+        k = k_;
+        theta = theta_;
+    }
+};
+
+
+typedef bisse32_tree_t tree_t;
+// typedef primate_tree_t tree_t;
+// typedef moth_div_tree_t tree_t;
+
+// const int MAX_DIV = 5;
+// const int MAX_LAM = 5;
+
+#define NUM_BBLOCKS 3
+INIT_MODEL(progState_t, NUM_BBLOCKS)
+
+BBLOCK_HELPER_DECLARE(crbdGoesUndetectedDelayed, bool, floating_t, floating_t, floating_t, floating_t);
+
+BBLOCK_DATA(tree, tree_t, 1)
+
+BBLOCK_DATA_CONST(rho, floating_t, 1.0)
+
+BBLOCK_HELPER(delayedSample, {
+    floating_t t = SAMPLE(lomax, 1/theta, k);
+    ret_delayed_t ret(t, k+1, theta / (1 + t * theta));
+    return ret;
+
+}, ret_delayed_t, floating_t k, floating_t theta)
+
+BBLOCK_HELPER(delayedObserve, {
+    ret_delayed_t ret(lomaxScore(x, 1/theta, k), k+1, theta / (1 + x * theta));
+    return ret;
+
+}, ret_delayed_t, floating_t x, floating_t k, floating_t theta)
+
+/*
+BBLOCK_HELPER(M_crbdGoesUndetected, {
+
+    if(maxM == 0) {
+        printf("Aborting crbdGoesUndetected simulation, too deep!\n");
+        return 1; // What do return instead of NaN?
+    }
+
+    if(! BBLOCK_CALL(crbdGoesUndetected, startTime, lambda, mu, rho) && ! BBLOCK_CALL(crbdGoesUndetected, startTime, lambda, mu, rho))
+        return 1;
+    else
+        return 1 + BBLOCK_CALL(M_crbdGoesUndetected, startTime, maxM - 1, lambda, mu, rho);
+
+}, int, floating_t startTime, int maxM, floating_t lambda, floating_t mu, floating_t rho)
+*/
+ 
+BBLOCK_HELPER(crbdGoesUndetectedDelayed, {
+
+    ret_delayed_t ret0 = BBLOCK_CALL(delayedSample, kLambda, thetaLambda);
+    floating_t tLambda = ret0.res;
+
+    // floating_t t = SAMPLE(exponential, lambda + mu);
+    floating_t tMu = SAMPLE(exponential, mu);
+
+    floating_t t = MIN(tLambda, tMu);
+
+    bool speciation = tLambda < tMu;
+    
+    floating_t currentTime = startTime - t;
+    if(currentTime < 0) {
+        if (SAMPLE(bernoulli, 1 - rho))
+            return ret_delayed_t(true, ret0.k, ret0.theta);
+        else
+            return ret_delayed_t(false, ret0.k, ret0.theta);
+    }
+    
+    bool extinction = !speciation;
+    if (extinction)
+        return ret_delayed_t(true, ret0.k, ret0.theta);
+
+    ret_delayed_t ret1 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret0.k, ret0.theta, mu, rho);
+
+    bool leftDetection = !ret1.res;
+
+    if (leftDetection)
+        return ret1;
+
+    ret_delayed_t ret2 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret1.k, ret1.theta, mu, rho);
+
+    return ret2;
+
+}, ret_delayed_t, floating_t startTime, floating_t kLambda, floating_t thetaLambda, floating_t mu, floating_t rho)
+
+
+BBLOCK_HELPER(simBranch, {
+
+    ret_delayed_t ret0 = BBLOCK_CALL(delayedSample, kLambda, thetaLambda);
+    floating_t t = ret0.res;
+
+    floating_t currentTime = startTime - t;
+
+    if(currentTime <= stopTime)
+        return ret_delayed_t(0.0, ret0.k, ret0.theta);
+
+    ret_delayed_t ret1 = BBLOCK_CALL(crbdGoesUndetectedDelayed, currentTime, ret0.k, ret0.theta, mu, rho);
+    
+    bool sideDetection = !ret1.res;
+    if(sideDetection)
+        return ret_delayed_t(-INFINITY, ret1.k, ret1.theta);
+
+    ret_delayed_t ret2 = BBLOCK_CALL(simBranch, currentTime, stopTime, ret1.k, ret1.theta, mu, rho);
+    floating_t newProb = ret2.res + log(2.0);
+    
+    return ret_delayed_t(newProb, ret2.k, ret2.theta);
+
+}, ret_delayed_t, floating_t startTime, floating_t stopTime, floating_t kLambda, floating_t thetaLambda, floating_t mu, floating_t rho)
+
+
+BBLOCK(simTree, {
+
+    tree_t* treeP = DATA_POINTER(tree);
+    int treeIdx = PSTATE.treeIdx;
+
+    // floating_t lambdaLocal = PSTATE.lambda;
+    floating_t muLocal = PSTATE.mu;
+    // floating_t kLambdaLocal = PSTATE.kLambda;
+    // floating_t thetaLambdaLocal = PSTATE.thetaLambda;
+    // floating_t rhoLocal = *DATA_POINTER(rho);
+    floating_t rhoLocal = DATA_CONST(rho);
+
+    int indexParent = treeP->idxParent[treeIdx];
+    
+    floating_t parentAge = treeP->ages[indexParent];
+    floating_t age = treeP->ages[treeIdx];
+
+    floating_t lnProb1 = - muLocal * (parentAge - age);
+
+    // Interior if at least one child
+    bool interiorNode = treeP->idxLeft[treeIdx] != -1 || treeP->idxRight[treeIdx] != -1;
+    // floating_t lnProb2 = interiorNode ? log(lambdaLocal) : log(rhoLocal);
+
+    ret_delayed_t ret0;
+    if (interiorNode)
+        ret0 = BBLOCK_CALL(delayedObserve, 0, PSTATE.kLambda, PSTATE.thetaLambda);
+    else
+        ret0 = ret_delayed_t(log(rho), PSTATE.kLambda, PSTATE.thetaLambda);
+
+    floating_t lnProb2 = ret0.res;
+
+    ret_delayed_t ret1 = BBLOCK_CALL(simBranch, parentAge, age, ret0.k, ret0.theta, muLocal, rhoLocal);
+    floating_t lnProb3 = ret1.res;
+
+    WEIGHT(lnProb1 + lnProb2 + lnProb3);
+
+    PSTATE.kLambda = ret1.k;
+    PSTATE.thetaLambda = ret1.theta;
+
+    // Instead of recurring, use pre-processed traversal order
+    int nextIdx = treeP->idxNext[treeIdx];
+    PSTATE.treeIdx = nextIdx;
+
+    if(nextIdx == -1)
+        PC++;
+})
+
+ 
+BBLOCK(simCRBD, {
+
+    // PSTATE.lambda = SAMPLE(gamma, 1.0, 1.0);
+    // PSTATE.lambda = 0.2;
+    floating_t epsilon = SAMPLE(uniform, 0.0, 1.0);
+    // floating_t epsilon = 0.5;
+    // PSTATE.mu = epsilon * PSTATE.lambda;
+    PSTATE.mu = 0.1;
+    // floating_t k_lambda = 1;
+    // floating_t theta_lambda = 0.2;
+    PSTATE.kLambda = 1;
+    PSTATE.thetaLambda = 0.2;
+
+    tree_t* treeP = DATA_POINTER(tree);
+
+    PSTATE.treeIdx = treeP->idxLeft[ROOT_IDX];
+
+    int numLeaves = countLeaves(treeP->idxLeft, treeP->idxRight, treeP->NUM_NODES);
+    floating_t corrFactor = (numLeaves - 1) * log(2.0) - lnFactorial(numLeaves);
+    WEIGHT(corrFactor);
+
+    PC++;
+    BBLOCK_CALL(DATA_POINTER(bblocksArr)[PC], NULL);
+})
+
+/*
+BBLOCK(survivorshipBias, {
+    floating_t age = DATA_POINTER(tree)->ages[ROOT_IDX];
+    int MAX_M = 10000;
+    int M = BBLOCK_CALL(M_crbdGoesUndetected, age, MAX_M, PSTATE.lambda, PSTATE.mu, DATA_CONST(rho));
+    WEIGHT(LOG(M));
+    PC++;
+})
+*/
+
+BBLOCK(sampleFinalLambda, {
+    PSTATE.lambda = SAMPLE(gamma, PSTATE.kLambda, PSTATE.thetaLambda);
+    PC++;
+})
+
+// Write particle data to file. 
+CALLBACK(saveResults, {
+    
+    std::string fileName = "parameterDataDelayed";
+    std::ofstream resFile (fileName);
+    if(resFile.is_open()) {
+
+        for(int i = 0; i < N; i++)
+            resFile << PSTATES[i].lambda << " " << PSTATES[i].mu << " " << exp(WEIGHTS[i]) << "\n";
+
+        resFile.close();
+    } else {
+        printf("Could not open file %s\n", fileName.c_str());
+    }
+    
+})
+
+
+MAIN(
+    
+    ADD_BBLOCK(simCRBD)
+    ADD_BBLOCK(simTree)
+    // ADD_BBLOCK(survivorshipBias)
+    ADD_BBLOCK(sampleFinalLambda)
+    
+    SMC(saveResults)
+)
+ 
+ 

--- a/rootppl/models/phylogenetics/crbd/crbd_webppl.cu
+++ b/rootppl/models/phylogenetics/crbd/crbd_webppl.cu
@@ -23,12 +23,12 @@ struct progState_t {
     floating_t mu;
     treeIdx_t treeIdx;
 };
-// typedef bisse32_tree_t tree_t;
+typedef bisse32_tree_t tree_t;
 // typedef primate_tree_t tree_t;
-typedef moth_div_tree_t tree_t;
+// typedef moth_div_tree_t tree_t;
 
-const int MAX_DIV = 5;
-const int MAX_LAM = 5;
+// const int MAX_DIV = 5;
+// const int MAX_LAM = 5;
 
 #define NUM_BBLOCKS 3
 INIT_MODEL(progState_t, NUM_BBLOCKS)
@@ -56,6 +56,7 @@ BBLOCK_HELPER(M_crbdGoesUndetected, {
 
 BBLOCK_HELPER(crbdGoesUndetected, {
 
+    /*
     // extreme values patch 1/2
     if (lambda - mu > MAX_DIV)
         return false;
@@ -64,6 +65,7 @@ BBLOCK_HELPER(crbdGoesUndetected, {
         return ! SAMPLE(bernoulli, rho);
 
     // end extreme values patch 1/2
+    */
 
     floating_t t = SAMPLE(exponential, lambda + mu);
     
@@ -82,6 +84,7 @@ BBLOCK_HELPER(crbdGoesUndetected, {
 
 BBLOCK_HELPER(simBranch, {
 
+    /*
     // extreme values patch 2/2
 	if (lambda > MAX_LAM) {
 	    return -INFINITY;
@@ -90,7 +93,8 @@ BBLOCK_HELPER(simBranch, {
 	if (lambda == 0.0) {
         return 0.0;
 	}
-	// extreme values patch 2/2
+    // extreme values patch 2/2
+    */
 
     floating_t t = SAMPLE(exponential, lambda);
 
@@ -146,10 +150,10 @@ BBLOCK(simCRBD, {
 
     PSTATE.lambda = SAMPLE(gamma, 1.0, 1.0);
     // PSTATE.lambda = 0.2;
-    floating_t epsilon = SAMPLE(uniform, 0.0, 1.0);
+    // floating_t epsilon = SAMPLE(uniform, 0.0, 1.0);
     // floating_t epsilon = 0.5;
-    PSTATE.mu = epsilon * PSTATE.lambda;
-    // PSTATE.mu = 0.1;
+    // PSTATE.mu = epsilon * PSTATE.lambda;
+    PSTATE.mu = 0.1;
 
     tree_t* treeP = DATA_POINTER(tree);
 
@@ -160,6 +164,7 @@ BBLOCK(simCRBD, {
     WEIGHT(corrFactor);
 
     PC++;
+    BBLOCK_CALL(DATA_POINTER(bblocksArr)[PC], NULL);
 })
 
 BBLOCK(survivorshipBias, {
@@ -172,7 +177,8 @@ BBLOCK(survivorshipBias, {
 
 // Write particle data to file. 
 CALLBACK(saveResults, {
-    std::string fileName = "parameterData";
+    
+    std::string fileName = "parameterDataImmediate";
     std::ofstream resFile (fileName);
     if(resFile.is_open()) {
 
@@ -183,6 +189,7 @@ CALLBACK(saveResults, {
     } else {
         printf("Could not open file %s\n", fileName.c_str());
     }
+    
 })
 
 
@@ -190,7 +197,7 @@ MAIN(
     
     ADD_BBLOCK(simCRBD)
     ADD_BBLOCK(simTree)
-    ADD_BBLOCK(survivorshipBias)
+    // ADD_BBLOCK(survivorshipBias)
 
     SMC(saveResults)
 )

--- a/rootppl/utils/math.cu
+++ b/rootppl/utils/math.cu
@@ -5,8 +5,11 @@
 
 
 #include <math.h>
+// V: needed for assert
+#include <cassert>
 
 #include "math.cuh"
+#include "../dists/scores.cuh"
 
 HOST DEV double lnFactorial(int n) {
     /*if(n == 1) {
@@ -22,11 +25,27 @@ HOST DEV double lnFactorial(int n) {
     return res;
 }
 
-
 HOST DEV floating_t maxNaive(const floating_t* arr, const int n) {
     floating_t maxVal = -INFINITY;
     for(int i = 0; i < n; i++) {
         maxVal = arr[i] > maxVal ? arr[i] : maxVal;
     }
     return maxVal;
+}
+
+// V: Logarithm of the binomial coefficient.
+// Based on: https://github.com/lawmurray/Birch/blob/master/libraries/Standard/src/math/special.birch
+HOST DEV floating_t lchoose(const int x, const int y) {
+    assert(0 <= x);
+    assert(0 <= y);
+    assert(x >= y);
+    
+    if (y == 0) {
+        return 0.0;
+    } else {
+        // Birch comment: see Boost binomial_coefficient function for this implementation
+        // V: replaced Real(y) and so one with static casts like in lnFactorial
+        return -log(static_cast<double>(y))
+            - logBeta(static_cast<double>(y), static_cast<double>(x - y + 1));
+    }
 }

--- a/rootppl/utils/math.cuh
+++ b/rootppl/utils/math.cuh
@@ -87,6 +87,13 @@ HOST DEV int sgn(T val) {
  */
 HOST DEV floating_t maxNaive(const floating_t* arr, const int n);
 
+// V: added signature
+/**
+ * Logarithm of the binomial coefficient.
+ * Based on: https://github.com/lawmurray/Birch/blob/master/libraries/Standard/src/math/special.birch
+ */
+HOST DEV floating_t lchoose(const int x, const int y);
+
 /**
  * Finds the maximum value, sequential implementation. 
  * General template version but for CPU only. 


### PR DESCRIPTION
- Add calculation of ESS within SMC
- Only resample if relative ESS above threshold (constant, currently set to 0.7, inspired by Birch default)

- Multiple (inference) runs supported by second program argument (To calculate statistics e.g. mean, std. This should probably be done at a higher level in the end)

- Log normalization constants and ESS (within SMC) automatically written to file (Connected to bullet above, so one can easily extract the result of each run and calculate statistics)

- Common resampling files (containing helper functions) moved to the parent of systematic, as it can be shared for other methods (The reason was to avoid duplicated code, primarily when more resampling strategies/variants are added)

- Add Lomax distribution (sampling and score, works for CPU and GPU)
- Add Negative Binomial distribution (sampling only, works for CPU and GPU)

- Viktor's work: Add crbd_delayed and negative binomial score