### PR TITLE
Fixed compilation error because of missing end keyword

### DIFF
--- a/coreppl/align.mc
+++ b/coreppl/align.mc
@@ -407,6 +407,7 @@ lang Align = MExprPPLCFA
 end
 
 lang Test = Align + MExprANFAll + DPPLParser
+end
 
 -----------
 -- TESTS --

--- a/coreppl/coreppl.mc
+++ b/coreppl/coreppl.mc
@@ -417,8 +417,10 @@ let weight_ = use Weight in
 
 lang CorePPL =
   Ast + Assume + Observe + Weight + ObserveWeightTranslation + DistAll
+end
 
 lang CorePPLInference = CorePPL + SMC -- + Importance
+end
 
 let pplKeywords = [
   "assume", "observe", "weight", "resample", "plate", "Uniform", "Bernoulli",
@@ -434,10 +436,10 @@ lang MExprPPL =
 
   sem mexprPPLToString =
   | expr -> exprToStringKeywords mexprPPLKeywords expr
-
 end
 
 lang Test = MExprPPL + MExprANF
+end
 
 mexpr
 

--- a/coreppl/dist.mc
+++ b/coreppl/dist.mc
@@ -898,10 +898,12 @@ lang DistAll =
   UniformDist + BernoulliDist + PoissonDist + BetaDist + GammaDist +
   CategoricalDist + MultinomialDist + DirichletDist +  ExponentialDist +
   EmpiricalDist + GaussianDist + BinomialDist
+end
 
 lang Test =
   DistAll + MExprAst + MExprPrettyPrint + MExprEq + MExprSym + MExprTypeAnnot
   + MExprANF + MExprTypeLiftUnOrderedRecords
+end
 
 mexpr
 

--- a/coreppl/pgm.mc
+++ b/coreppl/pgm.mc
@@ -126,6 +126,7 @@ let plate_ = use Plate in
   lam f. lam lst. TmPlate {fun=f, lst=lst, ty=tyunknown_, info=NoInfo()}
 
 lang TestLang = ProbabilisticGraphicalModel
+end
 
 mexpr
 

--- a/coreppl/smc.mc
+++ b/coreppl/smc.mc
@@ -99,10 +99,12 @@ let resample_ = use Resample in
   TmResample { ty = tyunit_, info = NoInfo () }
 
 lang SMC = Resample
+end
 
 lang Test =
   Resample + MExprEq + MExprSym + MExprTypeAnnot + MExprANF
   + MExprTypeLiftUnOrderedRecords + MExprPrettyPrint
+end
 
 mexpr
 

--- a/coreppl/transformation.mc
+++ b/coreppl/transformation.mc
@@ -105,6 +105,7 @@ let transform = lam model.
   reconstruct (collect {assumeMap=_emptyEnv, observeAssumeMap=_emptyEnv, env=_emptyEnv} movedModel) movedModel
 
 lang TestLang = Transformation + MExprPPL
+end
 
 mexpr
 

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -105,7 +105,7 @@ lang MExprPPLRootPPLCompileANF = MExprPPLRootPPLCompile + MExprANF
 end
 
 lang MExprPPLRootPPLCompileANFAll = MExprPPLRootPPLCompile + MExprANFAll
-
+end
 
 ----------------------
 -- ROOTPPL COMPILER --
@@ -1331,6 +1331,7 @@ let rootPPLCompile: String -> Expr -> RPProg =
 -- now, they are at least better than nothing
 
 lang Test = MExprPPLRootPPLCompileANF
+end
 
 mexpr
 use Test in


### PR DESCRIPTION
Added missing `end` keywords for `lang` constructs. This change in the main Miking repo was not fixed in Miking DPPL before.
