### PR TITLE
Add built-in stack program state

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ a parallel implementation for the GPU, and a sequential and parallel implementat
 - The `utils` directory contains code that RootPPL uses, but can be used by models as well. 
 - The `models` directory contains example models that use the inference. 
 
+### Compile with the built-in stack
+To compile with the `progStateStack_t` program state, the macro `INIT_MODEL_STACK(num_bblocks)` should be used instead of `INIT_MODEL(progState_t, num_bblocks)`.
+Then the stack size is specified in bytes with `--stack_size num_bytes`, e.g. `rootppl my_stack_model.cu --stack_size 10000`.
 
 ### Building a more interesting model
 TODO, stuff not yet demonstrated explicitly in README: 

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -3,8 +3,11 @@ ifndef EXEC_NAME
 EXEC_NAME=program
 endif
 
+ifdef STACK_SIZE_PROGSTATE
+STACK_FLAG=-D STACK_SIZE_PROGSTATE=$(STACK_SIZE_PROGSTATE)
+endif
 
-COMMON_FLAGS=$(EXTRA_FLAGS) -I. -std=c++14 -O3
+COMMON_FLAGS=$(EXTRA_FLAGS) -I. -std=c++14 -O3 $(STACK_FLAG)
 ifdef arch
 # GPU
 # CC=/usr/local/cuda-11.0/bin/nvcc

--- a/rootppl/inference/smc/particles_memory_handler.cu
+++ b/rootppl/inference/smc/particles_memory_handler.cu
@@ -16,7 +16,12 @@ particles_t allocateParticles(int numParticles, size_t progStateSize, bool print
 
     particles_t particles;
     
+    #ifdef STACK_SIZE_PROGSTATE
+    allocateMemory<progStateStack_t>(&particles.progStates, numParticles);
+    #else
     allocateMemoryVoid(&particles.progStates, numParticles * progStateSize);
+    #endif
+
     allocateMemory<int>(&particles.pcs, numParticles);
     allocateMemory<floating_t>(&particles.weights, numParticles);
 
@@ -37,14 +42,24 @@ particles_t allocateParticles(int numParticles, size_t progStateSize, bool print
 }
 
 void freeParticles(particles_t particles) {
+    #ifdef STACK_SIZE_PROGSTATE
+    freeMemory<progStateStack_t>(particles.progStates);
+    #else
     freeMemoryVoid(particles.progStates);
+    #endif
+
     freeMemory<int>(particles.pcs);
     freeMemory<floating_t>(particles.weights);
 }
 
 HOST DEV particles_t allocateParticlesNested(int numParticles, size_t progStateSize) {
     particles_t particles;
-    particles.progStates = malloc(progStateSize * numParticles);;
+    #ifdef STACK_SIZE_PROGSTATE
+    particles.progStates = new progStateStack_t[numParticles];
+    #else
+    particles.progStates = malloc(progStateSize * numParticles);
+    #endif
+
     particles.pcs = new int[numParticles];
     memset(particles.pcs, 0, sizeof(int) * numParticles);
     particles.weights = new floating_t[numParticles];
@@ -53,7 +68,12 @@ HOST DEV particles_t allocateParticlesNested(int numParticles, size_t progStateS
 }
 
 HOST DEV void freeParticlesNested(particles_t particles) {
+    #ifdef STACK_SIZE_PROGSTATE
+    delete[] particles.progStates;
+    #else
     free(particles.progStates);
+    #endif
+
     delete[] particles.pcs;
     delete[] particles.weights;
 }

--- a/rootppl/inference/smc/resample/common.cu
+++ b/rootppl/inference/smc/resample/common.cu
@@ -90,6 +90,14 @@ HOST DEV void copyParticle(const particles_t particlesDst, const particles_t par
 HOST DEV void copyStack(progStateStack_t* dst, progStateStack_t* src) {
     dst->stackPtr = src->stackPtr;
     size_t stackSpaceUsed = src->stackPtr;
+
+    // Try to round up copy size to nearest multiple of sizeof(long), this can speed up GPU copying
+    #ifdef __NVCC__
+    int remainder = stackSpaceUsed % sizeof(long);
+    if (remainder > 0)
+        stackSpaceUsed = MIN(stackSpaceUsed + sizeof(long) - remainder, STACK_SIZE_PROGSTATE);
+    #endif
+
     copyChunk(dst->stack, src->stack, stackSpaceUsed);
 }
 #endif

--- a/rootppl/inference/smc/resample/common.cu
+++ b/rootppl/inference/smc/resample/common.cu
@@ -66,46 +66,76 @@ HOST DEV void destResamplerNested(resampler_t resampler) {
 
 HOST DEV void copyParticle(const particles_t particlesDst, const particles_t particlesSrc, int dstIdx, int srcIdx, size_t progStateSize) {
     
+    // Program states
+    #ifdef STACK_SIZE_PROGSTATE
+    progStateStack_t* dstProgState = particlesDst.progStates + dstIdx;
+    progStateStack_t* srcProgState = particlesSrc.progStates + srcIdx;
+
+    copyStack(dstProgState, srcProgState);
+    
+    #else
     char* psDstAddress = static_cast<char*>(particlesDst.progStates) + progStateSize * dstIdx;
     char* psSrcAddress = static_cast<char*>(particlesSrc.progStates) + progStateSize * srcIdx;
 
+    copyChunk(psDstAddress, psSrcAddress, progStateSize);
+
+    #endif
+
+    // Generic particle stuff
+    particlesDst.pcs[dstIdx] = particlesSrc.pcs[srcIdx];
+    particlesDst.weights[dstIdx] = 0;
+}
+
+#ifdef STACK_SIZE_PROGSTATE
+HOST DEV void copyStack(progStateStack_t* dst, progStateStack_t* src) {
+    dst->stackPtr = src->stackPtr;
+    size_t stackSpaceUsed = src->stackPtr;
+    copyChunk(dst->stack, src->stack, stackSpaceUsed);
+}
+#endif
+
+HOST DEV void copyChunk(void* dst, void* src, size_t bytes) {
+    #ifdef __NVCC__
+    // Manual loop copying can be much faster on GPU than device memcpy
     // If the struct is aligned in the correct way, the loop long copying can give huge speedups compared to memcpy on GPU
-    bool longAligned = progStateSize % sizeof(long) == 0 
-                    && ((std::uintptr_t)psDstAddress) % sizeof(long) == 0
-                    && ((std::uintptr_t)psSrcAddress) % sizeof(long) == 0;
+    bool longAligned = bytes % sizeof(long) == 0 
+                    && ((std::uintptr_t)dst) % sizeof(long) == 0
+                    && ((std::uintptr_t)src) % sizeof(long) == 0;
 
     if(longAligned) {
-        long* psDstLong = (long*)(psDstAddress);
-        long* psSrcLong = (long*)(psSrcAddress);
+        long* dstLong = (long*)(dst);
+        long* srcLong = (long*)(src);
 
-        int numDblWords = progStateSize / sizeof(long);
+        int numDblWords = bytes / sizeof(long);
 
         for(int i = 0; i < numDblWords; i++) {
-            psDstLong[i] = psSrcLong[i];
+            dstLong[i] = srcLong[i];
         }
         
     } else {
-        bool intAligned = progStateSize % sizeof(int) == 0 
-                    && ((std::uintptr_t)psDstAddress) % sizeof(int) == 0
-                    && ((std::uintptr_t)psSrcAddress) % sizeof(int) == 0;
+        bool intAligned = bytes % sizeof(int) == 0 
+                    && ((std::uintptr_t)dst) % sizeof(int) == 0
+                    && ((std::uintptr_t)src) % sizeof(int) == 0;
         if(intAligned) {
 
-            int* psDstInt = (int*)(psDstAddress);
-            int* psSrcInt = (int*)(psSrcAddress);
+            int* dstInt = (int*)(dst);
+            int* srcInt = (int*)(src);
 
-            int numWords = progStateSize / sizeof(int);
+            int numWords = bytes / sizeof(int);
 
             for(int i = 0; i < numWords; i++) {
-                psDstInt[i] = psSrcInt[i];
+                dstInt[i] = srcInt[i];
             }
 
         } else {
-            memcpy(psDstAddress, psSrcAddress, progStateSize);
+            // Not aligned, fall back to memcpy
+            memcpy(dst, src, bytes);
         }
     }
-    
-    particlesDst.pcs[dstIdx] = particlesSrc.pcs[srcIdx];
-    particlesDst.weights[dstIdx] = 0;
+    #else
+    // On CPU, memcpy seems to perform much better. Seems to be true with OpenMP as well
+    memcpy(dst, src, bytes);
+    #endif
 }
 
 // This could probably be optimized by sorting the particles by descending weights first

--- a/rootppl/inference/smc/resample/common.cuh
+++ b/rootppl/inference/smc/resample/common.cuh
@@ -83,6 +83,24 @@ HOST DEV void destResamplerNested(resampler_t resampler);
  */
 HOST DEV void copyParticle(particles_t particlesDst, const particles_t particlesSrc, int dstIdx, int srcIdx, size_t progStateSize);
 
+/**
+ * Copies a chunk of memory. Uses memcpy on CPU and manual loops for speedup on GPU.
+ *
+ * @param dst destination address
+ * @param src source address
+ * @param bytes size in bytes of chunk to copy
+ */
+HOST DEV void copyChunk(void* dst, void* src, size_t bytes);
+
+#ifdef STACK_SIZE_PROGSTATE
+/**
+ * Copies a progStateStack_t, by copying the stack pointer, and only the used part of the stack (derived from stack pointer).
+ *
+ * @param dst destination address
+ * @param src source address
+ */
+HOST DEV void copyStack(progStateStack_t* dst, progStateStack_t* src);
+#endif
 
 /**
  * Samples an ancestor from the categorical distribution defined by the weights. 

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -44,6 +44,10 @@ typedef double floating_t;
 BBLOCK_DATA(bblocksArr, pplFunc_t, numBblocks) \
 typedef progStateType progStateTypeTopLevel_t;
 
+#define INIT_MODEL_STACK(numBblocks) \
+BBLOCK_DATA(bblocksArr, pplFunc_t, numBblocks) \
+typedef progStateStack_t progStateTypeTopLevel_t;
+
 
 /***    BBLOCKS    ***/
 

--- a/rootppl/rootppl
+++ b/rootppl/rootppl
@@ -48,6 +48,12 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --stack_size)
+    stack_size="$2"
+    args="${args} STACK_SIZE_PROGSTATE=${stack_size}"
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     POSITIONAL+=("$1") # save it in an array for later
     shift # past argument


### PR DESCRIPTION
The built-in stack is used to enable a special case particle copying in resampling. When using this stack, resampling only copies the part of the stack that is currently in use, derived from the stack pointer. 

Unfortunately, the stack size must be specified when compiling as follows:
`rootppl out.cu --stack_size 100000`
To change this stack size, `rootppl clean` must be called first, so the framework is recompiled as well. 

Also: CPU copying always uses `memcpy` instead of manual loops now, this seems to be faster for large program states and insignificant for smaller states. 