### PR TITLE
make install for rootppl

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RootPPL can be seen as an intermediate language for representing probabilistic m
 ## Getting Started
 The instructions below are tested on Ubuntu 18.04 but should work for other Linux distributions, Windows, and Mac. 
 
-### Install
+### Prerequisites
 Before building RootPPL programs, a C++/CUDA compiler is required. RootPPL works on CPU and Nvidia GPU:s. For the CPU version, a C++ compiler should suffice, e.g. g++.  In 
 order to build for GPU, CUDA must be installed. See
 CUDA installation guides: [Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/ "CUDA Installation Guide Linux"), 
@@ -22,47 +22,54 @@ CUDA installation guides: [Linux](https://docs.nvidia.com/cuda/cuda-installation
 To run the CPU version in parallel, [OpenMP](https://www.openmp.org/resources/openmp-compilers-tools/) must be installed. 
 OpenMP comes with recent gcc versions. However, OpenMP is not necessary if one does not want to execute programs in parallel on the CPU.
 
-### Build
-To build the program, clone this repository and change directory to the rootppl folder. Then to compile the model:
+### Install rootppl
+To install rootppl for the current user, first clone this repository and change directory to the rootppl folder. Then run:
 ```
-make model=path/to/model.cu
+make install
+```
+This will install rootppl to `$HOME/.local/bin` with resources copied to `$HOME/.local/lib/rootppl`. Some systems, e.g. Mac OS, will require manually adding `$HOME/.local/bin` to `$PATH`. 
+
+### Build
+To compile a model and build an executable:
+```
+rootppl path/to/model.cu
 ```
 This will compile the model along with the inference framework for CPU. To compile it for GPU, add your GPU:s compute capability to the arch variable.
 You can find your GPU:s compute capability in the [Wikipedia table](https://en.wikipedia.org/wiki/CUDA#GPUs_supported).
 Here is an example that will compile the airplane example for a GPU with a minimum compute capability of 7.5
-(simply remove `arch=75` to compile for CPU):
+(simply remove `--arch 75` to compile for CPU):
 ```
-make model=models/airplane/airplane.cu arch=75 -j5
+rootppl models/airplane/airplane.cu --arch 75 -j 5
 ```
-
+The optional argument `-j x` speeds up the compilation process by spawning `x` jobs, allowing for parallel compilation. 
 The corresponding parallel CPU (OpenMP) example is:
 ```
-make model=models/airplane/airplane.cu omp -j5
+rootppl models/airplane/airplane.cu --omp -j 5
 ```
 Alternatively, the c++ compiler can be specified with CXX. This is often required on Mac OS to enable OpenMP, by using g++ instead of the default clang. On Mac OS, g++ can be installed with e.g. `brew install gcc`. Then, assuming the version installed was `gcc-10`: 
 ```
-make model=models/airplane/airplane.cu omp -j5 CXX=g++-10
+rootppl models/airplane/airplane.cu --omp -j 5 --cxx g++-10
 ```
 
-The first `make` will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run make with the `-j numThreads` to use multiple threads and speed up the build). 
+The first build will compile the entire inference framework and can take 20 seconds or so when building for GPU. (Run `rootppl` with the `-j num_threads` to use multiple threads and speed up the build). 
 __Note that if the inference framework is compiled for GPU, and then the model is compiled for CPU, 
-there will be errors. So always perform a `make clean` before switching between CPU and GPU. The same goes for switching to/from OpenMP.__
+there will be errors. So always perform a `rootppl clean` before switching between CPU and GPU. The same goes for switching to/from OpenMP.__
 
-This should generate an executable named `program`. Execute it with either `make run N=num_particles` or `./program num_particles`. For example:
+This should generate an executable named `program` (add `-o <exec_name>` to name it differently). Execute it with `./program num_particles`. For example:
 ```
-make run N=1000
+./program 1000
 ```
 
-An example out of this:
+An example output of this:
 ```
 ./program 1000
 Num particles close to target: 96.5%, MinX: 63.1558, MaxX: 84.4023
 log normalization constant = -119.270143
 ```
-First is the command that is executed from the Makefile, it executes the executable `program` with program argument 1000.
+First is the command that is executed, it executes the executable `program` with program argument `1000`.
 The second row comes from a print statement within the model. Lastly, the log normalization constant approximated by the inference is printed. 
 
-### Building a simple model
+### Creating a simple model
 Models are divided into fragments to enable pausing the execution within models. 
 These fragments are functions referred to as basic blocks (`BBLOCK`). 
 To control the program execution flow, a program counter (`PC`) can be modified. 
@@ -149,7 +156,7 @@ This example can be found in
 [rootppl/models/simple-examples/coin_flip_mean.cu](rootppl/models/simple-examples/coin_flip_mean.cu)
 and, being in the rootppl directory, compiled with:
 ```
-make model=models/simple-examples/coin_flip_mean.cu
+rootppl models/simple-examples/coin_flip_mean.cu
 ```
 
 Then it can be executed with the executable followed by the

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -22,6 +22,14 @@ endif
 
 # EXEC_NAME=program
 
+.PHONY :\
+	install
+	clean
+	framework
+	ompframework
+	omp
+	openmpflag
+
 SMC_SRC=inference/smc/smc.cu
 SMC_NESTED_SRC=inference/smc/smc_nested.cu
 DISTS_SRC=dists/dists.cu
@@ -45,13 +53,38 @@ OBJ_FILES_FRAMEWORK=$(patsubst %.o, $(OBJDIR)/%.o, $(_OBJ_FILES_FRAMEWORK))
 FRAMEWORK_FILES = $(wildcard inference/*) $(wildcard inference/*/*) $(wildcard inference/*/*/*) $(wildcard inference/*/*/*/*) \
 	$(wildcard dists/*) $(wildcard macros/*) $(wildcard utils/*)
 
-# $@ is target name
-# $< is dependency list
-
 # Link object files to executable
 $(EXEC_NAME): $(OBJDIR) $(OBJDIR)/model.o $(OBJ_FILES_FRAMEWORK)
 	$(CC) $(FLAGS_LINK) out/*.o -o $@
 	rm $(OBJDIR)/model.o
+
+bin_path = $(HOME)/.local/bin
+rootppl_name = rootppl
+install:
+	mkdir -p $(bin_path)
+	cp -f ./$(rootppl_name) $(bin_path)/$(rootppl_name)
+	chmod +x $(bin_path)/$(rootppl_name)
+	
+
+clean:
+	rm -f out/*.o
+
+run:
+	./$(EXEC_NAME) $(N)
+
+openmpflag:
+	$(eval OMP = -fopenmp)
+
+# Compile only framework
+framework:\
+	$(OBJDIR) $(OBJ_FILES_FRAMEWORK)
+
+ompframework:\
+	openmpflag $(OBJDIR) $(OBJ_FILES_FRAMEWORK)
+
+omp:\
+	openmpflag $(EXEC_NAME)
+
 
 # Compile model, which is always recompiled as it is deleted after the executable is created.
 $(OBJDIR)/model.o: $(model)
@@ -62,18 +95,9 @@ $(OBJDIR)/model.o: $(model)
 $(OBJDIR):
 	mkdir $(OBJDIR)
 
-# Compile only framework
-.PHONY: framework
-framework: $(OBJDIR) $(OBJ_FILES_FRAMEWORK)
 
-.PHONY: ompframework
-ompframework: openmpflag $(OBJDIR) $(OBJ_FILES_FRAMEWORK)
-
-.PHONY: omp openmpflag
-omp: openmpflag $(EXEC_NAME)
-
-openmpflag:
-	$(eval OMP = -fopenmp)
+# $@ is target name
+# $< is dependency list
 
 # $(OBJ_FILES_FRAMEWORK): $(FRAMEWORK_FILES)
 	# $(CC) -c $(FLAGS) $< -o $@
@@ -129,14 +153,3 @@ $(OBJDIR)/systematic_kernels.o: $(FRAMEWORK_FILES)
 
 $(OBJDIR)/file_handler.o: $(FRAMEWORK_FILES)
 	$(CC) -c $(FLAGS) $(FILE_HANDLER_SRC) -o $@
-
-.PHONY: clean
-clean:
-	rm out/*.o
-
-# rm out/*.o $(EXEC_NAME)
-
-# run: ./$(EXEC_NAME)
-.PHONY: run
-run:
-	./$(EXEC_NAME) $(N)

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -3,6 +3,10 @@
 # $(error model argument needs to be set with e.g.: $(\n)make model=path/to/model.cu$(\n))
 # endif
 
+ifndef EXEC_NAME
+EXEC_NAME=program
+endif
+
 ifdef arch
 # GPU
 # CC=/usr/local/cuda-11.0/bin/nvcc
@@ -16,7 +20,7 @@ FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
 FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif
 
-EXEC_NAME=program
+# EXEC_NAME=program
 
 SMC_SRC=inference/smc/smc.cu
 SMC_NESTED_SRC=inference/smc/smc_nested.cu
@@ -52,6 +56,7 @@ $(EXEC_NAME): $(OBJDIR) $(OBJDIR)/model.o $(OBJ_FILES_FRAMEWORK)
 # Compile model, which is always recompiled as it is deleted after the executable is created.
 $(OBJDIR)/model.o: $(model)
 	$(CC) -c $(FLAGS) $(model) -o $@
+	
 # $(CC) -c $(FLAGS) $(model) -o model.o
 
 $(OBJDIR):
@@ -127,7 +132,9 @@ $(OBJDIR)/file_handler.o: $(FRAMEWORK_FILES)
 
 .PHONY: clean
 clean:
-	rm out/*.o $(EXEC_NAME)
+	rm out/*.o
+
+# rm out/*.o $(EXEC_NAME)
 
 # run: ./$(EXEC_NAME)
 .PHONY: run

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -1,26 +1,23 @@
 
-# ifndef model
-# $(error model argument needs to be set with e.g.: $(\n)make model=path/to/model.cu$(\n))
-# endif
-
 ifndef EXEC_NAME
 EXEC_NAME=program
 endif
 
+
+COMMON_FLAGS=$(EXTRA_FLAGS) -I. -std=c++14 -O3
 ifdef arch
 # GPU
 # CC=/usr/local/cuda-11.0/bin/nvcc
 CC=nvcc
-FLAGS=-I. -std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
+FLAGS=$(COMMON_FLAGS) -arch=sm_$(arch) -rdc=true -lcudadevrt
 FLAGS_LINK=-std=c++14 -arch=sm_$(arch) -rdc=true -lcudadevrt -O3
 else
 # CPU
 CC=$(CXX)
-FLAGS=-I. -xc++ -std=c++14 -O3 $(OMP)
+FLAGS=$(COMMON_FLAGS) -xc++ $(OMP)
 FLAGS_LINK=-std=c++14 -O3 $(OMP)
 endif
 
-# EXEC_NAME=program
 
 .PHONY :\
 	install
@@ -59,12 +56,13 @@ $(EXEC_NAME): $(OBJDIR) $(OBJDIR)/model.o $(OBJ_FILES_FRAMEWORK)
 	rm $(OBJDIR)/model.o
 
 bin_path = $(HOME)/.local/bin
+lib_path=$(HOME)/.local/lib/rootppl
 rootppl_name = rootppl
 install:
-	mkdir -p $(bin_path)
-	cp -f ./$(rootppl_name) $(bin_path)/$(rootppl_name)
-	chmod +x $(bin_path)/$(rootppl_name)
-	
+	mkdir -p $(bin_path) $(lib_path)
+	cp -f ./$(rootppl_name) $(bin_path)/$(rootppl_name); chmod +x $(bin_path)/$(rootppl_name)
+	cp -rf . $(lib_path)/
+	rm -f $(lib_path)/.gitignore $(lib_path)/rootppl
 
 clean:
 	rm -f out/*.o

--- a/rootppl/rootppl
+++ b/rootppl/rootppl
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 # This file builds the executable by: 
-#   1. Copying the source file to the installed rootppl directory
+#   1. Get the absolute path to the source file
 #   2. Change directory to installed rootppl directory
-#   3. Build the executable with the inference framework
+#   3. Build the executable with the inference framework with the users working directory added to the include paths
 #   4. Copy the executable back to the user's working directory and clean up rootppl directory
-
-# NOTE: Currently only works for relative paths to user source file
 
 
 out_name=program
@@ -75,32 +73,24 @@ cd ~/.local/lib/rootppl/
 
 # "rootppl clean" used for cleaning before changing platform, e.g. cpu to gpu
 if [ "$1" = "clean" ]; then
-make clean
+    make clean
 else
-# Define and create directory for user source files
-USER_SRC_DIR=user_files
-mkdir -p ${USER_SRC_DIR}
+    # Define and create directory for user source files
+    USER_SRC_DIR=temp_user_out
+    mkdir -p $(dirname ${USER_SRC_DIR}/${out_name})
 
-# OLD SOLUTION: Search for all files of relevant file extensions in current directory
-# file_extensions=("c" "cpp" "h" "hpp" "cu" "cuh")
-# find_cmd="find ${cwd} -maxdepth 1 -type f \( -iname \*.c"
-# for ext in ${file_extensions[@]}; do
-    # find_cmd="${find_cmd} -o -iname \*.${ext}"
-# done
-# find_cmd="${find_cmd} \);"
+    # Create absolute path by identifying leading slash
+    if [[ ${1:0:1} == "/" ]] ; then 
+        abs_path_src_file=$1
+    else  
+        abs_path_src_file="${cwd}/$1"
+    fi
 
-# Copy user's source file to installed rootppl directory
-destination_path=$(dirname ./${USER_SRC_DIR}/$1)
-mkdir -p ${destination_path}
-cp -rf ${cwd}/$1 ./${USER_SRC_DIR}/$1
+    # Build executable and copy it to the user's working directory
+    make model=${abs_path_src_file} EXEC_NAME=${USER_SRC_DIR}/${out_name} ${args} EXTRA_FLAGS=-I${cwd}
+    mkdir -p $(dirname ${cwd}/${out_name}) # Create out dir if the user specified out path does not exist
+    cp ${USER_SRC_DIR}/${out_name} ${cwd}/${out_name}
 
-# Build executable and copy it to the user's working directory
-# The user's working directory is included in the path when compiling in case of additional included files
-out_name=${USER_SRC_DIR}/${out_name}
-added_include_path=$(dirname ${cwd}/$1)
-make model=${USER_SRC_DIR}/$1 EXEC_NAME=${out_name} ${args} EXTRA_FLAGS=-I${added_include_path}
-cp ${out_name} ${cwd}/
-
-# Clear user source directory
-rm -rf ${USER_SRC_DIR}
+    # Delete temp user directory
+    rm -rf ${USER_SRC_DIR}
 fi

--- a/rootppl/rootppl
+++ b/rootppl/rootppl
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+##### START PARSE ARGS #####
+args=""
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -o|--out)
+    out_name="$2"
+    args="${args} EXEC_NAME=${out_name}"
+    shift # past argument
+    shift # past value
+    ;;
+    -j|--jobs)
+    num_compile_threads="$2"
+    args="${args} -j${num_compile_threads}"
+    shift # past argument
+    shift # past value
+    ;;
+    -a|--arch)
+    arch="$2"
+    args="${args} arch=${arch}"
+    shift # past argument
+    shift # past value
+    ;;
+    --omp)
+    # LIBPATH="$2"
+    args="${args} omp"
+    shift # past argument
+    ;;
+    --cxx)
+    cxx="$2"
+    args="${args} CXX=${cxx}"
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+##### END PARSE ARGS #####
+
+
+if [ "$1" = "clean" ]; then
+make clean
+else
+make model=$1 $args
+fi

--- a/rootppl/rootppl
+++ b/rootppl/rootppl
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# This file builds the executable by: 
+#   1. Copying the source file to the installed rootppl directory
+#   2. Change directory to installed rootppl directory
+#   3. Build the executable with the inference framework
+#   4. Copy the executable back to the user's working directory and clean up rootppl directory
+
+# NOTE: Currently only works for relative paths to user source file
+
+
+out_name=program
 
 ##### START PARSE ARGS #####
 args=""
@@ -12,7 +22,8 @@ key="$1"
 case $key in
     -o|--out)
     out_name="$2"
-    args="${args} EXEC_NAME=${out_name}"
+    # This argument is handled separately and hence not added to args string here
+    # args="${args} EXEC_NAME=${USER_SRC_DIR}/${out_name}"
     shift # past argument
     shift # past value
     ;;
@@ -46,11 +57,50 @@ case $key in
 esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [[ $# -eq 0 ]] ; then
+    echo 'Error: source file positional argument required'
+    exit 0
+fi
+
+if [[ -n $2 ]] ; then
+    echo 'Error: only one positional argument required, second positional argument passed: ' \"$2\"
+    exit 0
+fi
 ##### END PARSE ARGS #####
 
 
+cwd=$(pwd)
+cd ~/.local/lib/rootppl/
+
+# "rootppl clean" used for cleaning before changing platform, e.g. cpu to gpu
 if [ "$1" = "clean" ]; then
 make clean
 else
-make model=$1 $args
+# Define and create directory for user source files
+USER_SRC_DIR=user_files
+mkdir -p ${USER_SRC_DIR}
+
+# OLD SOLUTION: Search for all files of relevant file extensions in current directory
+# file_extensions=("c" "cpp" "h" "hpp" "cu" "cuh")
+# find_cmd="find ${cwd} -maxdepth 1 -type f \( -iname \*.c"
+# for ext in ${file_extensions[@]}; do
+    # find_cmd="${find_cmd} -o -iname \*.${ext}"
+# done
+# find_cmd="${find_cmd} \);"
+
+# Copy user's source file to installed rootppl directory
+destination_path=$(dirname ./${USER_SRC_DIR}/$1)
+mkdir -p ${destination_path}
+cp -rf ${cwd}/$1 ./${USER_SRC_DIR}/$1
+
+# Build executable and copy it to the user's working directory
+# The user's working directory is included in the path when compiling in case of additional included files
+out_name=${USER_SRC_DIR}/${out_name}
+added_include_path=$(dirname ${cwd}/$1)
+make model=${USER_SRC_DIR}/$1 EXEC_NAME=${out_name} ${args} EXTRA_FLAGS=-I${added_include_path}
+cp ${out_name} ${cwd}/
+
+# Clear user source directory
+rm -rf ${USER_SRC_DIR}
 fi


### PR DESCRIPTION
This PR changes the RootPPL build process to include `make install`. The `rootppl` command can then build models globally and not just inside the repository. It builds the executable into the users current working directory and it can be named with e.g. `-o my_exec`. The compile arguments are slightly changed due to new parsing code in the rootppl bash script. 

An example:
`rootppl my_crbd.cu -o crbd_omp --omp -j 5`
or (for Mac with e.g. gcc-10)
`rootppl my_crbd.cu -o crbd_omp --omp -j 5 --cxx g++-10`
or for GPU
`rootppl my_crbd.cu -o crbd_gpu --arch 75 -j 5 --cxx g++-10`

The README is updated with install instructions and previous compile commands are adapted. 

<br>

The `rootppl` command works by:

1. Get the absolute path to the source file
2. Change directory to installed rootppl directory
3. Build the executable with the inference framework with the users working directory added to the g++/nvcc include paths
4. Copy the executable back to the user's working directory and clean up rootppl directory

This is documented in the bash script as well. 