### PR TITLE
Change to fast binomial distribution implementation and remove old bbIdx

### DIFF
--- a/rootppl/macros/macros.cuh
+++ b/rootppl/macros/macros.cuh
@@ -123,7 +123,6 @@ body
 #define MAIN(body) \
 int main(int argc, char** argv) { \
     initGen(); \
-    int bbIdx = 0; \
     double res = 0; \
     body \
     freeGen(); \


### PR DESCRIPTION
- Changes the implementation of the binomial distribution in RootPPL from the naive Bernoulli loop to the same algorithm that WebPPL uses. It is implementing Lemma 6.1 from Ahrens & Dieter's article "Computer Methods for Sampling from Gamma, Beta, Poisson and Binomial Distributions". 

- Removes `bbIdx` that is no longer used.