### PR TITLE
Major refactoring of `rootppl/compile.mc`

### DIFF
--- a/coreppl/dppl-parser.mc
+++ b/coreppl/dppl-parser.mc
@@ -6,7 +6,7 @@ include "coreppl.mc"
 
 
 
-lang DPPLParser = BootParser + MExprPrettyPrint + CorePPL + KeywordMaker
+lang DPPLParser = BootParser + MExprPrettyPrint + CorePPLInference + KeywordMaker
 
   -- Keyword maker
   sem isKeyword =
@@ -26,6 +26,8 @@ lang DPPLParser = BootParser + MExprPrettyPrint + CorePPL + KeywordMaker
   | "weight" -> Some (1, lam lst. TmWeight {weight = get lst 0,
                                             ty = TyUnknown {info = info},
                                             info = info})
+  | "resample" -> Some (0, lam lst. TmResample {ty = TyUnknown {info = info},
+                                                info = info})
   | "Uniform" -> Some (2, lam lst. TmDist {dist = DUniform {a = get lst 0, b = get lst 1},
                                            ty = TyUnknown {info = info},
                                            info = info})
@@ -59,7 +61,7 @@ lang DPPLParser = BootParser + MExprPrettyPrint + CorePPL + KeywordMaker
 end
 
 let keywords =
-["assume", "observe", "weight",
+["assume", "observe", "weight", "resample",
  "Uniform", "Bernoulli", "Poisson", "Beta", "Gamma", "Categorical",
  "Multinomial", "Dirichlet", "Exponential", "Empirical"]
 

--- a/coreppl/inference.mc
+++ b/coreppl/inference.mc
@@ -7,6 +7,7 @@ let performInference = lam options. lam ast.
   match options.method with "importance" then
     print "TODO: perform importance sampling!"
   else match options.method with "rootppl-smc" then
+    -- dprint ast
     writeFile "out.cu" (printCompiledRPProg (rootPPLCompile ast))
     -- print (join ["TODO: perform SMC using RootPPL with ",
     --              int2string options.particles, " particles."])

--- a/rootppl/rootppl.mc
+++ b/rootppl/rootppl.mc
@@ -14,6 +14,7 @@ let nameBblocksArr = nameSym "bblocksArr"
 let nameBblockCall = nameSym "BBLOCK_CALL"
 let nameDataPointer = nameSym "DATA_POINTER"
 let nameNull = nameSym "NULL"
+let nameUIntPtr = nameSym "uintptr_t"
 
 let rpKeywords = concat (map nameNoSym [
   "BBLOCK", "BBLOCK_DECLARE", "SAMPLE", "WEIGHT", "PSTATE", "PC", "bernoulli",

--- a/rootppl/rootppl.mc
+++ b/rootppl/rootppl.mc
@@ -53,6 +53,13 @@ lang RootPPL = CAst + CPrettyPrint
   | CTBBlockDecl _ & t -> t
   | CTBBlock t -> CTBBlock { t with body = join (map f t.body) }
 
+  sem sfold_CTop_CStmt (f: a -> CStmt -> a) (acc: a) =
+  | CTBBlockData _ -> acc
+  | CTBBlockHelperDecl _ -> acc
+  | CTBBlockHelper t -> foldl f acc t.body
+  | CTBBlockDecl _ -> acc
+  | CTBBlock t -> foldl f acc t.body
+
   syn CExpr =
   | CEBBlockName { name: Name } -- Block names (will be replace by indices when printing)
   | CESample { dist: CDist }


### PR DESCRIPTION
- Major refactoring of `rootppl/compile.mc`. Now uses relative addressing and proper C stack frame types.
- Add `resample` to keywords.
- Add compilation of uniform, poisson, and gamma.
- Add keywords handling to RootPPL pprint.
