### PR TITLE
Switch to `--output` in tests

### DIFF
--- a/make
+++ b/make
@@ -2,13 +2,13 @@
 
 test () {
   set +e
-  compile_cmd="mi compile --test --disable-optimizations"
+  binary=tmp_test
+  compile_cmd="mi compile --test --disable-optimizations --output $binary"
   output=$1
   output="$output\n$($compile_cmd $1 2>&1)"
   exit_code=$?
   if [ $exit_code -eq 0 ]
   then
-    binary=$(basename "$1" .mc)
     output="$output$(./$binary)"
     exit_code=$?
     if [ $exit_code -eq 0 ]

--- a/make
+++ b/make
@@ -17,9 +17,11 @@ test () {
     else
       echo "ERROR: command ./$binary exited with $exit_code"
       rm $binary
+      exit 1
     fi
   else
     echo "ERROR: command '$compile_cmd $1 2>&1' exited with $exit_code"
+    exit 1
   fi
   echo "$output\n"
   set -e

--- a/test.mk
+++ b/test.mk
@@ -9,9 +9,6 @@ test-files := $(filter-out coreppl/pgm.mc,$(test-files))
 
 all: ${test-files}
 
-# TODO(dlunde,2021-10-25): We are getting lots of name collisions with `mi`, hence the temp dir. Could be solved by having an `-o` flag for `mi`
 ${test-files}::
-	@mkdir test-$(subst /,-,$@)
-	@cd test-$(subst /,-,$@) && ../make test ../$@
-	@rmdir test-$(subst /,-,$@)
+	@./make test $@
 


### PR DESCRIPTION
Replaces the old test hack with using the new `--output` flag in `mi` for running tests.