### PR TITLE
Major alignment analysis update

### DIFF
--- a/coreppl/align.mc
+++ b/coreppl/align.mc
@@ -215,7 +215,7 @@ lang Align = MExprPPLCFA
   -- Type: Expr -> CFAGraph -> Set Name
   -- Returns a list of unaligned names for a program.
   sem alignment (cfaRes: CFAGraph) =
-  | t -> match alignmentDebug (None ()) t with (_,res) in res
+  | t -> match alignmentDebug (None ()) cfaRes t with (_,res) in res
 
   sem alignmentDebug (env: Option PprintEnv) (cfaRes: CFAGraph) =
   | t ->

--- a/coreppl/coreppl.mc
+++ b/coreppl/coreppl.mc
@@ -420,9 +420,22 @@ lang CorePPL =
 
 lang CorePPLInference = CorePPL + SMC -- + Importance
 
+let pplKeywords = [
+  "assume", "observe", "weight", "resample", "plate", "Uniform", "Bernoulli",
+  "Poisson", "Beta", "Gamma", "Categorical", "Multinomial", "Dirichlet",
+  "Exponential", "Empirical", "Gaussian", "Binomial"
+]
+
+let mexprPPLKeywords = concat mexprKeywords pplKeywords
+
 lang MExprPPL =
   CorePPLInference + MExprAst + MExprPrettyPrint + MExprEq + MExprSym +
   MExprTypeAnnot + MExprTypeLiftUnOrderedRecords + MExprArity
+
+  sem mexprPPLToString =
+  | expr -> exprToStringKeywords mexprPPLKeywords expr
+
+end
 
 lang Test = MExprPPL + MExprANF
 
@@ -439,14 +452,14 @@ let tmWeight = weight_ (float_ 1.5) in
 ------------------------
 -- TODO(dlunde,2021-04-28): TmInfer test
 
-utest expr2str tmAssume
+utest mexprPPLToString tmAssume
 with strJoin "\n" [
   "assume",
   "  (Bernoulli",
   "     0.7)"
 ] using eqString in
 
-utest expr2str tmObserve
+utest mexprPPLToString tmObserve
 with strJoin "\n" [
   "observe",
   "  1.5",
@@ -455,7 +468,7 @@ with strJoin "\n" [
   "     2.)"
 ] using eqString in
 
-utest expr2str tmWeight
+utest mexprPPLToString tmWeight
 with strJoin "\n" [
   "weight",
   "  1.5"

--- a/coreppl/dist.mc
+++ b/coreppl/dist.mc
@@ -930,42 +930,42 @@ let tmBinomial = binomial_ (int_ 5) (float_ 0.5) in
 -- PRETTY-PRINT TESTS --
 ------------------------
 
-utest expr2str tmUniform with strJoin "\n" [
+utest mexprToString tmUniform with strJoin "\n" [
   "Uniform",
   "  1.",
   "  2."
 ] using eqString in
 
-utest expr2str tmBernoulli with strJoin "\n" [
+utest mexprToString tmBernoulli with strJoin "\n" [
   "Bernoulli",
   "  0.5"
 ] using eqString in
 
-utest expr2str tmPoisson with strJoin "\n" [
+utest mexprToString tmPoisson with strJoin "\n" [
   "Poisson",
   "  0.5"
 ] using eqString in
 
-utest expr2str tmBeta with strJoin "\n" [
+utest mexprToString tmBeta with strJoin "\n" [
   "Beta",
   "  1.",
   "  2."
 ] using eqString in
 
-utest expr2str tmGamma with strJoin "\n" [
+utest mexprToString tmGamma with strJoin "\n" [
   "Gamma",
   "  1.",
   "  2."
 ] using eqString in
 
-utest expr2str tmCategorical with strJoin "\n" [
+utest mexprToString tmCategorical with strJoin "\n" [
   "Categorical",
   "  [ 0.3,",
   "    0.2,",
   "    0.5 ]"
 ] using eqString in
 
-utest expr2str tmMultinomial with strJoin "\n" [
+utest mexprToString tmMultinomial with strJoin "\n" [
   "Multinomial",
   "  5",
   "  [ 0.3,",
@@ -973,31 +973,31 @@ utest expr2str tmMultinomial with strJoin "\n" [
   "    0.5 ]"
 ] using eqString in
 
-utest expr2str tmExponential with strJoin "\n" [
+utest mexprToString tmExponential with strJoin "\n" [
   "Exponential",
   "  1."
 ] using eqString in
 
-utest expr2str tmEmpirical with strJoin "\n" [
+utest mexprToString tmEmpirical with strJoin "\n" [
   "Empirical",
   "  [ (1., 1.5),",
   "    (3., 1.3) ]"
 ] using eqString in
 
-utest expr2str tmDirichlet with strJoin "\n" [
+utest mexprToString tmDirichlet with strJoin "\n" [
   "Dirichlet",
   "  [ 1.3,",
   "    1.3,",
   "    1.5 ]"
 ] using eqString in
 
-utest expr2str tmGaussian with strJoin "\n" [
+utest mexprToString tmGaussian with strJoin "\n" [
   "Gaussian",
   "  0.",
   "  1."
 ] using eqString in
 
-utest expr2str tmBinomial with strJoin "\n" [
+utest mexprToString tmBinomial with strJoin "\n" [
   "Binomial",
   "  5",
   "  0.5"
@@ -1185,7 +1185,7 @@ utest _anf tmEmpirical with bindall_ [
   ulet_ "t3" (empirical_ (var_ "t2")),
   var_ "t3"
 ] using eqExpr in
--- print (expr2str (_anf tmEmpirical)); print "\n";
+-- print (mexprToString (_anf tmEmpirical)); print "\n";
 utest _anf tmDirichlet with bindall_ [
   ulet_ "t" (seq_ [float_ 1.3, float_ 1.3, float_ 1.5]),
   ulet_ "t1" (dirichlet_ (var_ "t")),

--- a/coreppl/dppl-arg.mc
+++ b/coreppl/dppl-arg.mc
@@ -4,6 +4,7 @@ include "arg.mc"
 type Options = {
   method: String,
   particles : Int,
+  align: Bool,
   printModel: Bool,
   printMCore: Bool,
   exitBefore: Bool,
@@ -14,6 +15,7 @@ type Options = {
 let default = {
   method = "",
   particles = 5000,
+  align = false,
   printModel = false,
   printMCore = false,
   exitBefore = false,
@@ -31,6 +33,10 @@ let config = [
           "of the following methods are used: importance, rootppl-smc."],
     lam p: ArgPart.
       let o: Options = p.options in {o with particles = argToIntMin p 1}),
+  ([("--align", "", "")],
+    "Apply alignment for inference algorithms, when applicable.",
+    lam p: ArgPart.
+      let o: Options = p.options in {o with align = true}),
   ([("--print-model", "", "")],
     "The parsed model is pretty printed before inference.",
     lam p: ArgPart.

--- a/coreppl/dppl-arg.mc
+++ b/coreppl/dppl-arg.mc
@@ -34,7 +34,7 @@ let config = [
     lam p: ArgPart.
       let o: Options = p.options in {o with particles = argToIntMin p 1}),
   ([("--resample", " ", "<method>")],
-    "The selected resample placement method, for inference algorithms where applicable. The supported methods are: weight, align, manual.",
+    "The selected resample placement method, for inference algorithms where applicable. The supported methods are: likelihood (resample immediately after all likelihood updates), align (resample after aligned likelihood updates), and manual (sample only at manually defined resampling locations).",
     lam p: ArgPart.
       let o: Options = p.options in {o with resample = argToString p}),
   ([("--print-model", "", "")],

--- a/coreppl/dppl-arg.mc
+++ b/coreppl/dppl-arg.mc
@@ -34,7 +34,7 @@ let config = [
     lam p: ArgPart.
       let o: Options = p.options in {o with particles = argToIntMin p 1}),
   ([("--resample", " ", "<method>")],
-    "The selected resampling method, for inference algorithms where applicable. The supported methods are: weight, align, manual.",
+    "The selected resample placement method, for inference algorithms where applicable. The supported methods are: weight, align, manual.",
     lam p: ArgPart.
       let o: Options = p.options in {o with resample = argToString p}),
   ([("--print-model", "", "")],

--- a/coreppl/dppl-arg.mc
+++ b/coreppl/dppl-arg.mc
@@ -4,7 +4,7 @@ include "arg.mc"
 type Options = {
   method: String,
   particles : Int,
-  align: Bool,
+  resample: String,
   printModel: Bool,
   printMCore: Bool,
   exitBefore: Bool,
@@ -15,7 +15,7 @@ type Options = {
 let default = {
   method = "",
   particles = 5000,
-  align = false,
+  resample = "manual",
   printModel = false,
   printMCore = false,
   exitBefore = false,
@@ -33,10 +33,10 @@ let config = [
           "of the following methods are used: importance, rootppl-smc."],
     lam p: ArgPart.
       let o: Options = p.options in {o with particles = argToIntMin p 1}),
-  ([("--align", "", "")],
-    "Apply alignment for inference algorithms, when applicable.",
+  ([("--resample", " ", "<method>")],
+    "The selected resampling method, for inference algorithms where applicable. The supported methods are: weight, align, manual.",
     lam p: ArgPart.
-      let o: Options = p.options in {o with align = true}),
+      let o: Options = p.options in {o with resample = argToString p}),
   ([("--print-model", "", "")],
     "The parsed model is pretty printed before inference.",
     lam p: ArgPart.

--- a/coreppl/dppl-parser.mc
+++ b/coreppl/dppl-parser.mc
@@ -6,7 +6,7 @@ include "coreppl.mc"
 include "pgm.mc"
 
 
-lang DPPLParser = BootParser + MExprPrettyPrint + CorePPLInference + ProbabilisticGraphicalModel + KeywordMaker
+lang DPPLParser = BootParser + MExprPrettyPrint + MExprPPL + ProbabilisticGraphicalModel + KeywordMaker
 
   -- Keyword maker
   sem isKeyword =
@@ -71,22 +71,17 @@ lang DPPLParser = BootParser + MExprPrettyPrint + CorePPLInference + Probabilist
                                         info = info})
 end
 
-let keywords =
-["assume", "observe", "weight", "resample", "plate",
- "Uniform", "Bernoulli", "Poisson", "Beta", "Gamma", "Categorical",
- "Multinomial", "Dirichlet", "Exponential", "Empirical", "Gaussian", "Binomial"]
-
 let getAst = lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
   let config = {{defaultBootParserParseMCoreFileArg
                  with keepUtests = false}
-                 with keywords = keywords} in
+                 with keywords = pplKeywords} in
   makeKeywords [] (parseMCoreFile config filename)
 
 -- Similar to getAst, but calls parseMExprString instead
 let parseMExprPPLString = lam cpplstr.
   use DPPLParser in
-  makeKeywords [] (parseMExprString keywords cpplstr)
+  makeKeywords [] (parseMExprString pplKeywords cpplstr)
 
 

--- a/coreppl/importance.mc
+++ b/coreppl/importance.mc
@@ -49,7 +49,7 @@ let importanceSamplingInference = lam options: Options. lam ast.
   let ast = symbolize (transform ast) in
   -- Print (optional) the transformed MCore program
   if options.printMCore then
-    printLn (expr2str ast);
+    printLn (mexprPPLToString ast);
     exit 0
   -- Execute the inference
   else

--- a/coreppl/inference.mc
+++ b/coreppl/inference.mc
@@ -10,7 +10,7 @@ let performInference = lam options: Options. lam ast.
     importanceSamplingInference options ast
   else match options.method with "rootppl-smc" then
     -- dprint ast
-    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile options.align ast))
+    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile options.resample ast))
     -- print (join ["TODO: perform SMC using RootPPL with ",
     --              int2string options.particles, " particles."])
   else

--- a/coreppl/inference.mc
+++ b/coreppl/inference.mc
@@ -10,7 +10,7 @@ let performInference = lam options: Options. lam ast.
     importanceSamplingInference options ast
   else match options.method with "rootppl-smc" then
     -- dprint ast
-    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile ast))
+    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile options.align ast))
     -- print (join ["TODO: perform SMC using RootPPL with ",
     --              int2string options.particles, " particles."])
   else

--- a/coreppl/main.mc
+++ b/coreppl/main.mc
@@ -35,7 +35,7 @@ match result with ParseOK r then
 
     -- Optionally print the model
     (if options.printModel then
-      use DPPLParser in printLn (expr2str ast)
+      use DPPLParser in printLn (mexprPPLToString ast)
     else ());
 
     -- Exit before inference, it the flag is selected

--- a/coreppl/smc.mc
+++ b/coreppl/smc.mc
@@ -96,13 +96,13 @@ end
 -----------------
 
 let resample_ = use Resample in
-  TmResample { ty = tyunknown_, info = NoInfo () }
+  TmResample { ty = tyunit_, info = NoInfo () }
 
 lang SMC = Resample
 
 lang Test =
   Resample + MExprEq + MExprSym + MExprTypeAnnot + MExprANF
-  + MExprTypeLiftUnOrderedRecords
+  + MExprTypeLiftUnOrderedRecords + MExprPrettyPrint
 
 mexpr
 
@@ -113,7 +113,7 @@ use Test in
 -- PRETTY-PRINT TESTS --
 ------------------------
 
-utest expr2str resample_
+utest mexprToString resample_
 with strJoin "\n" [
   "resample"
 ] using eqString in

--- a/make
+++ b/make
@@ -2,20 +2,20 @@
 
 test () {
   set +e
-  binary=tmp_test
+  binary=$(mktemp)
   compile_cmd="mi compile --test --disable-optimizations --output $binary"
   output=$1
   output="$output\n$($compile_cmd $1 2>&1)"
   exit_code=$?
   if [ $exit_code -eq 0 ]
   then
-    output="$output$(./$binary)"
+    output="$output$($binary)"
     exit_code=$?
     if [ $exit_code -eq 0 ]
     then
       rm $binary
     else
-      echo "ERROR: command ./$binary exited with $exit_code"
+      echo "ERROR: compiled binary for $1 exited with $exit_code"
       rm $binary
       exit 1
     fi

--- a/models/crbd/crbd-unaligned.mc
+++ b/models/crbd/crbd-unaligned.mc
@@ -1,0 +1,119 @@
+------------------------------------------------
+-- The Constant-Rate Birth-Death (CRBD) model --
+------------------------------------------------
+
+-- The prelude includes a few PPL helper functions
+include "pplprelude.mc"
+
+-- The tree.mc file defines the general tree structure
+include "tree.mc"
+
+-- The tree-instance.mc file includes the actual tree and the rho constant
+include "tree-instance.mc"
+
+mexpr
+
+-- CRBD goes undetected, including iterations. Mutually recursive functions.
+recursive
+  let iter: Int -> Float -> Float -> Float -> Float -> Float -> Bool =
+    lam n: Int.
+    lam startTime: Float.
+    lam branchLength: Float.
+    lam lambda: Float.
+    lam mu: Float.
+    lam rho: Float.
+      if eqi n 0 then
+        true
+      else
+        let eventTime = assume (Uniform (subf startTime branchLength) startTime) in
+        if crbdGoesUndetected eventTime lambda mu rho then
+          iter (subi n 1) startTime branchLength lambda mu rho
+        else
+          false
+
+  let crbdGoesUndetected: Float -> Float -> Float -> Float -> Bool =
+    lam startTime: Float.
+    lam lambda: Float.
+    lam mu: Float.
+    lam rho: Float.
+      let duration = assume (Exponential mu) in
+      let cond =
+        -- `and` does not use short-circuiting: using `if` as below is more
+        -- efficient
+        if (gtf duration startTime) then
+          (eqBool (assume (Bernoulli rho)) true)
+        else false
+      in
+      if cond then
+        false
+      else
+        let branchLength = if ltf duration startTime then duration else startTime in
+        let n = assume (Poisson (mulf lambda branchLength)) in
+        iter n startTime branchLength lambda mu rho
+in
+
+-- Simulation of branch
+recursive
+let simBranch: Int -> Float -> Float -> Float -> Float -> Float -> Float =
+  lam n: Int.
+  lam startTime: Float.
+  lam stopTime: Float.
+  lam lambda: Float.
+  lam mu: Float.
+  lam rho: Float.
+    if eqi n 0 then 0.
+    else
+      let currentTime = assume (Uniform stopTime startTime) in
+      if crbdGoesUndetected currentTime lambda mu rho then
+        let w1 = weight (log 2.) in
+        simBranch (subi n 1) startTime stopTime lambda mu rho
+      else
+        let w2 = weight (negf inf) in
+        w2
+in
+
+-- Simulating along the tree structure
+recursive
+let simTree: Tree -> Tree -> Float -> Float -> Float -> () =
+  lam tree: Tree.
+  lam parent: Tree.
+  lam lambda: Float.
+  lam mu: Float.
+  lam rho: Float.
+    let lnProb1 = mulf (negf mu) (subf (getAge parent) (getAge tree)) in
+    let lnProb2 = match tree with Node _ then log lambda else log rho in
+
+    let startTime = getAge parent in
+    let stopTime = getAge tree in
+    let n = assume (Poisson (mulf lambda (subf startTime stopTime))) in
+    let lnProb3 = simBranch n startTime stopTime lambda mu rho in
+
+    let w3 = weight (addf lnProb1 lnProb2) in
+    -- resample;
+
+    match tree with Node { left = left, right = right } then
+      simTree left tree lambda mu rho;
+      simTree right tree lambda mu rho
+    else ()
+in
+
+-- Priors
+let lambda = assume (Gamma 1.0 1.0) in
+let mu = assume (Gamma 1.0 0.5) in
+
+-- Adjust for normalizing constant
+let numLeaves = countLeaves tree in
+let corrFactor =
+  subf (mulf (subf (int2float numLeaves) 1.) (log 2.)) (lnFactorial numLeaves) in
+weight corrFactor;
+resample;
+
+-- Start of the simulation along the two branches
+(match tree with Node { left = left, right = right } then
+  simTree left tree lambda mu rho;
+  simTree right tree lambda mu rho
+else ());
+
+lambda
+
+-- Returns the posterior for the lambda

--- a/models/crbd/crbd-unaligned.mc
+++ b/models/crbd/crbd-unaligned.mc
@@ -54,14 +54,14 @@ in
 
 -- Simulation of branch
 recursive
-let simBranch: Int -> Float -> Float -> Float -> Float -> Float -> Float =
+let simBranch: Int -> Float -> Float -> Float -> Float -> Float -> () =
   lam n: Int.
   lam startTime: Float.
   lam stopTime: Float.
   lam lambda: Float.
   lam mu: Float.
   lam rho: Float.
-    if eqi n 0 then 0.
+    if eqi n 0 then ()
     else
       let currentTime = assume (Uniform stopTime startTime) in
       if crbdGoesUndetected currentTime lambda mu rho then
@@ -69,7 +69,7 @@ let simBranch: Int -> Float -> Float -> Float -> Float -> Float -> Float =
         simBranch (subi n 1) startTime stopTime lambda mu rho
       else
         let w2 = weight (negf inf) in
-        w2
+        ()
 in
 
 -- Simulating along the tree structure
@@ -86,7 +86,7 @@ let simTree: Tree -> Tree -> Float -> Float -> Float -> () =
     let startTime = getAge parent in
     let stopTime = getAge tree in
     let n = assume (Poisson (mulf lambda (subf startTime stopTime))) in
-    let lnProb3 = simBranch n startTime stopTime lambda mu rho in
+    simBranch n startTime stopTime lambda mu rho;
 
     let w3 = weight (addf lnProb1 lnProb2) in
     -- resample; -- This should be added automatically by alignment analysis

--- a/models/crbd/crbd-unaligned.mc
+++ b/models/crbd/crbd-unaligned.mc
@@ -89,7 +89,7 @@ let simTree: Tree -> Tree -> Float -> Float -> Float -> () =
     let lnProb3 = simBranch n startTime stopTime lambda mu rho in
 
     let w3 = weight (addf lnProb1 lnProb2) in
-    -- resample;
+    -- resample; -- This should be added automatically by alignment analysis
 
     match tree with Node { left = left, right = right } then
       simTree left tree lambda mu rho;
@@ -106,7 +106,7 @@ let numLeaves = countLeaves tree in
 let corrFactor =
   subf (mulf (subf (int2float numLeaves) 1.) (log 2.)) (lnFactorial numLeaves) in
 weight corrFactor;
-resample;
+-- resample; -- This should be added automatically by alignment analysis
 
 -- Start of the simulation along the two branches
 (match tree with Node { left = left, right = right } then

--- a/models/crbd/crbd-unaligned.mc
+++ b/models/crbd/crbd-unaligned.mc
@@ -98,6 +98,8 @@ let simTree: Tree -> Tree -> Float -> Float -> Float -> () =
 in
 
 -- Priors
+-- let lambda = 0.125 in
+-- let mu = 0.05 in
 let lambda = assume (Gamma 1.0 1.0) in
 let mu = assume (Gamma 1.0 0.5) in
 

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -1266,6 +1266,7 @@ let rootPPLCompile: String -> Expr -> RPProg =
         let t = smap_Expr_Expr (addResample pred) t in
         match t
         with TmLet ({ ident = ident, body = TmWeight _, inexpr = inexpr } & r)
+           | TmLet ({ ident = ident, body = TmObserve _, inexpr = inexpr } & r)
         then
           if pred ident then
             let resample = withInfo r.info resample_ in
@@ -1276,7 +1277,7 @@ let rootPPLCompile: String -> Expr -> RPProg =
           else t
         else t
     in
-    match      resample with "weight" then addResample (lam. true) prog
+    match      resample with "likelihood" then addResample (lam. true) prog
     else match resample with "manual" then prog
     else match resample with "align"  then
 

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -1244,7 +1244,7 @@ let rootPPLCompile: Bool -> Expr -> RPProg =
 
   use MExprPPLRootPPLCompileANF in
 
-  -- print (expr2str prog); print "\n\n";
+  -- print (mexprPPLToString prog); print "\n\n";
   -- dprint prog; print "\n\n";
 
   -- Symbolize with empty environment
@@ -1253,7 +1253,7 @@ let rootPPLCompile: Bool -> Expr -> RPProg =
   -- Type annotate
   let prog: Expr = typeAnnot prog in
 
-  -- print (expr2str prog); print "\n\n";
+  -- print (mexprPPLToString prog); print "\n\n";
 
   -- ANF transformation
   let prog: Expr = normalizeTerm prog in
@@ -1280,7 +1280,8 @@ let rootPPLCompile: Bool -> Expr -> RPProg =
         then
           if isAligned ident then
             let resample = withInfo r.info resample_ in
-            let l = withInfo r.info (nulet_ (nameNoSym "") resample) in
+            let l = nlet_ (nameSym "resample") tyunit_ resample in
+            let l = withInfo r.info l in
             let inexpr = bind_ l inexpr in
             TmLet { r with inexpr = inexpr }
           else t
@@ -1291,17 +1292,17 @@ let rootPPLCompile: Bool -> Expr -> RPProg =
   in
 
   -- dprint prog; print "\n\n";
-  -- print (expr2str prog); print "\n\n";
+  print (mexprPPLToString prog); print "\n\n";
 
   -- Type lift
   match typeLift prog with (env, prog) in
 
-  -- print (expr2str prog); print "\n\n";
+  -- print (mexprPPLToString prog); print "\n\n";
 
   -- Remove redundant lets
   let prog: Expr = removeRedundantLets prog in
 
-  -- print (expr2str prog); print "\n\n";
+  -- print (mexprPPLToString prog); print "\n\n";
 
   -- Find categories for identifiers
   let ci: Map Name Int = catIdents prog in

--- a/rootppl/rootppl.mc
+++ b/rootppl/rootppl.mc
@@ -21,7 +21,7 @@ let nameProgStateTy = nameSym "progState_t"
 let namePplFuncTy = nameSym "pplFunc_t"
 
 -- NOTE(dlunde,2021-10-08): This list is currently not exhaustive
-let rpKeywords = concat (map nameNoSym [
+let rpKeywords = concat (map nameSym [
   "BBLOCK", "BBLOCK_DECLARE", "BBLOCK_DATA_MANAGED",
   "BBLOCK_DATA_MANAGED_SINGLE", "", "SAMPLE", "WEIGHT", "PSTATE", "NEXT",
   "bernoulli", "beta", "discrete", "multinomial", "dirichlet", "exponential",


### PR DESCRIPTION
- `coreppl/align.mc`
  - Complete revamp of alignment analysis. The alignment analysis is now separate from the stochastic value flow analysis.
  - Refactor tests to produce readable error messages.
  - Add more unit tests for alignment analysis.
- `coreppl/coreppl.mc`
  - Add CorePPL/MExprPPL keyword handling for pretty printing (based on https://github.com/miking-lang/miking/pull/513).
- `rootppl/compile.mc`, `coreppl/main.mc`, `coreppl/dppl-arg.mc`, `coreppl/inference.mc`
  - Add a flag
    ```
     --resample <method>  The selected resample placement method, for inference 
                          algorithms where applicable. The supported methods are: 
                          weight, align, manual.
    ```
    to `midppl`, and apply alignment analysis in CorePPL-to-RootPPL compiler for the `align` option. The `weight` option simply adds `resample` after _every_ `weight`.
- `make test` now creates unique temporary binaries  for each file tested. This avoids a rare error when running tests in parallel.
- Add `models/crbd/crbd-unaligned.mc`.
