### PR TITLE
Add support for OpenMP on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The corresponding parallel CPU (OpenMP) example is:
 ```
 make model=models/airplane/airplane.cu omp -j5
 ```
+Alternatively, the c++ compiler can be specified with CXX. This is often required on Mac OS to enable OpenMP, by using g++ instead of the default clang. On Mac OS, g++ can be installed with e.g. `brew install gcc`. Then, assuming the version installed was `gcc-10`: 
+```
+make model=models/airplane/airplane.cu omp -j5 CXX=g++-10
+```
 
 The first `make` will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run make with the `-j numThreads` to use multiple threads and speed up the build). 
 __Note that if the inference framework is compiled for GPU, and then the model is compiled for CPU, 

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -1,16 +1,7 @@
-# define \n
-
-
-# endef
 
 # ifndef model
 # $(error model argument needs to be set with e.g.: $(\n)make model=path/to/model.cu$(\n))
 # endif
-
-# ifdef ompthreads
-# OMP = -fopenmp
-# endif
-
 
 ifdef arch
 # GPU
@@ -20,7 +11,7 @@ FLAGS=-I. -std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else
 # CPU
-CC=g++
+CC=$(CXX)
 FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
 FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif


### PR DESCRIPTION
- Makefile now uses CXX, which defaults to the system default c++ compiler. CXX can be used to specify which c++ compiler to use. This allows Mac users to use g++ which comes with OpenMP by default in recent versions, instead of clang. 

- Description of this with an example in the README