### PR TITLE
Add `importance-cps` inference method and update alignment analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build/${cppl_name}
 
 cppl_tmp_file := $(shell mktemp)
 build/${cppl_name}: $(shell find . -name "*.mc")
-	time mi compile coreppl/src/${cppl_name}.mc --typecheck --output ${cppl_tmp_file}
+	time mi compile coreppl/src/${cppl_name}.mc --output ${cppl_tmp_file}
 	mkdir -p build
 	cp ${cppl_tmp_file} build/${cppl_name}
 	rm ${cppl_tmp_file}

--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -5,39 +5,70 @@ include "parser.mc"
 
 include "mexpr/cfa.mc"
 
-lang PPLCFA = MExprCFA
+lang PPLCFA = MExprCFA + MExprPPL
 
   type MCGF = Name -> Name -> Pat -> [Constraint]
 
-  -- TODO(dlunde,2022-05-30): It would be nice if we could achieve much of the
+  ----------------------------------------------------------------------------
+  -- TODO(dlunde,2022-05-30): It would be nice if we could achieve the
   -- below in a more modular way (e.g., alignment part of analysis is defined
   -- in the alignment fragment, stochastic part in the stochastic fragment,
   -- etc.)
+  ----------------------------------------------------------------------------
   sem generateStochMatchResConstraints : MCGF
   sem generateStochMatchConstraints : MCGF
-  sem generateUnalignedMatchConstraints : MCGF
   sem mcgfs : () -> [MCGF]
+  sem mcgfs =
   | _ -> [
       generateMatchConstraints,
       generateStochMatchResConstraints,
-      generateStochMatchConstraints,
-      generateUnalignedMatchConstraints
+      generateStochMatchConstraints
     ]
   sem generateStochConstraints : Expr -> [Constraint]
   sem generateAlignConstraints : Expr -> [Constraint]
   sem cgfs : [MCGF] -> [Expr -> [Constraint]]
   sem cgfs =
-  | mcfgs -> [
+  | mcgfs -> [
       generateConstraints,
       generateConstraintsMatch mcgfs,
       generateStochConstraints,
       generateAlignConstraints
     ]
+  ----------------------------------------------------------------------------
 
-  syn GraphData =
-  | PPLCFAData {
-      unaligned : Set Name
-    }
+  -- For a given expression, returns all variables directly bound in that
+  -- expression (all top-level let bindings).
+  sem exprNames: Expr -> [Name]
+  sem exprNames =
+  | t -> exprNamesAcc [] t
+
+  sem exprNamesAcc: [Name] -> Expr -> [Name]
+  sem exprNamesAcc acc =
+  | TmVar t -> acc
+  | TmLet t -> exprNamesAcc (cons t.ident acc) t.inexpr
+  | TmRecLets t ->
+      foldl (lam acc. lam bind : RecLetBinding. cons bind.ident acc)
+        acc t.bindings
+  | TmType t -> exprNamesAcc acc t.inexpr
+  | TmConDef t -> exprNamesAcc acc t.inexpr
+  | TmUtest t -> exprNamesAcc acc t.next
+  | TmExt t -> exprNamesAcc acc t.inexpr
+  | t -> errorSingle [infoTm t] "Error in exprNames for CFA"
+
+  -- Whether a pattern can fail
+  sem patFail =
+  | ( PatSeqTot _
+    | PatSeqEdge _
+    | PatCon _
+    | PatInt _
+    | PatChar _
+    | PatBool _
+    | PatRecord _
+    ) & pat -> true
+  | PatAnd p -> if patFail p.lpat then true else patFail p.rpat
+  | PatOr p -> if patFail p.lpat then patFail p.rpat else false
+  | PatNot p -> true
+  | PatNamed _ -> false
 
   -- Type: Expr -> CFAGraph
   sem initGraph (graphData: Option GraphData) =
@@ -61,16 +92,6 @@ lang PPLCFA = MExprCFA
     -- Return graph
     graph
 
-  sem cfaPPL: Expr -> CFAGraph
-  sem cfaPPL =
-  | t -> match cfaPPLDebug (None ()) t with (_,graph) in graph
-
-  sem cfaPPLDebug : Option PprintEnv -> Expr -> (Option PprintEnv, CFAGraph)
-  sem cfaPPLDebug penv
-  | t ->
-    let graphData = PPLCFAData { unaligned = setEmpty nameCmp } in
-    cfaDebug (Some graphData) penv t
-
 end
 
 lang StochCFA = PPLCFA
@@ -85,30 +106,21 @@ lang StochCFA = PPLCFA
   | (AVStoch _, AVStoch _) -> 0
 
   syn Constraint =
-  -- {const} ⊆ lhs AND {stoch} ⊆ rhs ⇒ {stoch} ⊆ res
+  -- {const} ⊆ lhs ⇒ ({stoch} ⊆ rhs ⇒ {stoch} ⊆ res)
   | CstrConstStochApp { lhs: Name, rhs: Name, res: Name }
 
   sem initConstraint (graph: CFAGraph) =
-  | CstrConstStochApp r & cstr ->
-    let graph = initConstraintName r.lhs graph cstr in
-    initConstraintName r.rhs graph cstr
+  | CstrConstStochApp r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem cstrStochDirect (lhs: Name) =
+  | rhs -> CstrDirectAv {
+      lhs = lhs, lhsav = AVStoch {}, rhs = rhs, rhsav = AVStoch {}
+    }
 
   sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
   | CstrConstStochApp { lhs = lhs, rhs = rhs, res = res } ->
-    if nameEq update.0 lhs then
-      match update.1 with AVConst _ then
-        let s = dataLookup rhs graph in
-        if setMem (AVStoch {}) s then
-          addData graph (AVStoch {}) res
-        else graph
-      else graph
-    else if nameEq update.0 rhs then
-      match update.1 with AVStoch _ then
-        let s = dataLookup lhs graph in
-        if setAny (lam av. match av with AVConst _ then true else false) s then
-          addData graph (AVStoch {}) res
-        else graph
-      else graph
+    match update.1 with AVConst _ then
+      initConstraint graph (cstrStochDirect rhs res)
     else graph
 
   -- This function is called from the base Miking CFA fragment when the
@@ -150,33 +162,9 @@ lang StochCFA = PPLCFA
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
 
-  sem cstrStochDirect (lhs: Name) =
-  | rhs -> CstrDirectAv {
-      lhs = lhs, lhsav = AVStoch {}, rhs = rhs, rhsav = AVStoch {}
-    }
-
   sem generateStochMatchResConstraints (id: Name) (target: Name) =
-  | ( PatSeqTot _
-    | PatSeqEdge _
-    | PatCon _
-    | PatInt _
-    | PatChar _
-    | PatBool _
-    | PatRecord _
-    ) & pat ->
-    -- We only generate this constraint where a match can fail, causing a
-    -- stochastic branch if the failed value is stochastic.
-    [
-      -- Result of match is stochastic if match can fail stochastically
-      cstrStochDirect target id,
-    ]
-
-  | ( PatAnd p
-    | PatOr p
-    | PatNot p
-    ) -> errorSingle [p.info] "Pattern currently not supported"
-
-  | PatNamed _ -> []
+  -- Result of match is stochastic if match can fail stochastically
+  | pat -> if patFail pat then [cstrStochDirect target id] else []
 
   -- Ensures all extracted pattern components of a stochastic value are also
   -- stochastic. For example, all elements of a stochastic list are stochastic.
@@ -200,314 +188,125 @@ lang AlignCFA = StochCFA
   syn AbsVal =
   | AVUnaligned {}
 
+  sem absValToString (env: PprintEnv) =
+  | AVUnaligned {} -> (env, "unaligned")
+
+  sem cmpAbsValH =
+  | (AVUnaligned _, AVUnaligned _) -> 0
+
   -- Alignment handling is custom (should not propagate as part of regular
   -- direct constraints)
   sem isDirect =
   | AVUnaligned _ -> false
 
   syn Constraint =
-  -- {stoch} ⊆ target ⇒ names are unaligned
+  -- {stoch} ⊆ target ⇒ for all n in names, {unaligned} ⊆ n
   | CstrStochAlign { target: Name, names: [Name] }
-  -- {id} ⊆ unaligned names ⇒ names ⊆ unaligned names
+  -- {unaligned} ⊆ id ⇒ for all n in names, {unaligned} ⊆ n
   | CstrAlign { id: Name, names: [Name] }
-  -- {app id} ⊆ unaligned names and {lam x. b} ⊆ lhs ⇒ {x} ⊆ unaligned names
+  -- {unaligned} ⊆ id ⇒ ({lam x. b} ⊆ lhs ⇒ {unaligned} ⊆ x)
   | CstrAlignApp { id: Name, lhs: Name }
+  -- {stoch} ⊆ lhs ⇒ ({lam x. b} ⊆ lhs ⇒ {unaligned} ⊆ x)
+  | CstrStochAlignApp { lhs: Name }
+  -- {lam x. b} ⊆ lhs ⇒ {unaligned} ⊆ x
+  | CstrAlignLamApp { lhs: Name }
 
   sem initConstraint (graph: CFAGraph) =
-  | CstrStochMatchCond r & cstr -> initConstraintName r.target graph cstr
+  | CstrStochAlign r & cstr -> initConstraintName r.target graph cstr
+  | CstrAlign r & cstr -> initConstraintName r.id graph cstr
+  | CstrAlignApp r & cstr -> initConstraintName r.id graph cstr
+  | CstrStochAlignApp r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrAlignLamApp r & cstr -> initConstraintName r.lhs graph cstr
 
   sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
-  | CstrStochMatchCond { target = target, id = id } ->
+  | CstrStochAlign { target = target, names = names } ->
     match update.1 with AVStoch _ then
-      match graph.graphData with Some (PPLCFAData r) then
-        let graphData = Some (PPLCFAData
-          {r with unaligned = setInsert id r.unaligned}
-        ) in
-        { graph with graphData = graphData }
-      else error "Impossible in coreppl/src/cfa.mc"
+      foldl (lam graph. lam name. addData graph (AVUnaligned {}) name)
+        graph names
+    else graph
+  | CstrAlign { id = id, names = names } ->
+    match update.1 with AVUnaligned _ then
+      foldl (lam graph. lam name. addData graph (AVUnaligned {}) name)
+        graph names
+    else graph
+  | CstrAlignApp { id = id, lhs = lhs } ->
+    match update.1 with AVUnaligned _ then
+      initConstraint graph (CstrAlignLamApp { lhs = lhs })
+    else graph
+  | CstrStochAlignApp { lhs = lhs } ->
+    match update.1 with AVStoch _ then
+      initConstraint graph (CstrAlignLamApp { lhs = lhs })
+    else graph
+  | CstrAlignLamApp { lhs = lhs } ->
+    match update.1 with AVLam { ident = x, body = b } then
+      addData graph (AVUnaligned {}) x
     else graph
 
   sem constraintToString (env: PprintEnv) =
-  | CstrStochMatchCond { target = target, id = id } ->
+  | CstrStochAlign { target = target, names = names } ->
     match pprintVarName env target with (env,target) in
-    match pprintVarName env id with (env,id) in
+    match mapAccumL pprintVarName env names with (env,names) in
     (env, join [
-      "{stoch} ⊆ ", target, " ⇒ match condition is stochastic for match ", id
+      "{stoch} ⊆ ", target, " ⇒ {unaligned} ⊆ ", strJoin "," names
     ])
+  | CstrAlign { id = id, names = names } ->
+    match pprintVarName env id with (env,id) in
+    match mapAccumL pprintVarName env names with (env,names) in
+    (env, join [
+      "{unaligned} ⊆ ", id, " ⇒ {unaligned} ⊆ ", strJoin "," names
+    ])
+  | CstrAlignApp { id = id, lhs = lhs } ->
+    match constraintToString env (CstrAlignLamApp { lhs = lhs })
+    with (env,rhs) in
+    match pprintVarName env id with (env,id) in
+    match pprintVarName env lhs with (env,lhs) in
+    (env, join [ "{unaligned} ⊆ ", id, " ⇒ (", rhs, ")" ])
+  | CstrStochAlignApp { lhs = lhs } ->
+    match constraintToString env (CstrAlignLamApp { lhs = lhs })
+    with (env,rhs) in
+    match pprintVarName env lhs with (env,lhs) in
+    (env, join [ "{stoch} ⊆ ", lhs, " ⇒ (", rhs, ")" ])
+  | CstrAlignLamApp { lhs = lhs } ->
+    match pprintVarName env lhs with (env,lhs) in
+    (env, join [ "{lam >x<. >b<} ⊆ ", lhs, " ⇒ {unaligned} ⊆ >x<"])
 
-  sem generateConstraintsMatchAlign  =
+  sem generateAlignConstraints  =
   | _ -> []
+  | TmLet { ident = ident, body = TmLam t } ->
+    [ CstrAlign { id = t.ident, names = exprNames t.body} ]
   | TmLet { ident = ident, body = TmMatch t } ->
-    let innerNames = -- TODO get names from t.thn and t.els
+    let innerNames = concat (exprNames t.thn) (exprNames t.els) in
     match t.target with TmVar tv then
-      
-      foldl (lam acc. lam f. concat (f ident tv.ident t.pat) acc) cstrs mcgfs
-    else infoErrorExit (infoTm t.target) "Not a TmVar in match target"
-
-  sem generateUnalignedMatchConstraints (id: Name) (target: Name) =
-  | ( PatSeqTot _
-    | PatSeqEdge _
-    | PatCon _
-    | PatInt _
-    | PatChar _
-    | PatBool _
-    | PatRecord _
-    ) & pat ->
-    -- We only generate this constraint where a match can fail, causing a
-    -- stochastic branch if the failed value is stochastic.
-    [
-      -- Match is unaligned if it can fail stochastically
-      CstrStochMatchCond { target = target, id = id }
-    ]
-
-  | ( PatAnd p
-    | PatOr p
-    | PatNot p
-    ) -> infoErrorExit p.info "Pattern currently not supported"
-
-  | PatNamed _ -> []
+      let cstrs =
+        if patFail t.pat then
+          [CstrStochAlign { target = tv.ident, names = innerNames }]
+        else []
+      in
+      cons (CstrAlign { id = ident, names = innerNames }) cstrs
+    else errorSingle [infoTm t.target] "Not a TmVar in match target"
+  | TmLet { ident = ident, body = TmApp app} ->
+    match app.lhs with TmVar l then
+      match app.rhs with TmVar r then
+        [ CstrAlignApp { id = ident, lhs = l.ident },
+          CstrStochAlignApp { lhs = l.ident }
+        ]
+      else errorSingle [infoTm app.rhs] "Not a TmVar in application"
+    else errorSingle [infoTm app.lhs] "Not a TmVar in application"
 
 end
 
+lang MExprPPLCFA = StochCFA + AlignCFA
+end
 
-lang Align = MExprPPLStochCFA
-
-  type AlignFlow = {
-    -- Unaligned names
-    unaligned: [Name],
-    -- LHS names of applications
-    lhss: [Name]
-  }
-
-  -- Types for keeping track of alignment flow
-  type AlignAcc = {
-    -- Map for matches (let key = match ...)
-    mMap: Map Name AlignFlow,
-    -- Map for lambdas (lam key. ...)
-    lMap: Map Name AlignFlow,
-    -- Current flow accumulator
-    current: AlignFlow
-  }
-  sem emptyAlignFlow : () -> AlignFlow
-  sem emptyAlignFlow =
-  | _ -> { unaligned = [], lhss = [] }
-
-  -- Type: Expr -> CFAGraph -> Set Name
-  -- Returns a list of unaligned names for a program.
-  sem alignment (cfaRes: CFAGraph) =
-  | t -> match alignmentDebug (None ()) cfaRes t with (_,res) in res
-
-  sem alignmentDebug (env: Option PprintEnv) (cfaRes: CFAGraph) =
-  | t ->
-
-    -- Construct unaligned name map (for matches and lambdas)
-    let m = mapEmpty nameCmp in
-    let acc: AlignAcc = { mMap = m, lMap = m, current = emptyAlignFlow () } in
-    match alignMap acc t with acc in
-    let acc: AlignAcc = acc in
-    let uMatch = acc.mMap in
-    let uLam = acc.lMap in
-
-    let env = match env with Some env then
-        match mapAccumL pprintVarName env (setToSeq cfaRes.stochMatches)
-        with (env,stochMatches) in
-        match alignFlowMapToString env uMatch with (env,uMatch) in
-        match alignFlowMapToString env uLam with (env,uLam) in
-        print "*** Stochastic matches ***\n";
-        printLn (strJoin ", " stochMatches);
-        print "*** Unaligned match map ***\n";
-        printLn uMatch;
-        print "*** Unaligned lambda map ***\n";
-        printLn uLam;
-        Some env
-      else None ()
-    in
-
-    type AccIter = {
-      unaligned: Set Name,
-      processedLams: Set Name,
-      processedLhss: Set Name,
-      newLhss: [Name]
-    } in
-
-    let emptyAccIter = {
-      unaligned = setEmpty nameCmp,
-      processedLams = setEmpty nameCmp,
-      processedLhss = setEmpty nameCmp,
-      newLhss = []
-    } in
-
-    -- Main alignment propagation
-    recursive let iter = lam acc: AccIter.
-      match acc.newLhss with [h] ++ newLhss then
-        let acc = { acc with newLhss = newLhss } in
-        if setMem h acc.processedLhss then iter acc
-        else
-          let acc = { acc with processedLhss = setInsert h acc.processedLhss } in
-          let avs = dataLookup h cfaRes in
-          let acc = setFold (lam acc: AccIter. lam av.
-              match av with AVLam { ident = ident } then
-                if setMem ident acc.processedLams then acc
-                else
-                  let v: AlignFlow = mapFindExn ident uLam in
-                  {{{ acc
-                    with unaligned =
-                      foldl (lam ua. lam n. setInsert n ua)
-                        acc.unaligned v.unaligned }
-                    with processedLams =
-                      setInsert ident acc.processedLams }
-                    with newLhss =
-                      concat v.lhss acc.newLhss }
-              else acc
-            ) acc avs
-          in
-          iter acc
-      else match acc.newLhss with [] then acc.unaligned
-      else never
-    in
-
-    -- Initial recursion over stochastic applications
-    recursive let recapp = lam acc: AccIter. lam t: Expr.
-      match t with TmApp { lhs = TmVar { ident = ident } } then
-        let avs = dataLookup ident cfaRes in
-        if setMem (AVStoch {}) avs then
-          let acc =
-            { acc with processedLhss = setInsert ident acc.processedLhss } in
-          setFold (lam acc: AccIter. lam av.
-            match av with AVLam { ident = ident } then
-              let v: AlignFlow = mapFindExn ident uLam in
-              {{{ acc
-                with unaligned =
-                  foldl (lam ua. lam n. setInsert n ua)
-                    acc.unaligned v.unaligned }
-                with processedLams =
-                  setInsert ident acc.processedLams }
-                with newLhss =
-                  concat v.lhss acc.newLhss }
-            else acc
-          ) acc avs
+let extractUnaligned = use MExprPPLCFA in
+  lam cfaRes: CFAGraph.
+    mapFoldWithKey (lam acc: Set Name. lam k: Name. lam v: Set AbsVal.
+        if setAny (lam av. match av with AVUnaligned _ then true else false) v
+        then setInsert k acc
         else acc
-      else sfold_Expr_Expr recapp acc t
-    in
+      ) (setEmpty nameCmp) cfaRes.data
 
-    -- Initial stochastic matches (provided by CFA analysis)
-    let acc = setFold (lam acc: AccIter. lam matchId.
-      let v: AlignFlow = mapFindExn matchId uMatch in
-      {{ acc
-        with unaligned =
-          foldl (lam ua. lam n. setInsert n ua) acc.unaligned v.unaligned }
-        with newLhss = concat v.lhss acc.newLhss }
-    ) emptyAccIter cfaRes.stochMatches
-    in
-
-    let acc = recapp acc t in
-
-    let res = iter acc in
-
-    let env = match env with Some env then
-        printLn "***UNALIGNED NAMES***";
-        match mapAccumL pprintVarName env (setToSeq res) with (_,res) in
-        printLn (strJoin ", " res);
-        Some env
-      else None ()
-    in
-
-    (env, res)
-
-  sem alignFlowMapToString (env: PprintEnv) =
-  | m ->
-    let f = lam env. lam k. lam v: AlignFlow.
-      match pprintVarName env k with (env, k) in
-      match mapAccumL pprintVarName env v.unaligned with (env, unaligned) in
-      match mapAccumL pprintVarName env v.lhss with (env, lhss) in
-      let unaligned = strJoin ", " unaligned in
-      let lhss = strJoin ", " lhss in
-      (env, join [k, " ->\n  unaligned: ", unaligned, "\n  lhss: ", lhss])
-    in
-    match mapMapAccum f env m with (env, m) in
-    (env, strJoin "\n" (mapValues m))
-
-  sem alignMap (acc: AlignAcc) =
-  | TmLet { ident = ident, body = TmApp a, inexpr = inexpr } ->
-    -- a.rhs is a variable due to ANF, no need to recurse
-    -- Add new values
-    let c: AlignFlow = acc.current in
-    let current = {{ c
-      with unaligned = cons ident c.unaligned }
-      with lhss =
-        let lhs = match a.lhs with TmVar t then t.ident
-          else errorSingle [infoTm a.lhs] "Not a TmVar in application" in
-        cons lhs c.lhss }
-    in
-    let acc = { acc with current = current } in
-    alignMap acc inexpr
-  | TmLet { ident = ident, body = TmMatch m, inexpr = inexpr } ->
-    -- m.target is a TmVar due to ANF, can safely be ignored here
-    let c: AlignFlow = acc.current in
-    let current = {
-      c with unaligned = cons ident c.unaligned
-    } in
-    let acc = { acc with current = current } in
-    -- Recursion
-    let accI: AlignAcc = { acc with current = emptyAlignFlow () } in
-    match alignMap accI m.thn with accI in
-    match alignMap accI m.els with accI in
-    let accI: AlignAcc = accI in
-    -- Record inner map and define next current
-    let mMap = mapInsert ident accI.current accI.mMap in
-    let c: AlignFlow = acc.current in
-    let ci: AlignFlow = accI.current in
-    let current = {
-      -- Flow in inner match is also part of outer lam/match
-      unaligned = concat c.unaligned ci.unaligned,
-      lhss = concat c.lhss ci.lhss
-    } in
-    let acc = {{ accI with mMap = mMap } with current = current } in
-    alignMap acc inexpr
-  | TmLet { ident = ident, body = TmLam b, inexpr = inexpr } ->
-    let c: AlignFlow = acc.current in
-    let current = {
-      c with unaligned = cons ident c.unaligned
-    } in
-    let acc = { acc with current = current } in
-    let accI: AlignAcc = { acc with current = emptyAlignFlow () } in
-    match alignMap accI b.body with accI in
-    let accI: AlignAcc = accI in
-    let lMap = mapInsert b.ident accI.current accI.lMap in
-    let acc = {{ accI with lMap = lMap } with current = current } in
-    alignMap acc inexpr
-  | TmRecLets { bindings = bindings, inexpr = inexpr } ->
-    let acc = foldl (lam acc: AlignAcc. lam b: RecLetBinding.
-        match b.body with TmLam t then
-          let c: AlignFlow = acc.current in
-          let current = {
-            c with unaligned = cons b.ident c.unaligned
-          } in
-          let acc = { acc with current = current } in
-          let accI: AlignAcc = { acc with current = emptyAlignFlow () } in
-          match alignMap accI t.body with accI in
-          let accI: AlignAcc = accI in
-          let lMap = mapInsert t.ident accI.current accI.lMap in
-          {{ accI with lMap = lMap } with current = current }
-        else errorSingle [infoTm b.body] "Not a lambda in recursive let body"
-      ) acc bindings in
-    alignMap acc inexpr
-  | TmLet { ident = ident, body = body, inexpr = inexpr } ->
-    let c: AlignFlow = acc.current in
-    let current = {
-      c with unaligned = cons ident c.unaligned
-    } in
-    let acc = { acc with current = current } in
-    alignMap acc inexpr
-  | t -> sfold_Expr_Expr alignMap acc t
-
-end
-
-lang MExprPPLCFA =
-
-end
-
-lang Test = Align + MExprANFAll + DPPLParser
+lang Test = MExprPPLCFA + MExprANFAll + DPPLParser
 end
 
 -----------
@@ -708,7 +507,7 @@ let _test: Bool -> Expr -> [String] -> [([Char], Bool)] =
     let tANF = normalizeTerm t in
     let env = if debug then Some pprintEnvEmpty else None () in
     match _testBase env tANF with (env, cfaRes) in
-    match alignmentDebug env cfaRes tANF with (_, aRes) in
+    let aRes: Set Name = extractUnaligned cfaRes in
     let sSet: Set String = setFold
       (lam acc. lam n. setInsert (nameGetStr n) acc)
       (setEmpty cmpString) aRes in
@@ -775,9 +574,9 @@ let t = _parse "
 ------------------------" in
 utest _test false t ["f","x","w1","y","w2","res"] with [
   ("f", true),
-  ("x", true),
+  ("x", false),
   ("w1", false),
-  ("y", true),
+  ("y", false),
   ("w2", false),
   ("res", true)
 ] using eqTest in

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -90,25 +90,11 @@ let mexprCompile: Options -> Expr -> Expr =
     -- Combine runtime, model, and generated post
     let prog = bindall_ [pre,runtime,prog,post] in
 
-    -- Strip all type annotations on lets and lambdas
-    -- NOTE(dlunde,2022-06-08): Temporary solution that does not work in all
-    -- cases. Should not be needed in the future when the type checker can
-    -- handle programs in CPS.
-    -- Temporary function for removing all type annotations on lets and lambdas
-    recursive let removeTypeAnnotations: Expr -> Expr = lam e.
-      let e =
-        match e with TmLam _ | TmRecLets _ | TmLet _ then
-          smap_Expr_Type (lam. tyunknown_) e
-        else e
-      in smap_Expr_Expr removeTypeAnnotations e
-    in
-    let prog = removeTypeAnnotations prog in
-
     -- Type check the combined program
-    let prog = typeCheck prog in
-
-    -- Remove types again, type-checked programs do not currently print well.
-    let prog = removeTypeAnnotations prog in
+    -- TODO(dlunde,2022-06-08): This makes the output program non-parsable
+    -- (should probably be fixed in pprint?), which is why it is turned off by
+    -- default.
+    -- let prog = typeCheck prog in
 
     -- Return complete program
     prog

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -90,8 +90,25 @@ let mexprCompile: Options -> Expr -> Expr =
     -- Combine runtime, model, and generated post
     let prog = bindall_ [pre,runtime,prog,post] in
 
+    -- Strip all type annotations on lets and lambdas
+    -- NOTE(dlunde,2022-06-08): Temporary solution that does not work in all
+    -- cases. Should not be needed in the future when the type checker can
+    -- handle programs in CPS.
+    -- Temporary function for removing all type annotations on lets and lambdas
+    recursive let removeTypeAnnotations: Expr -> Expr = lam e.
+      let e =
+        match e with TmLam _ | TmRecLets _ | TmLet _ then
+          smap_Expr_Type (lam. tyunknown_) e
+        else e
+      in smap_Expr_Expr removeTypeAnnotations e
+    in
+    let prog = removeTypeAnnotations prog in
+
     -- Type check the combined program
     let prog = typeCheck prog in
+
+    -- Remove types again, type-checked programs do not currently print well.
+    let prog = removeTypeAnnotations prog in
 
     -- Return complete program
     prog

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -26,4 +26,15 @@ lang TransformDist = MExprPPL
   | DCategorical { p = p } -> appf1_ (var_ "distCategorical") p
   | DDirichlet { a = a } -> appf1_ (var_ "distDirichlet") a
   | DUniform { a = a, b = b } -> appf2_ (var_ "distUniform") a b
+
+  -- It may be that certain TyDist annotations remain after compilation. This
+  -- function removes them.
+  -- TODO(dlunde,2022-06-03): Temporary fix, this should be handled in some
+  -- nicer way. The best would be to simply map over all types in the program
+  -- and replace TyDist with the runtime dists defined in runtime/dists.mc
+  sem removeTyDist: Expr -> Expr
+  sem removeTyDist =
+  | TmLet body ->
+    TmLet { body with tyBody = tyunknown_ }
+  | expr -> smap_Expr_Expr removeTyDist expr
 end

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -10,22 +10,22 @@ include "mexpr/ast-builder.mc"
 lang TransformDist = MExprPPL
   sem transformTmDist: Expr -> Expr
   sem transformTmDist =
-  | TmDist t -> withInfo t.info (transformDist t.dist)
+  | TmDist t -> transformDist (withInfo t.info) t.dist
   | t -> t
 
-  sem transformDist: Dist -> Expr
-  sem transformDist =
-  | DGamma { k = k, theta = theta } -> appf2_ (var_ "distGamma") k theta
-  | DExponential { rate = rate } -> appf1_ (var_ "distExponential") rate
-  | DPoisson { lambda = lambda } -> appf1_ (var_ "distPoisson") lambda
-  | DBinomial { n = n, p = p } -> appf2_ (var_ "distBinomial") n p
-  | DBernoulli { p = p } -> appf1_ (var_ "distBernoulli") p
-  | DBeta { a = a, b = b } -> appf2_ (var_ "distBeta") a b
-  | DGaussian { mu = mu, sigma = sigma } -> appf2_ (var_ "distGaussian") mu sigma
-  | DMultinomial { n = n, p = p } -> appf2_ (var_ "distMultinomial") n p
-  | DCategorical { p = p } -> appf1_ (var_ "distCategorical") p
-  | DDirichlet { a = a } -> appf1_ (var_ "distDirichlet") a
-  | DUniform { a = a, b = b } -> appf2_ (var_ "distUniform") a b
+  sem transformDist: (Expr -> Expr) -> Dist -> Expr
+  sem transformDist i =
+  | DGamma { k = k, theta = theta } -> i (appf2_ (i (var_ "distGamma")) k theta)
+  | DExponential { rate = rate } -> i (appf1_ (i (var_ "distExponential")) rate)
+  | DPoisson { lambda = lambda } -> i (appf1_ (i (var_ "distPoisson")) lambda)
+  | DBinomial { n = n, p = p } -> i (appf2_ (i (var_ "distBinomial")) n p)
+  | DBernoulli { p = p } -> i (appf1_ (i (var_ "distBernoulli")) p)
+  | DBeta { a = a, b = b } -> i (appf2_ (i (var_ "distBeta")) a b)
+  | DGaussian { mu = mu, sigma = sigma } -> i (appf2_ (i (var_ "distGaussian")) mu sigma)
+  | DMultinomial { n = n, p = p } -> i (appf2_ (i (var_ "distMultinomial")) n p)
+  | DCategorical { p = p } -> i (appf1_ (i (var_ "distCategorical")) p)
+  | DDirichlet { a = a } -> i (appf1_ (i (var_ "distDirichlet")) a)
+  | DUniform { a = a, b = b } -> i (appf2_ (i (var_ "distUniform")) a b)
 
   -- We need to remove TyDist after transforming to MExpr dists (the new MExpr
   -- types will be inferred by the type checker)
@@ -34,7 +34,7 @@ lang TransformDist = MExprPPL
   | e ->
     recursive let stripTyDist: Type -> Type =
       lam ty.
-        match ty with TyDist _ then tyunknown_
+        match ty with TyDist t then tyWithInfo t.info tyunknown_
         else smap_Type_Type stripTyDist ty
     in
     let e = smap_Expr_Type stripTyDist e in

--- a/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
@@ -49,7 +49,9 @@ lang MExprPPLImportanceCPS = MExprPPL + Resample + TransformDist + MExprCPS + ME
     t
 
   sem transformProb =
-  | TmAssume t -> withInfo t.info (app_ (recordproj_ "sample" t.dist) unit_)
+  | TmAssume t ->
+    let i = withInfo t.info in
+    i (app_ (i (recordproj_ "sample" t.dist)) (i unit_))
   | TmResample t -> withInfo t.info unit_
 
   -- Should already have been removed by CPS!

--- a/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
@@ -18,14 +18,16 @@ lang MExprPPLImportanceCPS = MExprPPL + Resample + TransformDist + MExprCPS + ME
   -- This is where we use the continuation (weight and observe)
   | TmLet { ident = ident, body = TmWeight { weight = weight },
             inexpr = inexpr} & t ->
-    let k = if tailCall t then k else nulam_ ident (exprCps k inexpr) in
-    appf2_ (var_ "updateWeight") weight k
+    let i = withInfo (infoTm t) in
+    let k = if tailCall t then k else i (nulam_ ident (exprCps k inexpr)) in
+    i (appf2_ (i (var_ "updateWeight")) weight k)
 
   | TmLet { ident = ident, body = TmObserve { value = value, dist = dist },
             inexpr = inexpr } & t ->
+    let i = withInfo (infoTm t) in
     let k = if tailCall t then k else nulam_ ident (exprCps k inexpr) in
-    let weight = app_ (recordproj_ "logObserve" dist) value in
-    appf2_ (var_ "updateWeight") weight k
+    let weight = i (app_ (i (recordproj_ "logObserve" dist)) value) in
+    i (appf2_ (i (var_ "updateWeight")) weight k)
 
   sem compile : Expr -> Expr
   sem compile =

--- a/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance-cps/compile.mc
@@ -1,0 +1,65 @@
+include "../dists.mc"
+include "../../inference-common/smc.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/cps.mc"
+
+lang MExprPPLImportanceCPS = MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll
+
+  -- CPS
+  sem cpsCont k =
+  -- Do nothing at assumes or resamples
+  | TmLet ({ body = TmAssume _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
+  | TmLet ({ body = TmResample _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
+
+  -- This is where we use the continuation (weight and observe)
+  | TmLet { ident = ident, body = TmWeight { weight = weight },
+            inexpr = inexpr} & t ->
+    let k = if tailCall t then k else nulam_ ident (cpsCont k inexpr) in
+    conapp_ "Checkpoint" (urecord_ [
+        ("weight", weight),
+        ("k", k)
+      ])
+
+  | TmLet { ident = ident, body = TmObserve { value = value, dist = dist },
+            inexpr = inexpr } & t ->
+    let k = if tailCall t then k else nulam_ ident (cpsCont k inexpr) in
+    conapp_ "Checkpoint" (urecord_ [
+        ("weight", (app_ (recordproj_ "logObserve" dist) value)),
+        ("k", k)
+      ])
+
+  sem compile : Expr -> Expr
+  sem compile =
+  | t ->
+
+    -- ANF transformation (required for CPS)
+    let t = normalizeTerm t in
+
+    -- CPS transformation
+    let t = cpsCont (ulam_ "x" (conapp_ "End" (var_ "x"))) t in
+
+    -- Transform distributions to MExpr distributions
+    let t = mapPre_Expr_Expr transformTmDist t in
+
+    -- Transform samples, observes, and weights to MExpr
+    let t = mapPre_Expr_Expr transformProb t in
+
+    -- Replace dist types with correct types
+    let t = mapPre_Expr_Expr removeTyDist t in
+
+    t
+
+  sem transformProb =
+  | TmAssume t -> withInfo t.info (app_ (recordproj_ "sample" t.dist) unit_)
+  | TmResample t -> withInfo t.info unit_
+
+  -- Should already have been removed by CPS!
+  | (TmObserve t | TmWeight t) -> errorSingle [t.info] "Impossible in importance-cps"
+  | t -> t
+
+end
+
+let compilerImportanceCPS = use MExprPPLImportanceCPS in
+  ("importance-cps/runtime.mc", compile)

--- a/coreppl/src/coreppl-to-mexpr/importance-cps/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance-cps/runtime.mc
@@ -16,8 +16,7 @@ con End : all a. a -> Stop a
 -- In importance sampling, the state is simply the accumulated weight.
 type State = Ref Float
 
--- TODO Remove, update state in run instead
-let updateWeight = lam v. lam state. modref state (addf (deref state) v)
+let updateWeight = lam weight. lam k. Checkpoint { weight = weight, k = k }
 
 let importance: all a. (State -> Stop a) -> State -> Option a =
   lam model. lam state.

--- a/coreppl/src/coreppl-to-mexpr/importance-cps/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance-cps/runtime.mc
@@ -1,0 +1,55 @@
+
+include "common.mc"
+
+include "ext/dist-ext.mc"
+include "ext/math-ext.mc"
+include "seq.mc"
+include "string.mc"
+
+include "../runtime/common.mc"
+include "../runtime/dists.mc"
+
+type Stop a
+con Checkpoint : all a. { weight: Float, k: () -> Stop a } -> Stop a
+con End : all a. a -> Stop a
+
+-- In importance sampling, the state is simply the accumulated weight.
+type State = Ref Float
+
+-- TODO Remove, update state in run instead
+let updateWeight = lam v. lam state. modref state (addf (deref state) v)
+
+let importance: all a. (State -> Stop a) -> State -> Option a =
+  lam model. lam state.
+
+    -- First run the initial model to the first checkpoint
+    let res: Stop a = model state in
+
+    -- Then run it until the end
+    recursive let rec: Stop a -> Option a = lam res.
+      match res with Checkpoint { weight = weight, k = k } then
+        modref state (addf (deref state) weight);
+        if eqf (deref state) (negf inf) then None ()
+        else rec (k ())
+      else match res with End a then Some a else never
+    in rec res
+
+-- General inference algorithm for importance sampling
+let run : all a. (State -> Stop a) -> (ResOption a -> ()) -> () =
+  lam model. lam printResFun.
+
+    -- Read number of runs and sweeps
+    match monteCarloArgs () with (particles, sweeps) in
+
+    -- Repeat once for each sweep
+    repeat (lam.
+        let weightInit: Float = 0. in
+        let states = createList particles (lam. ref weightInit) in
+        let res = mapReverse (importance model) states in
+        let res = (mapReverse deref states, res) in
+        printResFun res
+      ) sweeps
+
+let printRes : all a. (a -> String) -> ResOption a -> () = lam printFun. lam res.
+  printLn (float2string (normConstant res.0));
+  printSamplesOption printFun res.0 res.1

--- a/coreppl/src/coreppl-to-mexpr/importance/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/compile.mc
@@ -19,16 +19,20 @@ lang MExprPPLImportance = MExprPPL + Resample + TransformDist
     t
 
   sem transformProb =
-  | TmAssume t -> withInfo t.info (app_ (recordproj_ "sample" t.dist) unit_)
+  | TmAssume t ->
+    let i = withInfo t.info in
+    i (app_ (i (recordproj_ "sample" t.dist)) (i unit_))
 
   -- NOTE(dlunde,2022-05-16): Note that we cannot stop immediately when the
   -- weight becomes 0 (-inf in log-space). For this, we need CPS, PCFGs, or
   -- maybe some type of exception handler.
   | TmObserve t ->
-    let weight = withInfo t.info (app_ (recordproj_ "logObserve" t.dist) t.value) in
-    withInfo t.info (appf2_ (var_ "updateWeight") weight (var_ "state"))
+    let i = withInfo t.info in
+    let weight = i (app_ (i (recordproj_ "logObserve" t.dist)) t.value) in
+    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
   | TmWeight t ->
-    withInfo t.info (appf2_ (var_ "updateWeight") t.weight (var_ "state"))
+    let i = withInfo t.info in
+    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
   | TmResample t -> withInfo t.info unit_
   | t -> t
 

--- a/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
@@ -30,16 +30,5 @@ let run : all a. (State -> a) -> (Res a -> ()) -> () = lam model. lam printResFu
     ) sweeps
 
 let printRes : all a. (a -> String) -> Res a -> () = lam printFun. lam res.
-  recursive let printSamples = lam weights. lam samples.
-    if null weights then () else
-      let w = head weights in
-      let weights = tail weights in
-      let s = head samples in
-      let samples = tail samples in
-      print (printFun s);
-      print " ";
-      printLn (float2string w);
-      printSamples weights samples
-  in
   printLn (float2string (normConstant res.0));
-  printSamples res.0 res.1
+  printSamples printFun res.0 res.1

--- a/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
@@ -32,6 +32,7 @@ lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist
     let weight = i (app_ (i (recordproj_ "logObserve" t.dist)) t.value) in
     i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
   | TmWeight t ->
+    let i = withInfo t.info in
     i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
   | TmResample t -> withInfo t.info unit_
   | t -> t

--- a/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/naive-mcmc/compile.mc
@@ -20,16 +20,19 @@ lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist
     t
 
   sem transformProb =
-  | TmAssume t -> withInfo t.info (app_ (recordproj_ "sample" t.dist) unit_)
+  | TmAssume t ->
+    let i = withInfo t.info in
+    i (app_ (i (recordproj_ "sample" t.dist)) (i unit_))
 
   -- NOTE(dlunde,2022-05-16): Note that we cannot stop immediately when the
   -- weight becomes 0 (-inf in log-space). For this, we need CPS, PCFGs, or
   -- maybe some type of exception handler.
   | TmObserve t ->
-    let weight = withInfo t.info (app_ (recordproj_ "logObserve" t.dist) t.value) in
-    withInfo t.info (appf2_ (var_ "updateWeight") weight (var_ "state"))
+    let i = withInfo t.info in
+    let weight = i (app_ (i (recordproj_ "logObserve" t.dist)) t.value) in
+    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
   | TmWeight t ->
-    withInfo t.info (appf2_ (var_ "updateWeight") t.weight (var_ "state"))
+    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
   | TmResample t -> withInfo t.info unit_
   | t -> t
 

--- a/coreppl/src/coreppl-to-mexpr/naive-mcmc/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/naive-mcmc/runtime.mc
@@ -60,18 +60,7 @@ let run : all a. (State -> a) -> (Res a -> ()) -> () = lam model. lam printResFu
     ) sweeps
 
 let printRes : all a. (a -> String) -> Res a -> () = lam printFun. lam res.
-  recursive let printSamples = lam weights. lam samples.
-    if null weights then () else
-      let w = head weights in
-      let weights = tail weights in
-      let s = head samples in
-      let samples = tail samples in
-      print (printFun s);
-      print " ";
-      printLn (float2string w);
-      printSamples weights samples
-  in
   -- NOTE(dlunde,2022-05-23): I don't think printing the norm. const makes
   -- sense for MCMC
   -- printLn (float2string (normConstant res.0));
-  printSamples res.0 res.1
+  printSamples printFun res.0 res.1

--- a/coreppl/src/coreppl-to-mexpr/runtime/common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/common.mc
@@ -125,7 +125,7 @@ let printSamples : all a. (a -> String) -> [Float] -> [a] -> () =
         let samples = tail samples in
         print (printFun s);
         print " ";
-        printLn (float2string w);
+        print (float2string w); print "\n";
         rec weights samples
     in rec weights samples
 
@@ -140,6 +140,6 @@ let printSamplesOption : all a. (a -> String) -> [Float] -> [Option a] -> () =
         (match s with Some s then print (printFun s)
          else print ".");
         print " ";
-        printLn (float2string w);
+        print (float2string w); print "\n";
         rec weights samples
     in rec weights samples

--- a/coreppl/src/coreppl-to-mexpr/runtime/common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/common.mc
@@ -112,3 +112,17 @@ let output = lam res. lam names.
   let varianceVals = variance res expVals in
   printStatistics res names nc expVals varianceVals;
   saveCSV res names "data.csv" expOnLogWeights
+
+let printSamples : all a. (a -> String) -> [Float] -> [a] -> () =
+  lam printFun. lam weights. lam samples.
+    recursive let rec : [Float] -> [a] -> () = lam weights. lam samples.
+      if null weights then () else
+        let w = head weights in
+        let weights = tail weights in
+        let s = head samples in
+        let samples = tail samples in
+        print (printFun s);
+        print " ";
+        printLn (float2string w);
+        rec weights samples
+    in rec weights samples

--- a/coreppl/src/coreppl-to-mexpr/runtime/common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/common.mc
@@ -5,6 +5,7 @@ include "seq.mc"
 include "string.mc"
 
 type Res a = ([Float],[a])
+type ResOption a = ([Float],[Option a])
 
 -- Returns the number of particles/points from the program argument
 let numarg = lam.
@@ -122,6 +123,21 @@ let printSamples : all a. (a -> String) -> [Float] -> [a] -> () =
         let s = head samples in
         let samples = tail samples in
         print (printFun s);
+        print " ";
+        printLn (float2string w);
+        rec weights samples
+    in rec weights samples
+
+let printSamplesOption : all a. (a -> String) -> [Float] -> [Option a] -> () =
+  lam printFun. lam weights. lam samples.
+    recursive let rec : [Float] -> [Option a] -> () = lam weights. lam samples.
+      if null weights then () else
+        let w = head weights in
+        let weights = tail weights in
+        let s = head samples in
+        let samples = tail samples in
+        (match s with Some s then print (printFun s)
+         else print ".");
         print " ";
         printLn (float2string w);
         rec weights samples

--- a/coreppl/src/coreppl-to-mexpr/runtime/common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/common.mc
@@ -106,13 +106,14 @@ let expOnLogWeights = lam res.
 
 -- The output function. Prints normalizing constants, expected values, and variance
 -- to the standard output. Saves the plot data in a CSV file.
-let output = lam res. lam names.
-  let names = cons "#" names in
-  let nc = normConstant res in
-  let expVals = expectedValues res nc in
-  let varianceVals = variance res expVals in
-  printStatistics res names nc expVals varianceVals;
-  saveCSV res names "data.csv" expOnLogWeights
+-- NOTE(dlunde,2022-06-07): Does not currently type check
+-- let output = lam res. lam names.
+--   let names = cons "#" names in
+--   let nc = normConstant res in
+--   let expVals = expectedValues res nc in
+--   let varianceVals = variance res expVals in
+--   printStatistics res names nc expVals varianceVals;
+--   saveCSV res names "data.csv" expOnLogWeights
 
 let printSamples : all a. (a -> String) -> [Float] -> [a] -> () =
   lam printFun. lam weights. lam samples.

--- a/coreppl/src/coreppl-to-mexpr/runtime/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/dists.mc
@@ -1,6 +1,7 @@
 -- Runtime support for first-class distributions in coreppl-to-mexpr compiler.
 
 include "math.mc"
+include "seq.mc"
 include "ext/dist-ext.mc"
 
 type Dist a = { sample: () -> a, logObserve: a -> Float }

--- a/coreppl/src/coreppl-to-mexpr/runtime/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime/dists.mc
@@ -1,5 +1,6 @@
 -- Runtime support for first-class distributions in coreppl-to-mexpr compiler.
 
+include "math.mc"
 include "ext/dist-ext.mc"
 
 type Dist a = { sample: () -> a, logObserve: a -> Float }
@@ -18,11 +19,13 @@ let distBeta : Float -> Float -> Dist Float = lam a. lam b.
   { sample = lam. betaSample a b, logObserve = betaLogPdf a b }
 let distGaussian : Float -> Float -> Dist Float = lam mu. lam sigma.
   { sample = lam. gaussianSample mu sigma, logObserve = gaussianLogPdf mu sigma }
-let distMultinomial : Int -> [Float] -> Dist [Float] = lam n. lam p.
-  { sample = lam. multinomialSample n p, logObserve = multinomialLogPmf n p }
+let distMultinomial : Int -> [Float] -> Dist [Int] = lam n. lam p.
+  { sample = lam. multinomialSample p n,
+    logObserve = lam o.
+      if eqi n (foldl1 addi o) then multinomialLogPmf p o else negf (inf) }
 let distCategorical: [Float] -> Dist Int = lam p.
   { sample = lam. categoricalSample p, logObserve = categoricalLogPmf p }
-let distDirichlet: [Float] -> Dist Float = lam a.
+let distDirichlet: [Float] -> Dist [Float] = lam a.
   { sample = lam. dirichletSample a, logObserve = dirichletLogPdf a }
 let distUniform: Float -> Float -> Dist Float = lam a. lam b.
   { sample = lam. uniformContinuousSample a b, logObserve = uniformContinuousLogPdf a b }

--- a/coreppl/src/coreppl-to-mexpr/trace-mcmc/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/trace-mcmc/compile.mc
@@ -20,16 +20,20 @@ lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist
     t
 
   sem transformProb =
-  | TmAssume t -> withInfo t.info (app_ (var_ "sampleMH" ) t.dist)
+  | TmAssume t ->
+    let i = withInfo t.info in
+    i (app_ (i (var_ "sampleMH")) t.dist)
 
   -- NOTE(dlunde,2022-05-16): Note that we cannot stop immediately when the
   -- weight becomes 0 (-inf in log-space). For this, we need CPS, PCFGs, or
   -- maybe some type of exception handler.
   | TmObserve t ->
-    let weight = withInfo t.info (app_ (recordproj_ "logObserve" t.dist) t.value) in
-    withInfo t.info (appf1_ (var_ "updateWeight") weight)
+    let i = withInfo t.info in
+    let weight = i (app_ (i (recordproj_ "logObserve" t.dist)) t.value) in
+    i (appf1_ (i (var_ "updateWeight")) weight)
   | TmWeight t ->
-    withInfo t.info (appf1_ (var_ "updateWeight") t.weight)
+    let i = withInfo t.info in
+    i (appf1_ (i (var_ "updateWeight")) t.weight)
   | TmResample t -> withInfo t.info unit_
   | t -> t
 

--- a/coreppl/src/coreppl-to-mexpr/trace-mcmc/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/trace-mcmc/runtime.mc
@@ -125,15 +125,4 @@ let printRes : all a. (a -> String) -> Res a -> () = lam printFun. lam res.
   -- NOTE(dlunde,2022-05-23): I don't think printing the norm. const makes
   -- sense for MCMC
   -- printLn (float2string (normConstant res.0));
-  recursive let printSamples = lam weights. lam samples.
-    if null weights then () else
-      let w = head weights in
-      let weights = tail weights in
-      let s = head samples in
-      let samples = tail samples in
-      print (printFun s);
-      print " ";
-      printLn (float2string w);
-      printSamples weights samples
-  in
-  printSamples res.0 res.1
+  printSamples printFun res.0 res.1

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -251,10 +251,9 @@ lang Observe = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   | TmObserve t ->
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
-    let tyValue = newvar env.currentLvl t.info in
     let tyDistRes = newvar env.currentLvl t.info in
     unify [t.info] env (tyTm dist) (TyDist { info = t.info, ty = tyDistRes });
-    unify [t.info] env tyValue tyDistRes;
+    unify [t.info] env (tyTm value) tyDistRes;
     TmObserve {{{ t with value = value }
                     with dist = dist }
                     with ty = tyWithInfo t.info tyunit_ }

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -17,8 +17,8 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
              info: Info }
 
   syn Type =
-  | TyDist {info : Info,
-            ty   : Type}
+  | TyDist { info : Info,
+             ty   : Type }
 
   syn Dist =
   -- Intentionally left blank
@@ -128,6 +128,11 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   sem normalize (k : Expr -> Expr) =
   | TmDist ({ dist = dist } & t) ->
     normalizeDist (lam dist. k (TmDist { t with dist = dist })) dist
+
+  -- CPS
+  sem cpsCont k =
+  | TmLet ({ body = TmDist _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
 
   -- Type lift
   sem typeLiftDist (env : TypeLiftEnv) =

--- a/make
+++ b/make
@@ -3,7 +3,7 @@
 test () {
   set +e
   binary=$(mktemp)
-  compile_cmd="mi compile --test --typecheck --disable-optimizations --output $binary"
+  compile_cmd="mi compile --test --disable-optimizations --output $binary"
   output=$1
   output="$output\n$($compile_cmd $1 2>&1)"
   exit_code=$?


### PR DESCRIPTION
This PR depends on https://github.com/miking-lang/miking/pull/600.

## Major updates
- Add `importance-cps` inference algorithm to CorePPL -> MExpr compiler (see experiments below).
- General updates, fixes, and simplifications for the CorePPL -> MExpr compiler.
- Significantly simplify and refactor stochastic value flow and alignment analysis (inspired by @lingmar's hole CFA).

## Minor updates
- Remove `--typecheck` flag (now used as default for `mi`)
- Fix type checking bug for `observe`.

## Experiment

Execution time for `coreppl/models/crbd/crbd.mc` with `importance` and `importance-cps` inference methods. Early stop at -inf weight was disabled in `importance-cps` for fairness.

1000 particles: 0.094s `importance`, 0.262s `importance-cps`
10000 particles: 0.897s `importance`, 2.549s `importance-cps`
100000 particles: 8.863s `importance`, 24.704s `importance-cps`

That is, CPS version is approximately 2.8 times slower.

## Further comments
~~NOTE: Currently after CPS transformation in `importance-cps`, I strip _all_ type annotations from lambdas and lets, and let the type checker reinfer the types. However, I'm sure there are cases where this won't work. I believe @aathn is working on a fix (no rush though, my hack above seems to work for now).~~
Edit: I believe I found a solution. Actually, the types introduced by the CPS transformation need not be polymorphic: I think they should all be the same type: the top-level type of the program. All continuations ultimately return this type. This simplifies things significantly.

Also @aathn: Printing a program _after_ type checking it does not give parsable results because of unbound weak type variables (I think, the ones starting with `_`) in the output. Maybe this is an easy fix?
