### PR TITLE
CorePPL compiler update after #59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,16 @@ test:
 	@$(MAKE) -s -f test.mk all
 
 install:
-	@cp -f shell/* ~/.local/bin/.
+	@cp -f shell/midppl ~/.local/bin/.
 	@mkdir -p ~/.local/lib/midppl/coreppl
 	@cp -f coreppl/* ~/.local/lib/midppl/coreppl/.
 	@mkdir -p ~/.local/lib/midppl/rootppl
 	@cp -f rootppl/*.mc ~/.local/lib/midppl/rootppl/.
+
+uninstall:
+	@rm -rf ~/.local/bin/midppl
+	@rm -rf ~/.local/lib/midppl
+
 clean:
 	@rm -f coreppl/*~
 

--- a/coreppl/dist.mc
+++ b/coreppl/dist.mc
@@ -869,9 +869,9 @@ lang BinomialDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + SeqTypeAst + Bo
     let err = lam. infoErrorExit info "Type error Binomial" in
     match ty t.n with TyInt _ then
       match ty t.p with TyFloat _ then
-        TySeq { ty = TyBool { info = info }, info = info }
-      else err ()
-    else err ()
+        TyInt { info = info }
+      else dprint t.p; err ()
+    else dprint t.n; err ()
 
   -- ANF
   sem isValueDist =

--- a/coreppl/dist.mc
+++ b/coreppl/dist.mc
@@ -1227,7 +1227,7 @@ utest ty (typeAnnot tmExponential) with tydist_ tyfloat_ using eqTypeEmptyEnv in
 utest ty (typeAnnot tmEmpirical) with tydist_ tyfloat_ using eqTypeEmptyEnv in
 utest ty (typeAnnot tmDirichlet) with tydist_ (tyseq_ tyfloat_) using eqTypeEmptyEnv in
 utest ty (typeAnnot tmGaussian) with tydist_ tyfloat_ using eqTypeEmptyEnv in
-utest ty (typeAnnot tmBinomial) with tydist_ (tyseq_ tybool_) using eqTypeEmptyEnv in
+utest ty (typeAnnot tmBinomial) with tydist_ tyint_ using eqTypeEmptyEnv in
 
 ---------------
 -- ANF TESTS --

--- a/rootppl/Makefile
+++ b/rootppl/Makefile
@@ -72,6 +72,10 @@ install:
 	cp -rf . $(lib_path)/
 	rm -f $(lib_path)/.gitignore $(lib_path)/rootppl
 
+uninstall:
+	rm -rf $(bin_path)/$(rootppl_name)
+	rm -rf $(lib_path)
+
 clean:
 	rm -f out/*.o
 

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -135,7 +135,7 @@ let _debugPrint: [CTop] -> [CTop] -> [CStmt] -> [CStmt] -> String =
 
 -- Compiler names
 let nameRetAddr = nameSym "ra"
-let nameRetLoc = nameSym "retLoc"
+let nameRetValLoc = nameSym "retValLoc"
 let nameInit = nameSym "init"
 let nameSF = nameSym "sf"
 let nameGlobal = nameSym "global"
@@ -821,7 +821,7 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
         let args = zipWith f sf.params args in
         let ret =
           match ret with Some expr then
-            [f nameRetLoc
+            [f nameRetValLoc
                (toRelAddr (CEUnOp { op = COAddrOf {}, arg = expr })
                   (CTyPtr { ty = sf.ret }))]
           else []
@@ -928,7 +928,7 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
               op = COAssign {},
               lhs =
                 let expr =
-                  CEArrow { lhs = CEVar { id = nameSF }, id = nameRetLoc } in
+                  CEArrow { lhs = CEVar { id = nameSF }, id = nameRetValLoc } in
                 derefExpr (toAbsAddr expr (CTyPtr { ty = sf.ret })),
               rhs = val
             }}
@@ -1229,7 +1229,7 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
           mem = Some (join [
             [(CTyInt {}, Some nameRetAddr)],
             match sf.ret with ! CTyVoid _ then
-              [(CTyPtr { ty = sf.ret }, Some nameRetLoc)]
+              [(CTyPtr { ty = sf.ret }, Some nameRetValLoc)]
             else [],
             mem
           ])


### PR DESCRIPTION
- Update CorePPL compiler after RootPPL changes in #59
- Add `uninstall` make targets for `midppl` and `rootppl`
- Rename `retLoc` -> `retValLoc`
- Fix type of Binomial distribution `[Bool]` -> `Int`