### PR TITLE
Add checkpoint analysis to CorePPL

### DIFF
--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -714,7 +714,7 @@ utest _test false t ["t", "res"] with [
 -- ALIGNMENT TESTS --
 ---------------------
 
--- TODO Add missing tests for recursive lets!
+-- TODO(dlunde,2022-06-15): Add missing tests for recursive lets!
 
 let _test: Bool -> Expr -> [String] -> [([Char], Bool)] =
   lam debug. lam t. lam vars.

--- a/coreppl/src/coreppl-to-rootppl/compile.mc
+++ b/coreppl/src/coreppl-to-rootppl/compile.mc
@@ -1328,6 +1328,9 @@ let rootPPLCompile: Options -> Expr -> RPProg =
   -- ANF transformation
   let prog: Expr = normalizeTerm prog in
 
+  -- Type check (again, due to ANF externals...)
+  let prog: Expr = typeCheck prog in
+
   -- Resample at aligned weight if enabled
   let prog =
     -- Add resample after weights (given a predicate)

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -90,7 +90,7 @@ lang Infer =
                  with ty = symbolizeType env t.ty }
 
   -- Type check
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmInfer t ->
     let model = typeCheckExpr env t.model in
     let tyRes = newvar env.currentLvl t.info in
@@ -166,7 +166,7 @@ lang Assume = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
                   with ty = symbolizeType env t.ty }
 
   -- Type check
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmAssume t ->
     let dist = typeCheckExpr env t.dist in
     let tyRes = newvar env.currentLvl t.info in
@@ -247,7 +247,7 @@ lang Observe = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
                     with ty = symbolizeType env t.ty }
 
   -- Type check
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmObserve t ->
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
@@ -333,7 +333,7 @@ lang Weight =
                   with ty = symbolizeType env t.ty }
 
   -- Type check
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmWeight t ->
     let weight = typeCheckExpr env t.weight in
     unify [t.info] env (tyTm weight) (TyFloat { info = t.info });

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -110,7 +110,7 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   -- Type checking
   sem typeCheckDist : TCEnv -> Info -> Dist -> Type
   -- Intentionally left blank
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmDist t ->
     let dist = smapDist_Expr_Expr (typeCheckExpr env) t.dist in
     let innerTyDist = typeCheckDist env t.info dist in

--- a/coreppl/src/inference-common/smc.mc
+++ b/coreppl/src/inference-common/smc.mc
@@ -44,7 +44,7 @@ lang Resample = Ast + PrettyPrint + Eq + Sym + ANF + TypeLift
     TmResample { t with ty = symbolizeType env t.ty }
 
   -- Type check
-  sem typeCheckBase (env : TCEnv) =
+  sem typeCheckExpr (env : TCEnv) =
   | TmResample t -> TmResample { t with ty = tyWithInfo t.info tyunit_ }
 
   sem normalize (k : Expr -> Expr) =


### PR DESCRIPTION
- Add a checkpoint analysis to CorePPL to enable partial CPS transformations. **Note that this means it is now possible to efficiently implement inference algorithms requiring execution suspension in the CorePPL to MExpr compiler, such as SMC**. The checkpoint analysis discovers all expressions that may evaluate a "checkpoint expression" as part of its evaluation (the checkpoints are customizable through a semantic function). For example, given that `weight` (a CorePPL-specific term) is the sole checkpoint, the analysis result for
  ```
  let a = weight 1.0 in
  let b = assume (Bernoulli 0.5) in
  let c = addi 1 2 in
  c
  ```
  is that the expression labelled by `a` evaluates a checkpoint while `b` and `c` do not evaluate checkpoints.

  A slightly more elaborate example:
  ```
  let f = (lam x.
    let a = weight 1.0 in
    let b = assume (Bernoulli 0.5) in
    let c = addi 1 2 in
    c) in
  let g = (lam y.
    let a2 = assume (Bernoulli 0.5) in
    let b2 = addi 1 2 in
    b2) in
  let d = f 1 in
  let e = g 1 in
  e
  ```
  Here, the expressions labeled by `f`, `x`, `a`, and `d` evaluate checkpoints.

- Revise `mexpr-importance-cps` to use partial CPS instead of full CPS. Experiment results for `crbd.mc`:
  | | RootPPL* | Direct        | Partial CPS | Full CPS |
  | -----------      | ----------- | ------- | ---- | --- |
  | **1000 particles**     |  0.087 s |  0.094 s   | 0.126 s  |0.262 s |
  | **10000 particles**   | 0.846 s | 0.897 s        | 1.215 s | 2.549 s |
  | **100000 particles**  | 8.349 s | 8.863 s        | 11.94 s | 24.704 s |

  *No resampling, single CPU, compiled from CorePPL
- Add support for externals in stochastic value CFA.
- Simplify alignment analysis further (replace custom constraints with standard library constraints).

