### PR TITLE
Add naive MCMC and trace MCMC

### DIFF
--- a/coreppl/models/mcmc-test.mc
+++ b/coreppl/models/mcmc-test.mc
@@ -1,0 +1,6 @@
+include "common.mc"
+
+mexpr
+let b1 = ref (if assume (Bernoulli 0.5) then 1 else 2) in
+repeat (lam. modref b1 (addi (deref b1) (if assume (Bernoulli 0.5) then 0 else 0))) 100;
+deref b1

--- a/coreppl/models/sprinkler.mc
+++ b/coreppl/models/sprinkler.mc
@@ -1,0 +1,15 @@
+mexpr
+let rain = assume (Bernoulli 0.2) in
+let sprinkler =
+  if rain then assume (Bernoulli 0.01)
+          else assume (Bernoulli 0.4) in
+let grassWet = true in
+observe grassWet (
+  switch (rain, sprinkler)
+  case (false, false) then Bernoulli 0.0
+  case (false, true) then Bernoulli 0.8
+  case (true, false) then Bernoulli 0.9
+  case (true, true) then Bernoulli 0.99
+  end
+);
+rain

--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -5,7 +5,7 @@ include "parser.mc"
 
 include "mexpr/cfa.mc"
 
-lang MExprPPLCFA = MExprCFA + MExprPPL
+lang MExprPPLStochCFA = MExprCFA + MExprPPL
 
   syn AbsVal =
   | AVStoch {}

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -72,6 +72,7 @@ let mexprCompile: Options -> Expr -> Expr =
     let tyPrintFun =
       match resTy with TyInt _ then   (var_ "int2string")
       else match resTy with TyFloat _ then (var_ "float2string")
+      else match resTy with TyBool _ then (var_ "bool2string")
       else error "Return type cannot be printed"
     in
 

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -59,6 +59,10 @@ let mexprCompile: Options -> Expr -> Expr =
     -- Apply inference-specific transformation
     let prog = compile prog in
 
+    -- Construct record accessible in runtime (currently empty)
+    let pre = ulet_ "compileOptions" (urecord_ [
+    ]) in
+
     -- Put model in top-level model function
     let prog = ulet_ "model" (lams_ [("state", tycon_ "State")] prog) in
 
@@ -75,7 +79,7 @@ let mexprCompile: Options -> Expr -> Expr =
     ] in
 
     -- Combine runtime, model, and generated post
-    let prog = bindall_ [runtime,prog,post] in
+    let prog = bindall_ [pre,runtime,prog,post] in
 
     -- Return complete program
     prog

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -6,6 +6,8 @@ include "sys.mc"
 include "../coreppl.mc"
 include "../inference-common/smc.mc"
 include "../src-location.mc"
+include "../parser.mc"
+include "../dppl-arg.mc"
 
 -- Inference methods
 include "importance/compile.mc"
@@ -83,3 +85,24 @@ let mexprCompile: Options -> Expr -> Expr =
 
     -- Return complete program
     prog
+
+mexpr
+
+let parse = parseMExprPPLString in
+
+let simple = parse "
+let x = assume (Beta 10.0 5.0) in
+let obs = true in
+observe obs (Bernoulli x);
+x
+" in
+
+-- Simple tests that ensure compilation throws no errors
+utest mexprCompile {default with method = "mexpr-importance" } simple
+with () using lam. lam. true in
+utest mexprCompile {default with method = "mexpr-naive-mcmc" } simple
+with () using lam. lam. true in
+utest mexprCompile {default with method = "mexpr-trace-mcmc" } simple
+with () using lam. lam. true in
+
+()

--- a/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
@@ -14,10 +14,9 @@ type State = Ref Float
 
 let updateWeight = lam v. lam state. modref state (addf (deref state) v)
 
-type Res a = ([Float],[a])
-
 -- General inference algorithm for importance sampling
 let run : all a. (State -> a) -> (Res a -> ()) -> () = lam model. lam printResFun.
+
   -- Read number of runs and sweeps
   match monteCarloArgs () with (particles, sweeps) in
 

--- a/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
@@ -1,3 +1,39 @@
+include "../dists.mc"
+include "../../inference-common/smc.mc"
+include "mexpr/ast-builder.mc"
 
-let compilerNaiveMCMC =
-  ("naive-mcmc/runtime-pre.mc", (lam x. x))
+lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist
+
+  -- NOTE(dlunde,2022-05-04): No way to distinguish between CorePPL and MExpr
+  -- AST types here. Optimally, the type would be Options -> CorePPLExpr ->
+  -- MExprExpr or similar.
+  sem compile : Expr -> Expr
+  sem compile =
+  | t ->
+
+    -- Transform distributions to MExpr distributions
+    let t = mapPre_Expr_Expr transformTmDist t in
+
+    -- Transform samples, observes, and weights to MExpr
+    let t = mapPre_Expr_Expr transformProb t in
+
+    t
+
+  sem transformProb =
+  | TmAssume t -> withInfo t.info (app_ (recordproj_ "sample" t.dist) unit_)
+
+  -- NOTE(dlunde,2022-05-16): Note that we cannot stop immediately when the
+  -- weight becomes 0 (-inf in log-space). For this, we need CPS, PCFGs, or
+  -- maybe some type of exception handler.
+  | TmObserve t ->
+    let weight = withInfo t.info (app_ (recordproj_ "logObserve" t.dist) t.value) in
+    withInfo t.info (appf2_ (var_ "updateWeight") weight (var_ "state"))
+  | TmWeight t ->
+    withInfo t.info (appf2_ (var_ "updateWeight") t.weight (var_ "state"))
+  | TmResample t -> withInfo t.info unit_
+  | t -> t
+
+end
+
+let compilerNaiveMCMC = use MExprPPLNaiveMCMC in
+  ("naive-mcmc/runtime.mc", compile)

--- a/coreppl/src/coreppl-to-mexpr/naive-mcmc/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/naive-mcmc/runtime.mc
@@ -1,0 +1,77 @@
+include "common.mc"
+
+include "ext/dist-ext.mc"
+include "ext/math-ext.mc"
+include "math.mc"
+include "seq.mc"
+include "string.mc"
+
+include "../runtime/common.mc"
+include "../runtime/dists.mc"
+
+-- In naive MCMC, the state is simply the accumulated weight.
+type State = Ref Float
+
+let updateWeight = lam v. lam state. modref state (addf (deref state) v)
+
+-- General inference algorithm for naive MCMC
+let run : all a. (State -> a) -> (Res a -> ()) -> () = lam model. lam printResFun.
+
+  -- Read number of runs and sweeps
+  match monteCarloArgs () with (runs, sweeps) in
+
+  recursive let mh : [Float] -> [a] -> Int -> ([Float], [a]) =
+    lam weights: [Float]. lam samples: [a]. lam iter: Int.
+      if leqi iter 0 then (weights, samples)
+      else
+        let state: State = ref 0. in
+        let sample: a = model state in
+        let weight: Float = deref state in
+        let prevWeight: Float = head weights in
+        let prevSample: a = head samples in
+        let logMhAcceptProb: Float = minf 0. (subf weight prevWeight) in
+        let iter: Int = subi iter 1 in
+        if bernoulliSample (exp logMhAcceptProb) then
+          mh (cons weight weights) (cons sample samples) iter
+        else
+          mh (cons prevWeight weights) (cons prevSample samples) iter
+  in
+
+  -- Repeat once for each sweep
+  repeat (lam.
+
+      -- Draw an initial sample first
+      let state = ref 0. in
+      let sample = model state in
+      let weight = deref state in
+      let iter: Int = subi runs 1 in
+
+      -- Draw remaining samples
+      let res = mh [weight] [sample] iter in
+
+      -- Reverse to get the correct order
+      let res = match res with (weights,samples) in
+        (reverse weights, reverse samples)
+      in
+
+      -- Print
+      printResFun res
+
+    ) sweeps
+
+let printRes : all a. (a -> String) -> Res a -> () = lam printFun. lam res.
+  recursive let printSamples = lam weights. lam samples.
+    if null weights then () else
+      let w = head weights in
+      let weights = tail weights in
+      let s = head samples in
+      let samples = tail samples in
+      print (printFun s);
+      print " ";
+      printLn (float2string w);
+      printSamples weights samples
+  in
+  -- NOTE(dlunde,2022-05-23): I don't think printing the norm. const makes
+  -- sense for MCMC
+  -- printLn (float2string (normConstant res.0));
+  printSamples res.0 res.1

--- a/coreppl/src/coreppl-to-mexpr/runtime/common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/common.mc
@@ -4,6 +4,8 @@ include "ext/math-ext.mc"
 include "seq.mc"
 include "string.mc"
 
+type Res a = ([Float],[a])
+
 -- Returns the number of particles/points from the program argument
 let numarg = lam.
   if neqi (length argv) 2 then
@@ -110,4 +112,3 @@ let output = lam res. lam names.
   let varianceVals = variance res expVals in
   printStatistics res names nc expVals varianceVals;
   saveCSV res names "data.csv" expOnLogWeights
-

--- a/coreppl/src/coreppl-to-mexpr/trace-mcmc/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/trace-mcmc/compile.mc
@@ -1,3 +1,39 @@
+include "../dists.mc"
+include "../../inference-common/smc.mc"
+include "mexpr/ast-builder.mc"
 
-let compilerTraceMCMC =
-  ("trace-mcmc/runtime.mc", (lam x. x))
+lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist
+
+  -- NOTE(dlunde,2022-05-04): No way to distinguish between CorePPL and MExpr
+  -- AST types here. Optimally, the type would be Options -> CorePPLExpr ->
+  -- MExprExpr or similar.
+  sem compile : Expr -> Expr
+  sem compile =
+  | t ->
+
+    -- Transform distributions to MExpr distributions
+    let t = mapPre_Expr_Expr transformTmDist t in
+
+    -- Transform samples, observes, and weights to MExpr
+    let t = mapPre_Expr_Expr transformProb t in
+
+    t
+
+  sem transformProb =
+  | TmAssume t -> withInfo t.info (app_ (var_ "sampleMH" ) t.dist)
+
+  -- NOTE(dlunde,2022-05-16): Note that we cannot stop immediately when the
+  -- weight becomes 0 (-inf in log-space). For this, we need CPS, PCFGs, or
+  -- maybe some type of exception handler.
+  | TmObserve t ->
+    let weight = withInfo t.info (app_ (recordproj_ "logObserve" t.dist) t.value) in
+    withInfo t.info (appf1_ (var_ "updateWeight") weight)
+  | TmWeight t ->
+    withInfo t.info (appf1_ (var_ "updateWeight") t.weight)
+  | TmResample t -> withInfo t.info unit_
+  | t -> t
+
+end
+
+let compilerTraceMCMC = use MExprPPLTraceMCMC in
+  ("trace-mcmc/runtime.mc", compile)

--- a/coreppl/src/coreppl-to-mexpr/trace-mcmc/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/trace-mcmc/runtime.mc
@@ -1,0 +1,139 @@
+include "common.mc"
+
+include "ext/dist-ext.mc"
+include "ext/math-ext.mc"
+include "math.mc"
+include "seq.mc"
+include "string.mc"
+
+include "../runtime/common.mc"
+include "../runtime/dists.mc"
+
+-- Any-type, used for traces
+type Any = ()
+
+-- In trace MCMC, the state is the accumulated weight, samples, and samples to
+-- reuse.
+type State = {
+
+  -- The weight of the current execution
+  weight: Ref Float,
+
+  -- The trace and trace length counter
+  trace: Ref [Any],
+  traceLength: Ref Int,
+
+  -- The previous trace and when to cut
+  oldTrace: Ref [Any],
+  cut: Ref Int
+
+}
+
+-- NOTE(dlunde,2022-05-23): The below implementation does not
+-- work with ropes for some reason (segfaults). We must therefore use lists.
+let emptyList = createList 0 (lam. ())
+
+-- State (reused throughout inference)
+let state = {
+  weight = ref 0.,
+  trace = ref emptyList,
+  traceLength = ref 0,
+  oldTrace = ref emptyList,
+  cut = ref 0
+}
+
+let updateWeight = lam v.
+  let weight = state.weight in
+  modref weight (addf (deref weight) v)
+
+let sampleMH: all a. Dist a -> a = lam dist.
+  let traceLength = deref state.traceLength in
+  let cut = deref state.cut in
+  let sample: Any =
+    if lti traceLength cut then
+      let r = deref state.oldTrace in
+      let sample = head r in
+      modref state.oldTrace (tail r);
+      sample
+    else unsafeCoerce (dist.sample ())
+  in
+  modref state.traceLength (addi (deref state.traceLength) 1);
+  modref state.trace (cons sample (deref state.trace));
+  unsafeCoerce sample
+
+-- General inference algorithm for trace MCMC
+let run : all a. (State -> a) -> (Res a -> ()) -> () = lam model. lam printResFun.
+
+  -- Read number of runs and sweeps
+  match monteCarloArgs () with (runs, sweeps) in
+
+  recursive let mh : [Float] -> [a] -> Int -> ([Float], [a]) =
+    lam weights. lam samples. lam iter.
+      if leqi iter 0 then (weights, samples)
+      else
+        let prevTraceLength = deref state.traceLength in
+        -- print "prev trace length: "; printLn (int2string prevTraceLength);
+        modref state.weight 0.;
+        modref state.traceLength 0;
+        -- mapReverse (lam val. dprint val; printLn "") (deref state.trace);
+        -- printLn (int2string (length (reverse (deref state.trace))));
+        modref state.oldTrace (reverse (deref state.trace));
+        modref state.trace emptyList;
+        -- print "trace length: "; printLn (int2string (deref state.traceLength));
+        modref state.cut (uniformDiscreteSample 0 (subi prevTraceLength 1));
+        -- print "cut: "; printLn (int2string (deref state.cut));
+
+        let sample = model state in
+        let weight = deref state.weight in
+        -- printResFun ([weight],[sample]); printLn "------";
+        let prevWeight = head weights in
+        let prevSample = head samples in
+        let traceLength = deref state.traceLength in
+        let logMhAcceptProb =
+          minf 0. (addf (subf weight prevWeight)
+                        (subf (log (int2float prevTraceLength))
+                              (log (int2float traceLength)))) in
+        let iter = subi iter 1 in
+        if bernoulliSample (exp logMhAcceptProb) then
+          mh (cons weight weights) (cons sample samples) iter
+        else
+          mh (cons prevWeight weights) (cons prevSample samples) iter
+  in
+
+  -- Repeat once for each sweep
+  repeat (lam.
+
+      -- First sample
+      let sample = model state in
+      let weight = deref state.weight in
+      let iter = subi runs 1 in
+
+      -- Sample the rest
+      let res = mh [weight] [sample] iter in
+
+      -- Reverse to get the correct order
+      let res = match res with (weights,samples) in
+        (reverse weights, reverse samples)
+      in
+
+      -- Print
+      printResFun res
+
+    ) sweeps
+
+let printRes : all a. (a -> String) -> Res a -> () = lam printFun. lam res.
+  -- NOTE(dlunde,2022-05-23): I don't think printing the norm. const makes
+  -- sense for MCMC
+  -- printLn (float2string (normConstant res.0));
+  recursive let printSamples = lam weights. lam samples.
+    if null weights then () else
+      let w = head weights in
+      let weights = tail weights in
+      let s = head samples in
+      let samples = tail samples in
+      print (printFun s);
+      print " ";
+      printLn (float2string w);
+      printSamples weights samples
+  in
+  printSamples res.0 res.1

--- a/coreppl/src/coreppl-to-rootppl/compile.mc
+++ b/coreppl/src/coreppl-to-rootppl/compile.mc
@@ -3,7 +3,7 @@
 include "../coreppl.mc"
 include "../parser.mc"
 include "../dppl-arg.mc"
-include "../align.mc"
+include "../cfa.mc"
 
 include "../inference-common/smc.mc"
 


### PR DESCRIPTION
Adds naive MCMC and trace MCMC inference algorithms to the CorePPL -> MExpr compiler. Also add simple tests for checking that the compilers (importance, naive MCMC, trace MCMC) do not crash.

This PR depends on https://github.com/miking-lang/miking-dppl/pulls.