### PR TITLE
Updated work on the importance sampling + fixed compilation error

### DIFF
--- a/coreppl/dppl-parser.mc
+++ b/coreppl/dppl-parser.mc
@@ -79,9 +79,13 @@ let keywords =
 let getAst = lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
-  makeKeywords [] (parseMCoreFile keywords filename)
+  let config = {keepUtests = false, pruneExternalUtests = false,
+                externalsExclude = [], keywords = keywords} in
+  makeKeywords [] (parseMCoreFile config filename)
 
 -- Similar to getAst, but calls parseMExprString instead
 let parseMExprPPLString = lam cpplstr.
   use DPPLParser in
   makeKeywords [] (parseMExprString keywords cpplstr)
+
+

--- a/coreppl/dppl-parser.mc
+++ b/coreppl/dppl-parser.mc
@@ -79,8 +79,9 @@ let keywords =
 let getAst = lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
-  let config = {keepUtests = false, pruneExternalUtests = false,
-                externalsExclude = [], keywords = keywords} in
+  let config = {{defaultBootParserParseMCoreFileArg
+                 with keepUtests = false}
+                 with keywords = keywords} in
   makeKeywords [] (parseMCoreFile config filename)
 
 -- Similar to getAst, but calls parseMExprString instead

--- a/coreppl/external-dists.mc
+++ b/coreppl/external-dists.mc
@@ -31,7 +31,9 @@ let externalNames =[
 lang MExprExternalDists = MExprAst
    sem addExternalDists =
   | e ->
-      let f = lam acc. lam n. TmExt {ident = n, tyIdent = tyunknown_,
-                       effect = true, ty = tyunknown_, inexpr = acc, info = NoInfo ()} in
+      let f = lam acc. lam n.
+          TmExt {ident = n, tyIdent = tyunknown_,
+                 effect = true, ty = tyunknown_,
+                 inexpr = acc, info = NoInfo ()} in
       foldl f e externalNames
 end

--- a/coreppl/external-dists.mc
+++ b/coreppl/external-dists.mc
@@ -38,9 +38,3 @@ lang MExprExternalDists = MExprAst
                  inexpr = acc, info = NoInfo ()} in
       foldl f e externalNames
 end
-
-let symlet_ = use MExprAst in
-  lam sym_x. lam body. lam rest. bind_ (nulet_ sym_x body) rest
-
-let strlet_ = use MExprAst in
-  lam str_x. lam body. lam rest. bind_ (let_ str_x body) rest

--- a/coreppl/external-dists.mc
+++ b/coreppl/external-dists.mc
@@ -1,0 +1,37 @@
+
+include "ocaml/mcore.mc"
+include "seq.mc"
+
+let logName = nameSym "externalLog"
+let expName = nameSym "externalExp"
+let log_ = lam x. app_ (nvar_ logName) x
+let exp_ = lam x. app_ (nvar_ expName) x
+
+let binomialSampleName = nameSym "externalBinomialSample"
+let binomialLogPdfName = nameSym "externalBinomialLogPmf"
+let binomialSample_ = lam p. lam n. app_ (app_ (nvar_ binomialSampleName) p) n
+let bernoulliSample_ = lam p. app_ (app_ (nvar_ binomialSampleName) p) (int_ 1)
+let bernoulliPmf_ = lam p. lam x. if_ x p (subf_ (float_ 1.) p)
+let bernoulliLogPmf_ = lam p. lam x. log_ (bernoulliPmf_ p x)
+
+let betaSampleName = nameSym "externalBetaSample"
+let betaLogPdfName = nameSym "externalBetaLogPdf"
+let betaSample_ = lam a. lam b. app_ (app_ (nvar_ betaSampleName) a) b
+let betaLogPdf_ = lam a. lam b. lam x. app_ (app_ (app_ (nvar_ betaLogPdfName) x) a) b
+
+let externalNames =[
+  logName,
+  expName,
+  binomialSampleName,
+  binomialLogPdfName,
+  betaSampleName,
+  betaLogPdfName
+]
+
+lang MExprExternalDists = MExprAst
+   sem addExternalDists =
+  | e ->
+      let f = lam acc. lam n. TmExt {ident = n, tyIdent = tyunknown_,
+                       effect = true, ty = tyunknown_, inexpr = acc, info = NoInfo ()} in
+      foldl f e externalNames
+end

--- a/coreppl/external-dists.mc
+++ b/coreppl/external-dists.mc
@@ -28,6 +28,7 @@ let externalNames =[
   betaLogPdfName
 ]
 
+
 lang MExprExternalDists = MExprAst
    sem addExternalDists =
   | e ->
@@ -37,3 +38,9 @@ lang MExprExternalDists = MExprAst
                  inexpr = acc, info = NoInfo ()} in
       foldl f e externalNames
 end
+
+let symlet_ = use MExprAst in
+  lam sym_x. lam body. lam rest. bind_ (nulet_ sym_x body) rest
+
+let strlet_ = use MExprAst in
+  lam str_x. lam body. lam rest. bind_ (let_ str_x body) rest

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -6,18 +6,22 @@ include "dppl-arg.mc"
 
 lang MExprPPLImportance = MExprPPL
 
-  sem transformImpSeq =
-  | TmAssume {dist = d} -> sampleDistExpr d
-  | TmObserve {dist = d, value = v} -> logPdfDistExpr v d
-  | expr -> smap_Expr_Expr transformImpSeq expr
+  sem transformImpSeq (stateName:Name) =
+  | TmAssume {dist = d} -> sampleDistExpr stateName d
+  | TmObserve {dist = d, value = v} -> logPdfDistExpr v stateName d
+  | expr -> smap_Expr_Expr (transformImpSeq stateName) expr
 
-  sem sampleDistExpr =
+  sem sampleDistExpr (stateName:Name) =
   | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (var_ "betaSample") a) b)
   | TmDist { dist = DBernoulli {p = p}} -> (app_ (var_ "bernoulliSample") p)
 
-  sem logPdfDistExpr (x:Expr) =
+  sem logPdfDistExpr (x:Expr) (stateName:Name) =
   | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (app_ (var_ "betaLogPdf") a) b) x)
   | TmDist { dist = DBernoulli {p = p}} -> (app_ (app_ (var_ "bernoulliLogPmf") p) x)
+
+  sem addState =
+  | e -> let stateName = nameSym "accWeight" in
+         {name = stateName, expr = bind_ (nulet_ stateName (ref_ (float_ 0.))) e}
 
 end
 
@@ -25,7 +29,9 @@ end
 
 let importanceSamplingInference = lam options: Options. lam ast.
   use MExprPPLImportance in
-  let ast = symbolize (transformImpSeq ast) in
+  let res = addState ast in
+  let ast = transformImpSeq res.name res.expr in
+  let ast = symbolize ast in
   -- Print (optional) the transformed MCore program
   (if options.printMCore then
     printLn (expr2str ast)

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -4,6 +4,10 @@ include "seq.mc"
 include "coreppl.mc"
 include "dppl-arg.mc"
 
+--let binomialSample = lam p:Float. lam n:Int. externalBinomialSample p n
+
+let myName = nameSym "externalBetaSample"
+
 lang MExprPPLImportance = MExprPPL
 
   sem transformImpSeq (stateName:Name) =
@@ -12,7 +16,8 @@ lang MExprPPLImportance = MExprPPL
   | expr -> smap_Expr_Expr (transformImpSeq stateName) expr
 
   sem sampleDistExpr (stateName:Name) =
-  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (var_ "betaSample") a) b)
+  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (nvar_ myName) a) b)
+--  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (var_ "betaSample") a) b)
   | TmDist { dist = DBernoulli {p = p}} -> (app_ (var_ "bernoulliSample") p)
 
   sem logPdfDistExpr (x:Expr) (stateName:Name) =
@@ -21,8 +26,11 @@ lang MExprPPLImportance = MExprPPL
 
   sem addState =
   | e -> let stateName = nameSym "accWeight" in
-         {name = stateName, expr = bind_ (nulet_ stateName (ref_ (float_ 0.))) e}
-
+      let e_in = bind_ (nulet_ stateName (ref_ (float_ 0.))) e in
+      let e2 = TmExt {ident = myName, tyIdent = tyunknown_, effect = true, ty = tyunknown_,
+         inexpr = e_in, info = NoInfo ()} in
+      {name = stateName, expr = e2}
+--         {name = stateName, expr = bind_ (nulet_ stateName (ref_ (float_ 0.))) e}
 end
 
 

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -3,31 +3,45 @@ include "ocaml/mcore.mc"
 include "seq.mc"
 include "coreppl.mc"
 include "dppl-arg.mc"
+include "mexpr/ast-builder.mc"
 include "external-dists.mc"
+
+let symlet_ = use MExprAst in
+  lam sym_x. lam body. lam rest. bind_ (nulet_ sym_x body) rest
+
+let strlet_ = use MExprAst in
+  lam str_x. lam body. lam rest. bind_ (let_ str_x body) rest
+
+
 
 lang MExprPPLImportance = MExprPPL + MExprExternalDists
 
-  sem transformImpSeq (stateName:Name) =
-  | TmAssume {dist = d} -> sampleDistExpr stateName d
-  | TmObserve {dist = d, value = v} -> logPdfDistExpr v stateName d
-  | expr -> smap_Expr_Expr (transformImpSeq stateName) expr
+  sem transformImpSeq (accWeight:Name) =
+  | TmAssume {dist = d} -> sampleDistExpr accWeight d
+  | TmObserve {dist = d, value = v} ->
+--     (modref_ accWeight (logPdfDistExpr v accWeight d))
+     strlet_ "bla" (modref_ accWeight (logPdfDistExpr v accWeight d)) (float_ 0.)
+     --modref_ accWeight (logPdfDistExpr v accWeight d)
+     --(logPdfDistExpr v accWeight d)
+  | expr -> smap_Expr_Expr (transformImpSeq accWeight) expr
 
-  sem sampleDistExpr (stateName:Name) =
+  sem sampleDistExpr (accWeight:Name) =
   | TmDist { dist = DBeta {a = a, b = b}} -> betaSample_ a b
   | TmDist { dist = DBernoulli {p = p}} -> bernoulliSample_ p
 
-  sem logPdfDistExpr (x:Expr) (stateName:Name) =
+  sem logPdfDistExpr (x:Expr) (accWeight:Name) =
   | TmDist { dist = DBeta {a = a, b = b}} -> betaLogPdf_ a b x
   | TmDist { dist = DBernoulli {p = p}} -> bernoulliLogPmf_ p x
 
   sem transform =
   | e ->
       -- Create a name for the accumulated weight
-      let stateName = nameSym "accWeight" in
+      let accWeight = nameSym "accWeight" in
       -- Transform the AST, rewrite with importance sampling
-      let e = transformImpSeq stateName e in
+      let e = transformImpSeq accWeight e in
       -- Add the state on top
-      let e = bind_ (nulet_ stateName (ref_ (float_ 0.))) e in
+--      let e = bind_ (nulet_ accWeight (ref_ (float_ 0.))) e in
+      let e = symlet_ accWeight (ref_ (float_ 0.)) e in
       -- Add imports of external distributions
       addExternalDists e
 end
@@ -36,10 +50,11 @@ end
 
 let importanceSamplingInference = lam options: Options. lam ast.
   use MExprPPLImportance in
-  let ast = symbolize (transform ast) in
+  let ast =  (transform ast) in
   -- Print (optional) the transformed MCore program
   if options.printMCore then
-    printLn (expr2str ast)
+    printLn (expr2str ast);
+    exit 0
   -- Execute the inference
   else
     let res = compileRunMCore "" [] ast in

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -20,9 +20,9 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
   | TmAssume {dist = d} -> sampleDistExpr accWeight d
   | TmObserve {dist = d, value = v} ->
 --     (modref_ accWeight (logPdfDistExpr v accWeight d))
-     strlet_ "bla" (modref_ accWeight (logPdfDistExpr v accWeight d)) (float_ 0.)
+-- strlet_ "bla" (modref_ accWeight (logPdfDistExpr v accWeight d)) (float_ 0.)
      --modref_ accWeight (logPdfDistExpr v accWeight d)
-     --(logPdfDistExpr v accWeight d)
+     (logPdfDistExpr v accWeight d)
   | expr -> smap_Expr_Expr (transformImpSeq accWeight) expr
 
   sem sampleDistExpr (accWeight:Name) =
@@ -59,3 +59,14 @@ let importanceSamplingInference = lam options: Options. lam ast.
   else
     let res = compileRunMCore "" [] ast in
     print res.stdout
+
+mexpr
+
+utest
+  use MExprPPLImportance in
+  let x = transform (int_ 888) in
+  print (expr2str x);
+  int_ 0
+with int_ 0 in
+
+()

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -3,27 +3,7 @@ include "ocaml/mcore.mc"
 include "seq.mc"
 include "coreppl.mc"
 include "dppl-arg.mc"
-
-let betaSampleName = nameSym "externalBetaSample"
-let betaSample = lam a. lam b. app_ (app_ (nvar_ betaSampleName) a) b
-
-let binomialSampleName = nameSym "externalBinomialSample"
-let binomialSample = lam p. lam b. app_ (app_ (nvar_ binomialSampleName) p) b
-let bernoulliSample = lam p. app_ (app_ (nvar_ binomialSampleName) p) (int_ 1)
-
-
-let externalNames =[
-  betaSampleName,
-  binomialSampleName
-]
-
-lang MExprExternalDists = MExprAst
-   sem addExternalDists =
-  | e ->
-      let f = lam acc. lam n. TmExt {ident = n, tyIdent = tyunknown_,
-                       effect = true, ty = tyunknown_, inexpr = acc, info = NoInfo ()} in
-      foldl f e externalNames
-end
+include "external-dists.mc"
 
 lang MExprPPLImportance = MExprPPL + MExprExternalDists
 
@@ -33,13 +13,12 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
   | expr -> smap_Expr_Expr (transformImpSeq stateName) expr
 
   sem sampleDistExpr (stateName:Name) =
-  | TmDist { dist = DBeta {a = a, b = b}} -> betaSample a b
-  | TmDist { dist = DBernoulli {p = p}} -> bernoulliSample p
---  | TmDist { dist = DBernoulli {p = p}} -> (app_ (var_ "bernoulliSample") p)
+  | TmDist { dist = DBeta {a = a, b = b}} -> betaSample_ a b
+  | TmDist { dist = DBernoulli {p = p}} -> bernoulliSample_ p
 
   sem logPdfDistExpr (x:Expr) (stateName:Name) =
-  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (app_ (var_ "betaLogPdf") a) b) x)
-  | TmDist { dist = DBernoulli {p = p}} -> (app_ (app_ (var_ "bernoulliLogPmf") p) x)
+  | TmDist { dist = DBeta {a = a, b = b}} -> betaLogPdf_ a b x
+  | TmDist { dist = DBernoulli {p = p}} -> bernoulliLogPmf_ p x
 
   sem transform =
   | e ->
@@ -51,19 +30,13 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
       let e = bind_ (nulet_ stateName (ref_ (float_ 0.))) e in
       -- Add imports of external distributions
       addExternalDists e
---      let e2 = TmExt {ident = betaSampleName, tyIdent = tyunknown_, effect = true, ty = tyunknown_,
---         inexpr = e_in, info = NoInfo ()} in
---       let e2 = e_in in
---      {name = stateName, expr = e2}
---         {name = stateName, expr = bind_ (nulet_ stateName (ref_ (float_ 0.))) e}
 end
 
 
 
 let importanceSamplingInference = lam options: Options. lam ast.
   use MExprPPLImportance in
-  let ast = transform ast in
-  let ast = symbolize ast in
+  let ast = symbolize (transform ast) in
   -- Print (optional) the transformed MCore program
   if options.printMCore then
     printLn (expr2str ast)

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -6,9 +6,20 @@ include "dppl-arg.mc"
 
 --let binomialSample = lam p:Float. lam n:Int. externalBinomialSample p n
 
-let myName = nameSym "externalBetaSample"
+let betaSampleName = nameSym "externalBetaSample"
+let betaSample = lam a. lam b. app_ (app_ (nvar_ betaSampleName) a) b
 
-lang MExprPPLImportance = MExprPPL
+let externalNames = [betaSampleName]
+
+lang MExprExternalDists = MExprAst
+   sem addExternalDists =
+  | e ->
+      let f = lam a. lam n. TmExt {ident = n, tyIdent = tyunknown_,
+                     effect = true, ty = tyunknown_, inexpr = e, info = NoInfo ()} in
+      foldl f e externalNames
+end
+
+lang MExprPPLImportance = MExprPPL + MExprExternalDists
 
   sem transformImpSeq (stateName:Name) =
   | TmAssume {dist = d} -> sampleDistExpr stateName d
@@ -16,20 +27,27 @@ lang MExprPPLImportance = MExprPPL
   | expr -> smap_Expr_Expr (transformImpSeq stateName) expr
 
   sem sampleDistExpr (stateName:Name) =
-  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (nvar_ myName) a) b)
---  | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (var_ "betaSample") a) b)
+  | TmDist { dist = DBeta {a = a, b = b}} -> betaSample a b
   | TmDist { dist = DBernoulli {p = p}} -> (app_ (var_ "bernoulliSample") p)
 
   sem logPdfDistExpr (x:Expr) (stateName:Name) =
   | TmDist { dist = DBeta {a = a, b = b}} -> (app_ (app_ (app_ (var_ "betaLogPdf") a) b) x)
   | TmDist { dist = DBernoulli {p = p}} -> (app_ (app_ (var_ "bernoulliLogPmf") p) x)
 
-  sem addState =
-  | e -> let stateName = nameSym "accWeight" in
-      let e_in = bind_ (nulet_ stateName (ref_ (float_ 0.))) e in
-      let e2 = TmExt {ident = myName, tyIdent = tyunknown_, effect = true, ty = tyunknown_,
-         inexpr = e_in, info = NoInfo ()} in
-      {name = stateName, expr = e2}
+  sem transform =
+  | e ->
+      -- Create a name for the accumulated weight
+      let stateName = nameSym "accWeight" in
+      -- Transform the AST, rewrite with importance sampling
+      let e = transformImpSeq stateName e in
+      -- Add the state on top
+      let e = bind_ (nulet_ stateName (ref_ (float_ 0.))) e in
+      -- Add imports of external distributions
+      addExternalDists e
+--      let e2 = TmExt {ident = betaSampleName, tyIdent = tyunknown_, effect = true, ty = tyunknown_,
+--         inexpr = e_in, info = NoInfo ()} in
+--       let e2 = e_in in
+--      {name = stateName, expr = e2}
 --         {name = stateName, expr = bind_ (nulet_ stateName (ref_ (float_ 0.))) e}
 end
 
@@ -37,12 +55,12 @@ end
 
 let importanceSamplingInference = lam options: Options. lam ast.
   use MExprPPLImportance in
-  let res = addState ast in
-  let ast = transformImpSeq res.name res.expr in
+  let ast = transform ast in
   let ast = symbolize ast in
   -- Print (optional) the transformed MCore program
-  (if options.printMCore then
+  if options.printMCore then
     printLn (expr2str ast)
-  else ());
-  let res = compileRunMCore "" [] ast in
-  print res.stdout
+  -- Execute the inference
+  else
+    let res = compileRunMCore "" [] ast in
+    print res.stdout

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -10,7 +10,7 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
 
   sem transformImpSeq (accWeight:Name) =
   | TmAssume {dist = d} -> sampleDistExpr accWeight d
-  | TmObserve {dist = d, value = v} ->
+  | TmObserve {dist = d, value = v} ->  -- TODO: update log weight
      modref_ (nvar_ accWeight) (logPdfDistExpr v accWeight d)
   | expr -> smap_Expr_Expr (transformImpSeq accWeight) expr
 
@@ -28,20 +28,18 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
       let accWeight = nameSym "accWeight" in
       -- Transform the AST, rewrite with importance sampling
       let e = transformImpSeq accWeight e in
-      -- Add the state on top
-      let e = bindall_ [nulet_ accWeight (ref_ (float_ 0.)), e] in
-      -- Add imports of external distributions
-      let e = addExternalDists e in
       -- Add printing of accumulated weight and the result (one float)
-      bindall_ [
+      let e = bindall_ [
+         nulet_ accWeight (ref_ (float_ 0.)),
          ulet_ "res" e,
          ulet_ "" (print_ (str_ "Result = ")),
          ulet_ "" (print_ (float2string_ (var_ "res"))),
          ulet_ "" (print_ (str_ "\nAccumulated weight = ")),
---         ulet_ "" (print_ (float2string_ (deref_ (nvar_ accWeight)))),
-         ulet_ "" (print_ (float2string_ (float_ 0.72))),
+         ulet_ "" (print_ (float2string_ (deref_ (nvar_ accWeight)))),
          ulet_ "" (print_ (str_ "\n"))
-      ]
+      ] in
+      -- Add imports of external distributions
+      addExternalDists e
 end
 
 

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -38,7 +38,8 @@ lang MExprPPLImportance = MExprPPL + MExprExternalDists
          ulet_ "" (print_ (str_ "Result = ")),
          ulet_ "" (print_ (float2string_ (var_ "res"))),
          ulet_ "" (print_ (str_ "\nAccumulated weight = ")),
-         ulet_ "" (print_ (float2string_ (float_ 0.88))),
+--         ulet_ "" (print_ (float2string_ (deref_ (nvar_ accWeight)))),
+         ulet_ "" (print_ (float2string_ (float_ 0.72))),
          ulet_ "" (print_ (str_ "\n"))
       ]
 end

--- a/models/test-dists.mc
+++ b/models/test-dists.mc
@@ -2,7 +2,7 @@
 
 include "seq.mc"
 include "string.mc"
-include "dppl.mc"
+--include "dppl.mc"
 
 mexpr
 
@@ -11,7 +11,7 @@ let y = assume (Bernoulli 0.5) in
 
 let obs = true in
 observe obs (Bernoulli x);
-let dummy = observe obs (Bernoulli x) in
+let dummy = observe obs (Bernoulli 0.8) in
 
 print (join ["Beta: ", float2string x, "\n"]);
 print (join ["Bernoulli: ", int2string y, "\n"]);

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -1,11 +1,11 @@
 
-include "dppl.mc"
+--include "dppl.mc"
 include "seq.mc"
 
 mexpr
 
 let x = assume (Beta 10.0 5.0) in
 let obs = true in
-observe obs (Bernoulli x);
+--observe obs (Bernoulli x);
 print (join ["x = ", float2string x, "\n"]);
 [x]

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -3,7 +3,7 @@ include "seq.mc"
 
 mexpr
 
-let x = assume (Beta 10.0 5.0) in
+let x = assume (Beta 10.0 8.0) in
 let obs = true in
 observe obs (Bernoulli x);
 x

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -6,5 +6,4 @@ mexpr
 let x = assume (Beta 10.0 5.0) in
 let obs = true in
 observe obs (Bernoulli x);
-print (join ["x = ", float2string x, "\n"]);
 x

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -6,4 +6,5 @@ mexpr
 let x = assume (Beta 10.0 8.0) in
 let obs = true in
 observe obs (Bernoulli x);
+observe true (Bernoulli x);
 x

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -1,11 +1,14 @@
 
 --include "dppl.mc"
 include "seq.mc"
+include "string.mc"
 
 mexpr
 
 let x = assume (Beta 10.0 5.0) in
+let y = assume (Bernoulli 0.6) in
 let obs = true in
 --observe obs (Bernoulli x);
 print (join ["x = ", float2string x, "\n"]);
+print (join ["y = ", int2string y, "\n"]);
 [x]

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -7,4 +7,5 @@ mexpr
 let x = assume (Beta 10.0 5.0) in
 let obs = true in
 observe obs (Bernoulli x);
-print (join ["x = ", float2string x, "\n"])
+print (join ["x = ", float2string x, "\n"]);
+[x]

--- a/models/test-model.mc
+++ b/models/test-model.mc
@@ -1,14 +1,10 @@
 
---include "dppl.mc"
 include "seq.mc"
-include "string.mc"
 
 mexpr
 
 let x = assume (Beta 10.0 5.0) in
-let y = assume (Bernoulli 0.6) in
 let obs = true in
---observe obs (Bernoulli x);
+observe obs (Bernoulli x);
 print (join ["x = ", float2string x, "\n"]);
-print (join ["y = ", int2string y, "\n"]);
-[x]
+x


### PR DESCRIPTION
This is an intermediate patch for the importance sampling, where externals now are automatically included and do not depend on a model library. This PR also includes a fix of a compilation error because this repo was not in sync with the main Miking repo.