### PR TITLE
Add sample printouts to CorePPL->RootPPL compiler

### DIFF
--- a/coreppl/align.mc
+++ b/coreppl/align.mc
@@ -156,7 +156,7 @@ lang MExprPPLCFA = MExprCFA + MExprPPL
   | t ->
 
     -- Initial graph
-    let graph = emptyCFAGraph in
+    let graph: CFAGraph = emptyCFAGraph in
 
     -- Initialize match constraint generating functions
     let graph = { graph with mcgfs = [

--- a/coreppl/dppl-arg.mc
+++ b/coreppl/dppl-arg.mc
@@ -8,7 +8,10 @@ type Options = {
   printModel: Bool,
   printMCore: Bool,
   exitBefore: Bool,
-  transform: Bool
+  transform: Bool,
+
+  -- Options for the `rootppl-smc` method. TODO(dlunde,2022-03-24): Should maybe be defined somewhere else eventually?
+  printSamples: Bool
 }
 
 -- Default values for options
@@ -19,7 +22,8 @@ let default = {
   printModel = false,
   printMCore = false,
   exitBefore = false,
-  transform = false
+  transform = false,
+  printSamples = true
 }
 
 -- Options configuration
@@ -52,7 +56,13 @@ let config = [
   ([("--transform", "", "")],
     "The model is transformed to an efficient representation if possible.",
     lam p: ArgPart.
-      let o: Options = p.options in {o with transform = true})
+      let o: Options = p.options in {o with transform = true}),
+
+  -- Options for method `rootppl-smc`
+  ([("--no-print-samples", "", "")],
+    "Do not print the final samples when compiling with the rootppl-smc method.",
+    lam p: ArgPart.
+      let o: Options = p.options in {o with printSamples = false})
 ]
 
 -- Menu

--- a/coreppl/inference.mc
+++ b/coreppl/inference.mc
@@ -10,7 +10,7 @@ let performInference = lam options: Options. lam ast.
     importanceSamplingInference options ast
   else match options.method with "rootppl-smc" then
     -- dprint ast
-    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile options.resample ast))
+    writeFile "out.cu" (printCompiledRPProg (rootPPLCompile options ast))
     -- print (join ["TODO: perform SMC using RootPPL with ",
     --              int2string options.particles, " particles."])
   else

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -403,6 +403,7 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
 
     match res with (tops, detFunMap) in
 
+    -- print (_debugPrint types tops detInits stochInits);
 
     ----------------------------
     -- DETERMINE STACK FRAMES --
@@ -602,6 +603,8 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
     ) tops in
     let stochInits: [CStmt] =
       join (map (replaceDefs stochInitSF.mem) stochInits) in
+
+    -- print (_debugPrint types tops detInits stochInits);
 
     -----------------------------------
     -- TRANSLATE LOCAL VARIABLE USES --
@@ -946,7 +949,10 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
               let stmt =
                 CSIf { cond = cond, thn = accThn.block, els = accEls.block }
               in
-              splitStmts {acc with block = snoc acc.block stmt} sf stmts
+              match stmts with [] then
+                {acc with block = snoc acc.block stmt}
+              else
+                splitStmts {acc with block = snoc acc.block stmt} sf stmts
 
             -- At least one split in branches
             else
@@ -1042,6 +1048,8 @@ let rootPPLCompileH: [(Name,Type)] -> [Name] -> Expr -> RPProg =
     let tops = match splitFunctions accSplit tops with { tops = tops }
                in tops in
     let tops = concat tops (splitInit accSplit stochInitSF stochInits) in
+
+    -- print (_debugPrint types tops detInits stochInits);
 
     ------------------------------------
     -- TRANSLATE GLOBAL VARIABLE REFS --

--- a/rootppl/compile.mc
+++ b/rootppl/compile.mc
@@ -1396,9 +1396,9 @@ end
 mexpr
 use Test in
 
-let test = lam cpplstr.
+let test = lam options. lam cpplstr.
   let cppl = parseMExprPPLString cpplstr in
-  let rppl = rootPPLCompile default "manual" cppl in
+  let rppl = rootPPLCompile options cppl in
   printCompiledRPProg rppl
 in
 
@@ -1408,12 +1408,13 @@ observe true (Bernoulli x);
 x
 ------------------------" in
 
-utest test simple with strJoin "\n" [
+utest test default simple with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
   "#include <math.h>",
   "#include \"inference/smc/smc.cuh\"",
   "#include <stdint.h>",
+  "#include <stdio.h>",
   "INIT_MODEL_STACK()",
   "struct GLOBAL {double ret; double x;};",
   "struct STACK_init {pplFunc_t ra; double (*retValLoc);};",
@@ -1441,9 +1442,17 @@ utest test simple with strJoin "\n" [
   "  ((PSTATE.stackPtr) = ((PSTATE.stackPtr) - (sizeof(struct STACK_init))));",
   "  BBLOCK_JUMP((sf->ra), NULL);",
   "})",
+  "CALLBACK(callback, {",
+  "  int i = 0;",
+  "  while ((i < N)) {",
+  "    struct GLOBAL (*global) = (( struct GLOBAL (*) ) ((PSTATES[i]).stack));",
+  "    printf(\"%f %f\\n\", (global->ret), (WEIGHTS[i]));",
+  "    (i = (i + 1));",
+  "  }",
+  "})",
   "MAIN({",
   "  FIRST_BBLOCK(start);",
-  "  SMC(NULL);",
+  "  SMC(callback);",
   "})"
 ] using eqString in
 
@@ -1468,12 +1477,13 @@ in
 f 1.0; 1.0
 ----------------------" in
 
-utest test nestedIfs with strJoin "\n" [
+utest test { default with printSamples = false } nestedIfs with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
   "#include <math.h>",
   "#include \"inference/smc/smc.cuh\"",
   "#include <stdint.h>",
+  "#include <stdio.h>",
   "INIT_MODEL_STACK()",
   "struct GLOBAL {double ret; double _;};",
   "struct STACK_init {pplFunc_t ra; double (*retValLoc);};",

--- a/rootppl/rootppl.mc
+++ b/rootppl/rootppl.mc
@@ -441,6 +441,7 @@ let basic = RPProg {
   includes = ["test.h"],
   startBlock = startBlock,
   pStateTy = Some (CTyInt {}),
+  callback = None (),
   types = [ CTTyDef { ty = CTyInt {}, id = nameSym "newint" } ],
   tops = [
     CTBBlockDecl { id = startBlock },
@@ -469,6 +470,7 @@ let wrapTops = lam tops. RPProg {
   includes = [],
   startBlock = startBlock,
   pStateTy = None (),
+  callback = None (),
   types = [],
   tops = tops,
   pre = []


### PR DESCRIPTION
This PR adds support for printing samples produced by CorePPL programs compiled to RootPPL. The old behavior (print no samples) is achieved with the option `--no-print-samples` to `midppl`.

Note: `--no-print-samples` is also _required_ when the distribution is not over integers or floats.

Minor updates:
- Fixed a subtle CorePPL->RootPPL compiler bug related to `if`-expressions in tail position.