### PR TITLE
Add macros for CUDA managed allocation, BBLOCK_DATA_MANAGED

### DIFF
--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -83,6 +83,9 @@ body
 
 // Call functions that takes the particles as argument (syntactic sugar).
 #define BBLOCK_CALL(funcName, ...) funcName(BBLOCK_ARGS, ##__VA_ARGS__)
+
+// Declares global data with CUDA managed memory to handle transfers between host and device. 
+#define BBLOCK_DATA_MANAGED(pointerName, type, n) MANAGED type pointerName[n];
 /***    *****    ***/
 
 

--- a/rootppl/macros/macros_adaptive.cuh
+++ b/rootppl/macros/macros_adaptive.cuh
@@ -10,6 +10,7 @@
 
 #define HOST __host__
 #define DEV __device__
+#define MANAGED __managed__
 
 #define LOG(x) log(static_cast<floating_t>(x))
 
@@ -22,7 +23,10 @@
 // Copies a reference to a device function to a host pointer, necessary to handle GPU function pointers on CPU
 #define FUN_REF(funcName, progStateType) cudaSafeCall(cudaMemcpyFromSymbol(&funcName ## Host, funcName ## Dev, sizeof(pplFunc_t))); 
 
-// Allocate data on host and device, should be followed by a COPY_DATA_GPU call before inference if values are not initialized automatically
+/* Allocate data on host and device, should be followed by a COPY_DATA_GPU call before inference if values are not initialized automatically
+ * If the memory should be modifiable from device code, it must be declared as __device__ and not __constant__.
+ * This does not seem to have a remarkable impact on performance. 
+ */
 #define BBLOCK_DATA(pointerName, type, n) type pointerName[n];\
 __constant__ type pointerName ## Dev[n];
 
@@ -66,6 +70,7 @@ __constant__ type constName ## Dev = value;
 // The macros below are equivalent to the GPU variants above, but for CPU
 #define HOST
 #define DEV
+#define MANAGED
 #define LOG(x) log(x)
 #define ALLOC_TYPE(pointerAddress, type, n) *pointerAddress = new type[n];
 #define FREE(pointer) delete[] pointer;


### PR DESCRIPTION
Contains some additional documentation about modifiers `__device__` vs `__constant__`.

More importantly, new macros to handle global data that can be initialized on CPU and automatically used on GPU:
- `MANAGED`: empty macro on CPU and `__managed__` on GPU to declare CUDA managed data. 
- `BBLOCK_DATA_MANAGED`: Creates global array data, like `BBLOCK_DATA` but with `MANAGED` modifier. This requires no explicit copying to GPU which is usually done with `COPY_DATA_GPU` and accessing this data requires no usage of the `DATA_POINTER` macro. Very brief tests indicate that no significant performance penalty comes with this CUDA-managed memory. 