### PR TITLE
CorePPL compiler updates

### DIFF
--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -152,8 +152,9 @@ let removeRedundantLets: Expr -> Expr = use MExprPPLRootPPLCompile in
     recursive let rec: Bool -> Expr -> Expr = lam inLet. lam expr.
 
       -- Let
-      match expr
-      with TmLet ({ ident = idLet, body = body, inexpr = inexpr } & t) then
+      match expr with TmLet ({
+        ident = idLet, body = body, inexpr = inexpr
+      } & t) then
         let ok = match body with TmApp _ then inLet else true in
         if ok then
           let f = lam. TmLet {{ t with body = rec true body }
@@ -163,6 +164,9 @@ let removeRedundantLets: Expr -> Expr = use MExprPPLRootPPLCompile in
             else f ()
           else f ()
         else smap_Expr_Expr (rec inLet) expr
+
+      -- Lambda
+      else match expr with TmLam _ then smap_Expr_Expr (rec false) expr
 
       -- Not a let
       else smap_Expr_Expr (rec inLet) expr
@@ -1293,6 +1297,8 @@ let rootPPLCompile: Expr -> RPProg = use MExprPPLRootPPLCompile in lam prog.
 
   -- Remove redundant lets
   let prog: Expr = removeRedundantLets prog in
+
+  -- print (expr2str prog); print "\n\n";
 
   -- Find categories for identifiers
   let ci: Map Name Int = catIdents prog in

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -84,6 +84,11 @@ body
 // Call functions that takes the particles as argument (syntactic sugar).
 #define BBLOCK_CALL(funcName, ...) funcName(BBLOCK_ARGS, ##__VA_ARGS__)
 
+// Jump directly to a BBLOCK without adding a new stack frame.
+// TODO Current implementation is identical to BBLOCK_CALL, but it would be
+// nice to change this.
+#define BBLOCK_JUMP(funcName, ...) funcName(BBLOCK_ARGS, ##__VA_ARGS__)
+
 // Declares global data with CUDA managed memory to handle transfers between host and device. 
 #define BBLOCK_DATA_MANAGED(pointerName, type, n) MANAGED type pointerName[n];
 /***    *****    ***/

--- a/rootppl/rootppl.mc
+++ b/rootppl/rootppl.mc
@@ -12,6 +12,7 @@ include "c/pprint.mc"
 -- Explicit handles on certain keywords
 let nameBblocksArr = nameSym "bblocksArr"
 let nameBblockCall = nameSym "BBLOCK_CALL"
+let nameBblockJump = nameSym "BBLOCK_JUMP"
 let nameDataPointer = nameSym "DATA_POINTER"
 let nameNull = nameSym "NULL"
 let nameUIntPtr = nameSym "uintptr_t"
@@ -23,8 +24,8 @@ let rpKeywords = concat (map nameNoSym [
   "poisson", "gamma", "INIT_MODEL", "MAIN", "SMC", "ADD_BBLOCK", "particleIdx",
   "lnFactorial"
 ]) [
-  nameBblocksArr, nameBblockCall, nameDataPointer, nameNull, nameUIntPtr,
-  nameProgState
+  nameBblocksArr, nameBblockCall, nameBblockJump, nameDataPointer, nameNull,
+  nameUIntPtr, nameProgState
 ]
 
 lang RootPPL = CAst + CPrettyPrint


### PR DESCRIPTION
- Simplifies compilation as a result of https://github.com/miking-lang/miking/pull/435.
- Adds `BBLOCK_JUMP` in RootPPL. This is currently equivalent to `BBLOCK_CALL`, but optimally we would like this macro to jump directly (cf. `goto` in C) to another `BBLOCK` without creating a new frame on the call stack.
- Fix bug related to decomposition of C `if`-statements.