### PR TITLE
Replace PC by next pointer and optimize ess calculations

### DIFF
--- a/rootppl/inference/smc/particles_memory_handler.cu
+++ b/rootppl/inference/smc/particles_memory_handler.cu
@@ -22,19 +22,17 @@ particles_t allocateParticles(int numParticles, size_t progStateSize, bool print
     allocateMemoryVoid(&particles.progStates, numParticles * progStateSize);
     #endif
 
-    allocateMemory<int>(&particles.pcs, numParticles);
+    allocateMemory<pplFunc_t>(&particles.next, numParticles);
     allocateMemory<floating_t>(&particles.weights, numParticles);
 
     #ifdef __NVCC__
-    cudaMemset(particles.pcs, 0, sizeof(int) * numParticles);
     cudaMemset(particles.weights, 0, sizeof(floating_t) * numParticles);
     #else
-    memset(particles.pcs, 0, sizeof(int) * numParticles);
     memset(particles.weights, 0, sizeof(floating_t) * numParticles);
     #endif
 
     if (printMemSize) {
-        floating_t totalMem = progStateSize * numParticles + sizeof(int) * numParticles + sizeof(floating_t) * numParticles;
+        floating_t totalMem = progStateSize * numParticles + sizeof(pplFunc_t) * numParticles + sizeof(floating_t) * numParticles;
         printf("Particles memory size for N=%d: %fMB\n", numParticles, totalMem * 2 / 1000000.0);
     }
     
@@ -48,10 +46,12 @@ void freeParticles(particles_t particles) {
     freeMemoryVoid(particles.progStates);
     #endif
 
-    freeMemory<int>(particles.pcs);
+    freeMemory<pplFunc_t>(particles.next);
     freeMemory<floating_t>(particles.weights);
 }
 
+/*
+// Obsolete!
 HOST DEV particles_t allocateParticlesNested(int numParticles, size_t progStateSize) {
     particles_t particles;
     #ifdef STACK_SIZE_PROGSTATE
@@ -77,3 +77,4 @@ HOST DEV void freeParticlesNested(particles_t particles) {
     delete[] particles.pcs;
     delete[] particles.weights;
 }
+*/

--- a/rootppl/inference/smc/resample/common.cu
+++ b/rootppl/inference/smc/resample/common.cu
@@ -34,6 +34,19 @@ resampler_t initResampler(int numParticles, size_t progStateSize) {
     return resampler;
 }
 
+void destResampler(resampler_t resampler) {
+
+    freeMemory<int>(resampler.ancestor);
+    freeMemory<int>(resampler.cumulativeOffspring);
+    freeMemory<floating_t>(resampler.prefixSum);
+    #ifdef __NVCC__
+    freeMemory<floating_t>(resampler.wSquared);
+    #endif
+    freeParticles(resampler.auxParticles);
+}
+
+/*
+// Obsolete
 HOST DEV resampler_t initResamplerNested(int numParticles, size_t progStateSize) {
 
     resampler_t resampler;
@@ -46,23 +59,13 @@ HOST DEV resampler_t initResamplerNested(int numParticles, size_t progStateSize)
     return resampler;
 }
 
-void destResampler(resampler_t resampler) {
-
-    freeMemory<int>(resampler.ancestor);
-    freeMemory<int>(resampler.cumulativeOffspring);
-    freeMemory<floating_t>(resampler.prefixSum);
-    #ifdef __NVCC__
-    freeMemory<floating_t>(resampler.wSquared);
-    #endif
-    freeParticles(resampler.auxParticles);
-}
-
 HOST DEV void destResamplerNested(resampler_t resampler) {
     delete[] resampler.ancestor;
     delete[] resampler.cumulativeOffspring;
     delete[] resampler.prefixSum;
     freeParticlesNested(resampler.auxParticles);
 }
+*/
 
 HOST DEV void copyParticle(const particles_t particlesDst, const particles_t particlesSrc, int dstIdx, int srcIdx, size_t progStateSize) {
     
@@ -82,7 +85,7 @@ HOST DEV void copyParticle(const particles_t particlesDst, const particles_t par
     #endif
 
     // Generic particle stuff
-    particlesDst.pcs[dstIdx] = particlesSrc.pcs[srcIdx];
+    particlesDst.next[dstIdx] = particlesSrc.next[srcIdx];
     particlesDst.weights[dstIdx] = 0;
 }
 

--- a/rootppl/inference/smc/resample/systematic/kernels.cuh
+++ b/rootppl/inference/smc/resample/systematic/kernels.cuh
@@ -13,8 +13,9 @@
  * @param w the weight array.
  * @param numParticles the number of particles used in SMC.
  * @param maxLogWeight the log of the maximum weight. 
+ * @param wSquared the output array that should hold the scaled squared weights
  */
-__global__ void expWeightsKernel(floating_t* w, int numParticles, floating_t maxLogWeight);
+__global__ void scaleExpWeightsAndSquareWeightsKernel(floating_t* w, int numParticles, floating_t maxLogWeight, floating_t* wSquared);
 
 /**
  * Takes the logarithm of the prefixSum and weight belonging to the current particle then scales back. 
@@ -26,16 +27,6 @@ __global__ void expWeightsKernel(floating_t* w, int numParticles, floating_t max
  * @param maxLogWeight the log of the maximum weight. 
  */
 __global__ void renormaliseKernel(floating_t* w, floating_t* prefixSum, int numParticles, floating_t maxLogWeight);
-
-/**
- *  Calculate the array of squared weights. 
- * 
- * @param w the input log-weight array.
- * @param w the squared weight array too store the result in.
- * @param maxLogWeight the maximum log weight.
- * @param numParticles the number of particles used in SMC.
- */
-__global__ void expSquareWeightsKernel(floating_t* w, floating_t* wSquared, floating_t maxLogWeight, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 

--- a/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_cpu.cuh
@@ -7,25 +7,27 @@
 
  #include "inference/smc/resample/common.cuh"
 
+ #include <tuple>
+
 /**
- * Calculates the log weight prefix sums. 
+ * Calculates the log weight prefix sums and ESS. 
  * 
  * @param w the weight array.
  * @param resampler the resampler struct.
  * @param numParticles the number of particles used in SMC.
- * @return the logarithm of the total weight sum. 
+ * @return tuple(the logarithm of the total weight sum, ESS)
  */
-HOST DEV floating_t calcLogWeightSumCpu(floating_t* w, resampler_t& resampler, int numParticles);
+HOST std::tuple<floating_t, floating_t> calcLogWeightSumAndESSCpu(floating_t* w, resampler_t& resampler, int numParticles);
 
 /**
- * Calculates the ESS (effective sample size). 
- *
- * @param w the array of particle weights
- * @param logWeightSum the logarithm of the sum of weights. 
+ * Calculates the ESS. 
+ * 
+ * @param scaledW the max weight scaled weight array.
+ * @param scaledWeightSum the max log weight scaled weight sum.
  * @param numParticles the number of particles used in SMC.
- * @return the effective sample size.
+ * @return effective sample size
  */
-HOST DEV floating_t calcESSCpu(floating_t* w, floating_t logWeightSum, resampler_t resampler, int numParticles);
+HOST floating_t calcESSHelperCpu(floating_t* scaledW, floating_t scaledWeightSum, int numParticles);
 
 /**
  * Calculates the cumulative offspring of each particle. 

--- a/rootppl/inference/smc/resample/systematic/systematic_gpu.cu
+++ b/rootppl/inference/smc/resample/systematic/systematic_gpu.cu
@@ -21,37 +21,41 @@ HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numPartic
         resampler.prefixSum[i] = resampler.prefixSum[i-1] + w[i];
 }
 
-HOST DEV floating_t calcLogWeightSumGpu(floating_t* w, resampler_t& resampler, int numParticles, int numBlocks, int numThreadsPerBlock) {
+HOST std::tuple<floating_t, floating_t> calcLogWeightSumAndESSGpu(floating_t* w, resampler_t& resampler, int numParticles, int numBlocks, int numThreadsPerBlock) {
 
     floating_t maxLogWeight = *(thrust::max_element(thrust::device, w, w + numParticles));
     resampler.maxLogWeight = maxLogWeight;
     // floating_t maxLogWeight = maxNaive(w, numParticles);
     
-    expWeightsKernel<<<numBlocks, numThreadsPerBlock>>>(w, numParticles, maxLogWeight);
+    scaleExpWeightsAndSquareWeightsKernel<<<numBlocks, numThreadsPerBlock>>>(w, numParticles, maxLogWeight, resampler.wSquared);
     cudaDeviceSynchronize();
     thrust::inclusive_scan(thrust::device, w, w + numParticles, resampler.prefixSum); // prefix sum
     // prefixSumNaive(w, resampler, numParticles);
 
+    // At this point: w are scaled weights (not log), prefixSum[numParticles-1] is the scaled sum
+    floating_t ess = calcESSHelperGpu(w, resampler.prefixSum[numParticles - 1], resampler.wSquared, numParticles);
+
     renormaliseKernel<<<numBlocks, numThreadsPerBlock>>>(w, resampler.prefixSum, numParticles, maxLogWeight);
     
     cudaDeviceSynchronize();
-    return resampler.prefixSum[numParticles - 1];
+    // return resampler.prefixSum[numParticles - 1];
+    return std::make_tuple(resampler.prefixSum[numParticles - 1], ess);
 }
 
-HOST DEV floating_t calcESSGpu(floating_t* w, floating_t logWeightSum, resampler_t resampler, int numParticles, int numBlocks, int numThreadsPerBlock) {
+HOST floating_t calcESSHelperGpu(floating_t* scaledW, floating_t scaledWeightSum, floating_t* scaledWSquared, int numParticles) {
 
     // Kernel saving new square exp log weights
-    expSquareWeightsKernel<<<numBlocks, numThreadsPerBlock>>>(w, resampler.wSquared, resampler.maxLogWeight, numParticles);
+    // expSquareWeightsKernel<<<numBlocks, numThreadsPerBlock>>>(w, resampler.wSquared, resampler.maxLogWeight, numParticles);
 
     // Thrust for summing squared weights
     cudaDeviceSynchronize();
-    floating_t wSumOfSquares = (thrust::reduce(thrust::device, resampler.wSquared, resampler.wSquared + numParticles));
+    floating_t wSumOfSquares = (thrust::reduce(thrust::device, scaledWSquared, scaledWSquared + numParticles));
 
-    floating_t scaledLogSum = logWeightSum - resampler.maxLogWeight;
-    floating_t wSumSquared = exp(scaledLogSum + scaledLogSum);
+    floating_t wSumSquared = scaledWeightSum * scaledWeightSum;
 
     return wSumSquared / wSumOfSquares;
 }
+
 
 HOST DEV void decideAncestors(resampler_t& resampler, floating_t u, int numParticles, int numBlocks, int numThreadsPerBlock) {
 

--- a/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
+++ b/rootppl/inference/smc/resample/systematic/systematic_gpu.cuh
@@ -7,6 +7,8 @@
 
 #ifdef __NVCC__
 
+#include <tuple>
+
 #include "inference/smc/resample/common.cuh"
 
 HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numParticles);
@@ -19,22 +21,21 @@ HOST DEV void prefixSumNaive(floating_t* w, resampler_t resampler, int numPartic
  * @param numParticles the number of particles used in SMC.
  * @param numBlocks kernel launch setting.
  * @param numThreadsPerBlock kernel launch setting.
- * @return the logarithm of the total weight sum. 
+ * @return tuple (log weight sum, ess)
  */
-HOST DEV floating_t calcLogWeightSumGpu(floating_t* w, resampler_t& resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
+HOST std::tuple<floating_t, floating_t> calcLogWeightSumAndESSGpu(floating_t* w, resampler_t& resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
 
 /**
  * Calculates the ESS (effective sample size).  
  * 
- * @param w the weight array.
- * @param logWeightSum the logarithm of the sum of weights. 
- * @param resampler the resampler struct.
+ * @param scaledW the max weight scaled weight array.
+ * @param scaledWeightSum the max weight scaled weight sum. 
+ * @param scaledWSquared the max weight scaled weights squared. 
  * @param numParticles the number of particles used in SMC.
- * @param numBlocks kernel launch setting.
- * @param numThreadsPerBlock kernel launch setting.
  * @return the effective sample size.
  */
-HOST DEV floating_t calcESSGpu(floating_t* w, floating_t logWeightSum, resampler_t resampler, int numParticles, int numBlocks, int numThreadsPerBlock);
+HOST floating_t calcESSHelperGpu(floating_t* scaledW, floating_t scaledWeightSum, floating_t* scaledWSquared, int numParticles);
+
 
 /**
  * Calculates the cumulative offsprings and then uses it to calculate the ancestor indices. 

--- a/rootppl/inference/smc/smc_kernels.cu
+++ b/rootppl/inference/smc/smc_kernels.cu
@@ -20,8 +20,16 @@ __global__ void initCurandStates(curandState* randStates, int numThreads, int se
     randStates[i] = randStateLocal;
 }
 
-__global__ void execFuncs(curandState* randStates, particles_t particles, const pplFunc_t* funcs, 
-                            int numParticles, int numThreads, int numBblocks, void* arg) {
+__global__ void initParticlesNext(particles_t particles, int numParticles, pplFunc_t firstBblock) {
+
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if(i >= numParticles || i < 0) return;
+
+    particles.next[i] = firstBblock;
+
+}
+
+__global__ void execFuncs(curandState* randStates, particles_t particles, int numParticles, int numThreads, void* arg) {
 
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     // if(i >= numParticles || i < 0) return;
@@ -31,9 +39,12 @@ __global__ void execFuncs(curandState* randStates, particles_t particles, const 
     
     for(int j = i; j < numParticles; j += numThreads) {
         // funcs[particles.pcs[i]](&randStateLocal, particles, i, arg);
-        int pc = particles.pcs[j];
-        if(pc < numBblocks && pc >= 0)
-            funcs[pc](&randStateLocal, particles, j, arg);
+        // int pc = particles.pcs[j];
+        pplFunc_t next = particles.next[j];
+        if(next != NULL)
+            next(&randStateLocal, particles, j, arg);
+        // if(pc < numBblocks && pc >= 0)
+            // funcs[pc](&randStateLocal, particles, j, arg);
     }
 
     randStates[i] = randStateLocal;

--- a/rootppl/inference/smc/smc_kernels.cuh
+++ b/rootppl/inference/smc/smc_kernels.cuh
@@ -18,8 +18,18 @@
  */
 __global__ void initCurandStates(curandState* randStates, int numThreads, int seed);
 
+
 /**
- * Each thread executes the bblock pointed to by the corresponding particle's PC. 
+ * Initializes the next pointers to the first basic block. 
+ * 
+ * @param particles the particles used by SMC.
+ * @param numParticles the number of particles used by SMC.
+ * @param firstBblock the first basic block to be exectued
+ */
+__global__ void initParticlesNext(particles_t particles, int numParticles, pplFunc_t firstBblock);
+
+/**
+ * Each thread executes the bblock pointed to by the corresponding particle's next pointer. 
  * 
  * @param randStates the curandStates, one for each particle, that should be used in inference.
  * @param particles the particles used by SMC.
@@ -28,7 +38,6 @@ __global__ void initCurandStates(curandState* randStates, int numThreads, int se
  * @param numBblocks the size of the bblock array
  * @param arg argument that are passed to the bblocks when invoking them, often not used and set to NULL. 
  */
-__global__ void execFuncs(curandState* randStates, particles_t particles, const pplFunc_t* funcs, 
-                            int numParticles, int numThreads, int numBblocks, void* arg);
+__global__ void execFuncs(curandState* randStates, particles_t particles, int numParticles, int numThreads, void* arg);
 
 #endif

--- a/rootppl/inference/smc/smc_nested.cu
+++ b/rootppl/inference/smc/smc_nested.cu
@@ -4,6 +4,8 @@
  * This file is included by smc_impl.cuh and relies on the includes in smc_impl.cuh.
  */
 
+// Nested inference is never used, and this code has become obsolete.
+/*
  #include "macros/macros.cuh"
  #include "smc.cuh"
  #include "dists/dists.cuh"
@@ -118,3 +120,4 @@ DEV double runSMCNested(
 
     return logNormConstant;
 }
+*/

--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -40,12 +40,10 @@ typedef double floating_t;
 #define GET_MACRO(_1, _2, _3, NAME,...) NAME
 
 // Sets up globally accessible bblock array, that can be accessed from the bblocks, and defines the type used in the model.
-#define INIT_MODEL(progStateType, numBblocks) \
-BBLOCK_DATA(bblocksArr, pplFunc_t, numBblocks) \
+#define INIT_MODEL(progStateType) \
 typedef progStateType progStateTypeTopLevel_t;
 
-#define INIT_MODEL_STACK(numBblocks) \
-BBLOCK_DATA(bblocksArr, pplFunc_t, numBblocks) \
+#define INIT_MODEL_STACK() \
 typedef progStateStack_t progStateTypeTopLevel_t;
 
 
@@ -100,7 +98,9 @@ body
 #define WEIGHT(w) particles.weights[particleIdx] += w
 
 // Access particle program counter (bblock index).
-#define PC particles.pcs[particleIdx]
+// #define PC particles.pcs[particleIdx]
+// #define NEXT ((pplFunc_t*)particles.next)[particleIdx]
+#define NEXT particles.next[particleIdx]
 
 // Access the particle's program/model specific state. Uses the top-level program state type.
 #define PSTATE static_cast<progStateTypeTopLevel_t*>(particles.progStates)[particleIdx]
@@ -134,22 +134,12 @@ int main(int argc, char** argv) { \
 #define CALLBACK(funcName, body) void funcName(particles_t& particles, int N, void* arg=NULL) body
 #define CALLBACK_NESTED(funcName, progStateType, body, arg) DEV void funcName(particles_t& particles, int N, arg) body
 
-/* 
-Initialize the basic block (add it to the array of bblocks), the order of bblocks matters!
-The first bblock to be initialized will be the first to be executed, then the execution follows the
-index (PC) specified by the model (bblocks).
-*/
-#define ADD_BBLOCK_DEF(funcName, progStateType) \
+// Define the first BBLOCK that should be executed in inference. The model itself then defines the order of BBLOCK execution. 
+#define FIRST_BBLOCK(funcName) \
 pplFunc_t funcName ## Host; \
-FUN_REF(funcName, progStateType) \
-bblocksArr[bbIdx] = funcName ## Host; \
-bbIdx++;
-// Handles parameter overloading
-#define ADD_BBLOCK(...) GET_MACRO(__VA_ARGS__, 0, ADD_BBLOCK_DEF, ADD_BBLOCK_NOTYPE)(__VA_ARGS__)
-#define ADD_BBLOCK_NOTYPE(funcName) ADD_BBLOCK_DEF(funcName, progStateTypeTopLevel_t)
+FUN_REF(funcName, progStateTypeTopLevel_t) \
+pplFunc_t firstBblock = funcName ## Host;
 
-// Same as above, but for nested inference.
-#define ADD_BBLOCK_NESTED(funcName, progStateType) bblocks[bbIdx] = funcName; bbIdx++;
 
 // Samples from distributions, which should all take the curandState as argument first if compiled for GPU.
 #define SAMPLE(distName, ...) distName(RAND_STATE __VA_ARGS__ )
@@ -181,21 +171,10 @@ int particlesPerThread = 1; \
 if(argc > 4) { \
     particlesPerThread = atoi(argv[4]); \
 } \
-int numBblocks = bbIdx; \
 prepareSMC(); \
-COPY_DATA_GPU(bblocksArr, pplFunc_t, numBblocks) \
-pplFunc_t* bblocksArrCudaManaged; \
-ALLOC_TYPE(&bblocksArrCudaManaged, pplFunc_t, numBblocks); \
-for(int i = 0; i < numBblocks; i++) \
-    bblocksArrCudaManaged[i] = bblocksArr[i]; \
 for(int i = 0; i < numRuns; i++) \
-    res = runSMC(bblocksArrCudaManaged, numBblocks, numParticles, ompThreads, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
-finishFilesSMC(); \
-FREE(bblocksArrCudaManaged)
-
-// freeMemory<pplFunc_t>(bblocksArrCudaManaged);
-
-// allocateMemory<pplFunc_t>(&bblocksArrCudaManaged, numBblocks); \
+    res = runSMC(firstBblock, numParticles, ompThreads, particlesPerThread, sizeof(progStateTypeTopLevel_t), callback); \
+finishFilesSMC();
 
 /*** Nested SMC, not as thoroughly developed as top-level SMC ***/
 


### PR DESCRIPTION
- Particles program counters `pcs` are replaced with direct `next` bblock pointers.
- Optimized log weight sum and ESS calculations, they contained some redundant operations. The CPU version of ESS also had a non-parallel sum which is now parallel. 
- Most of nested smc code is removed or commented out as it has become obsolete and is not used. 

As a consequence of replacing `PC` with `NEXT`, the structure of models is slightly changed:

- `ADD_BBLOCK` is no longer needed
- `FIRST_BBLOCK` should be specified for the first bblock and `ADD_BBLOCK` is no longer required. 
- `INIT_MODEL` does no longer have the argument NUM_BBLOCKS, only `progState_t` (or no arguments in case of `INIT_MODEL_STACK`)
- `PC` macro is replaced with `NEXT` and holds a function pointer. 

`NEXT` can be used like this (example from the `crbd` example model where `simTree` is a `BBLOCK`):
```
NEXT = simTree;
BBLOCK_CALL(NEXT, NULL);
```

Everything is tested on the CRBD example model for both CPU sequential, CPU OMP, and GPU. Inference yields the same log Z. Brief execution time tests were done before and after these changes with 200,000 particles. On GPU I saw no significant difference. With OMP I observed a 5-10% reduction in execution time. This could of course differ for other models and the number of particles. 