### PR TITLE
Externals for TreePPL

### DIFF
--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -81,6 +81,17 @@ let parseMCorePPLFile = lam filename.
                   with allowFree = true} in
   makeKeywords [] (parseMCoreFile config filename)
 
+
+let parseMCorePPLFileNoDeadCodeElimination = lam filename.
+  use DPPLParser in
+  -- Read and parse the mcore file
+  let config = {{{{defaultBootParserParseMCoreFileArg
+                   with keepUtests = false}
+                   with keywords = pplKeywords}
+                   with eliminateDeadCode = false}
+                   with allowFree = true} in
+  makeKeywords [] (parseMCoreFile config filename)
+
 -- Similar to getAst, but calls parseMExprString instead
 let parseMExprPPLString = lam cpplstr.
   use DPPLParser in

--- a/treeppl/CHANGELOG.md
+++ b/treeppl/CHANGELOG.md
@@ -1,0 +1,23 @@
+# CHANGELOG
+
+## PR-candidate 2022-07-07 (externals-for-treeppl)
+
+This PR attempts to add externals support to TreePPL.
+
+We introduce two new functions, which may need to be moved to `externals.mc`
+
+	sem constructExternalMap : Expr -> Map String Name
+	sem filterExternalMap: Set String -> Expr -> Expr
+
+Then we parse a runtime, which only includes `dist-ext.mc` and `math-ext.mc`, we filter only the externals that we need, we run `symbolize` on the filtered externals, then we construct a map from the identifier strings to the Names for the externals, and finally we retrieve the Names of the externals that we need by searching this map. Finally, to use an external we utilize `(app_ (nvar_ NAME))`, whereas NAME is the name we just found and is passed around with a `TpplCompileContext` record.
+
+Currently, there is an issue in `mexprCompile`. To reproduce the issue, attempt to compile any of the examples:
+
+	miking-dppl/treeppl$ mi run src/tppl.mc -- models/externals/externals.tppl models/externals/data.mc 
+	checkpoint 1
+
+	FILE "/home/viktor/Dropbox/Work/miking/stdlib/ext/math-ext.mc" 25:0-25:37 ERROR: Error in exprName for CFA
+	external externalLog : Float -> Float
+
+	miking-dppl/treeppl$ 
+

--- a/treeppl/models/externals/data.mc
+++ b/treeppl/models/externals/data.mc
@@ -1,0 +1,4 @@
+-- This file is instead of IO
+-- The values should be supplied from "outside" somehow
+-- tree is provided by tree-instance.mc
+let p = 0.5

--- a/treeppl/models/externals/externals.mc
+++ b/treeppl/models/externals/externals.mc
@@ -1,0 +1,39 @@
+mexpr
+
+external externalExp : Float -> Float
+in
+external externalLog : Float -> Float
+in
+let p =
+  0.5
+in
+recursive
+  let foobar =
+    lam p: Float.
+      let e =
+        assume
+          (Bernoulli
+             p)
+      in
+      let ifCont =
+        lam #var"": Int.
+          e
+      in
+      match
+        e
+      with
+        true
+      then
+        let foo =
+          weight
+            (externalLog
+               2.)
+        in
+        ifCont
+          0
+      else
+        ifCont
+          0
+in
+foobar
+  p

--- a/treeppl/models/externals/externals.tppl
+++ b/treeppl/models/externals/externals.tppl
@@ -1,0 +1,7 @@
+model function foobar(p: Real) {
+  assume e ~ Bernoulli(p);
+  if e {
+    weight(2.0);
+  }
+  return(e);
+}

--- a/treeppl/models/flip/flip.mc
+++ b/treeppl/models/flip/flip.mc
@@ -16,6 +16,13 @@ in
 (flip 0.5)
 -/
 mexpr
+external externalExp : Float -> Float
+in
+external externalLog : Float -> Float
+in
+let p =
+  0.5
+in
 recursive
   let flip =
     lam p: Float.
@@ -25,9 +32,6 @@ recursive
              p)
       in
       e
-in
-let p =
-  0.5
 in
 flip
   p

--- a/treeppl/models/if/if.mc
+++ b/treeppl/models/if/if.mc
@@ -1,7 +1,11 @@
-include "math.mc"
-
 mexpr
-
+external externalExp : Float -> Float
+in
+external externalLog : Float -> Float
+in
+let p =
+  0.5
+in
 recursive
   let iftest =
     lam p: Float.
@@ -61,17 +65,6 @@ recursive
         in
         ifCont
           0
-  let flip =
-    lam p: Float.
-      let e =
-        assume
-          (Bernoulli
-             p)
-      in
-      e
-in
-let p =
-  0.5
 in
 iftest
   p

--- a/treeppl/src/externals/ext.mc
+++ b/treeppl/src/externals/ext.mc
@@ -1,0 +1,23 @@
+-- 1. We define this `ext.mc` which contains the includes needed for log, etc. 
+-- external functions
+include "ext/dist-ext.mc"
+include "ext/math-ext.mc"
+
+-- 2. We parse this file to Expr
+-- let externals = parseMCoreFile "src/externals/ext.mc" in
+
+-- 3. We bind this, as well as our input, to the AST we're generating
+--   let input = bind_ externals input in
+-- and then in TmRecLets
+--   inexpr = bind_ input invocation
+
+-- 4. We need to get  the name for symbol that has the string "log"
+-- this is where I am stuck
+--   getExternalIds externals
+-- will give us a Set String
+-- but I am looking for a function like
+--   getNameFor "log" externals
+-- But I can't find that
+-- There is nameGetStr, but this is from Name -> Str
+-- 
+

--- a/treeppl/src/tppl.mc
+++ b/treeppl/src/tppl.mc
@@ -64,8 +64,9 @@ else -- defaulting to MExpr
     --printLn (mexprPPLToString corePplAst);
     --let prog = corePplAst in
     let prog: Expr = typeCheck corePplAst in
-    printLn "after typeCheck";
+    printLn "checkpoint 1";
     let ast = (mexprCompile options prog) in
+    printLn "checkpoint 2";
     writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));
 
     -- Output the compiled OCaml code (unless --skip-final is specified)

--- a/treeppl/src/tppl.mc
+++ b/treeppl/src/tppl.mc
@@ -64,9 +64,7 @@ else -- defaulting to MExpr
     --printLn (mexprPPLToString corePplAst);
     --let prog = corePplAst in
     let prog: Expr = typeCheck corePplAst in
-    printLn "checkpoint 1";
     let ast = (mexprCompile options prog) in
-    printLn "checkpoint 2";
     writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));
 
     -- Output the compiled OCaml code (unless --skip-final is specified)

--- a/treeppl/src/tppl.mc
+++ b/treeppl/src/tppl.mc
@@ -32,6 +32,7 @@ if eqString backend "rootppl" then
     --  TODO(vsenderov,2022-05-10): Maybe parse from the command line  
     let outfile = "out.cu" in
     let options = {default with method = "rootppl-smc"} in
+    printLn "NEVER!";
     let prog: Expr = typeCheck corePplAst in
     --let prog = corePplAst in
     writeFile outfile (printCompiledRPProg (rootPPLCompile options prog));
@@ -48,7 +49,7 @@ else -- defaulting to MExpr
     exit 0
   else match argv with [_, filename, data] in
   use BootParser in
-  let input = parseMCoreFile {defaultBootParserParseMCoreFileArg with   eliminateDeadCode = false}
+  let input = parseMCoreFile {defaultBootParserParseMCoreFileArg with eliminateDeadCode = false}
     data in
   let content = readFile filename in
   use TreePPLAst in
@@ -56,10 +57,14 @@ else -- defaulting to MExpr
   
   use TreePPLCompile in
     let corePplAst: Expr = compile input file in
+    --dprint corePplAst;
     --  TODO(vsenderov,2022-05-10): Maybe parse from the command line  
     let outName = "out.mc" in
     let options = { default with method = "mexpr-importance" } in
+    --printLn (mexprPPLToString corePplAst);
+    --let prog = corePplAst in
     let prog: Expr = typeCheck corePplAst in
+    printLn "after typeCheck";
     let ast = (mexprCompile options prog) in
     writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));
 

--- a/treeppl/src/treeppl-to-coreppl/compile.mc
+++ b/treeppl/src/treeppl-to-coreppl/compile.mc
@@ -296,19 +296,33 @@ mexpr
 -- test the flip example, TODO should iterate through the files instead
 let testTpplProgram = parseTreePPLFile "models/flip/flip.tppl" in
 let testInput = parseMCoreFile "models/flip/data.mc" in
-let testMCoreProgram = parseMCorePPLFile "models/flip/flip.mc" in
+let testMCoreProgram = parseMCorePPLFileNoDeadCodeElimination "models/flip/flip.mc" in
+
 
 -- Doesn't work TODO
 use MExprPPL in
 utest compileTreePPL testInput testTpplProgram with testMCoreProgram using eqExpr in
 
--- test the flip example, should iterate through the files instead
+-- test the if example, should iterate through the files instead
 let testTpplProgram = parseTreePPLFile "models/if/if.tppl" in
 let testInput = parseMCoreFile "models/if/data.mc" in
-let testMCoreProgram = parseMCorePPLFile "models/if/if.mc" in
+let testMCoreProgram = parseMCorePPLFileNoDeadCodeElimination "models/if/if.mc" in
 
-use MExprPPL in
+--debug pretty printing
+--use TreePPLCompile in
+--printLn (mexprToString testMCoreProgram);
+
+--use MExprPPL in
 utest compileTreePPL testInput testTpplProgram with testMCoreProgram using eqExpr in
+
+-- test the externals example, should iterate through the files instead
+let testTpplProgram = parseTreePPLFile "models/externals/externals.tppl" in
+let testInput = parseMCoreFile "models/externals/data.mc" in
+let testMCoreProgram = parseMCorePPLFileNoDeadCodeElimination "models/externals/externals.mc" in
+
+--use MExprPPL in
+utest compileTreePPL testInput testTpplProgram with testMCoreProgram using eqExpr in
+
 -- If you want to print out the strings, use the following:
 -- use MExprPPL in
 --utest compileTreePPLToString testInput testTpplProgram with (mexprPPLToString testMCoreProgram) using eqString in

--- a/treeppl/src/treeppl-to-coreppl/compile.mc
+++ b/treeppl/src/treeppl-to-coreppl/compile.mc
@@ -14,6 +14,7 @@ include "treeppl-ast.mc"
 include "mexpr/ast.mc"
 include "mexpr/boot-parser.mc"
 include "mexpr/type-check.mc"
+
 include "sys.mc"
 
 include "../../../coreppl/src/coreppl-to-mexpr/compile.mc"
@@ -21,21 +22,65 @@ include "../../../coreppl/src/coreppl-to-rootppl/compile.mc"
 include "../../../coreppl/src/coreppl.mc"
 include "../../../coreppl/src/parser.mc"
 
-lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst 
-  sem compile: Expr -> FileTppl -> Expr
-  sem compile (input: Expr) =
+-- Version of parseMCoreFile needed to get input data into the program
+let parseMCoreFile = lam filename.
+  use BootParser in
+    parseMCoreFile
+      {defaultBootParserParseMCoreFileArg with eliminateDeadCode = false}
+        filename
 
+lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym
+-- TODO If this works it should go to externals
+  sem constructExternalMap : Expr -> Map String Name
+  sem constructExternalMap =
+  | expr -> constructExternalMapH (mapEmpty cmpString) expr
+  sem constructExternalMapH : Map String Name -> Expr -> Map String Name
+  sem constructExternalMapH acc =
+  | TmExt t -> constructExternalMapH (mapInsert (nameGetStr t.ident) t.ident acc) t.inexpr
+  | expr -> sfold_Expr_Expr constructExternalMapH acc expr
+
+  -- smap_Expr_Expr, sfold_Expr_Expr explained in recursion cookbook
+  sem filterExternalMap: Set String -> Expr -> Expr
+  sem filterExternalMap ids =
+  | TmExt t ->
+    let inexpr = filterExternalMap ids t.inexpr in
+    --if (nameGetStr t.ident) in ids then TmExt {t with inexpr = inexpr}
+    match setMem (nameGetStr t.ident) ids with true then TmExt {t with inexpr = inexpr}
+    else inexpr
+  | expr -> smap_Expr_Expr (filterExternalMap ids) expr
+  | TmLet t -> filterExternalMap ids t.inexpr -- strips all the lets
+
+  -- a type with useful information passed down from compile
+  type TpplCompileContext = {
+    logName: Name,
+    expName: Name
+  }
+
+  sem compile: Expr -> FileTppl -> Expr
+
+  sem compile (input: Expr) =
   | FileTppl x -> 
+      let externals = parseMCoreFile "src/externals/ext.mc" in
+      let exts = setOfSeq cmpString ["externalLog", "externalExp"] in
+      let externals = filterExternalMap exts externals in  -- strip everything but needed stuff from externals
+      let externals = symbolize externals in
+      let externalMap = constructExternalMap externals in
+      let compileContext: TpplCompileContext = {
+        logName = mapFindExn "externalLog" externalMap,
+        expName = mapFindExn "externalExp" externalMap
+      } in
+      let input = bind_ externals input in
+      --dprint x;
       let invocation = match findMap mInvocation x.decl with Some x
         then x
         else printLn "You need a model function"; never
       in 
-      TmRecLets {
-        bindings = map compileTpplDecl x.decl,
-        inexpr = bind_ input invocation,
+      bind_ input (TmRecLets {
+        bindings = map (compileTpplDecl compileContext) x.decl,
+        inexpr = invocation,
         ty = tyunknown_, 
         info = x.info
-      }
+      })
 
   sem mInvocation: DeclTppl -> Option Expr
   sem mInvocation = 
@@ -70,14 +115,14 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst
       frozen = false 
     } 
 
-  sem compileTpplDecl: DeclTppl -> RecLetBinding
-  sem compileTpplDecl = 
+  sem compileTpplDecl: TpplCompileContext -> DeclTppl -> RecLetBinding
+  sem compileTpplDecl (context: TpplCompileContext) = 
 
   | FunDeclTppl f -> {
         ident = f.name.v,
         tyBody = tyunknown_,
         body = 
-          foldr (lam f. lam e. f e) unit_ (concat (map compileFunArg f.args) (map compileStmtTppl f.body)),          
+          foldr (lam f. lam e. f e) unit_ (concat (map compileFunArg f.args) (map (compileStmtTppl context) f.body)),          
         info = f.info
       }   
 
@@ -110,9 +155,9 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst
     info = x.info
   }
 
-  sem compileStmtTppl: StmtTppl -> (Expr -> Expr)
+  sem compileStmtTppl: TpplCompileContext -> StmtTppl -> (Expr -> Expr)
 
-  sem compileStmtTppl = 
+  sem compileStmtTppl (context: TpplCompileContext) = 
 
   | AssumeStmtTppl a -> 
   lam cont. TmLet {
@@ -139,18 +184,25 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst
   }
 
   | WeightStmtTppl a ->
-  lam cont. TmLet {
+  lam cont. 
+
+  let cExpr: Expr = (compileExprTppl a.value) in
+  let logExpr: Expr = withInfo a.info (app_ (nvar_ context.logName) cExpr) in
+  let tmp = TmLet {
     ident = nameNoSym "foo", 
     tyBody = tyunknown_, 
     body =  TmWeight {
-      weight = compileExprTppl a.value,
+      weight = logExpr,
+      --weight = cExpr,
       ty = tyunknown_,
       info = a.info
     },
     inexpr = cont,
     ty = tyunknown_,
     info = a.info
-  }
+  } in
+  --printLn (mexprPPLToString tmp);
+  tmp
 
   /--
   To avoid code duplication.
@@ -178,8 +230,8 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst
       inexpr = TmMatch {
         target = compileExprTppl a.condition,
         pat    = ptrue_,
-        thn    = foldr (lam f. lam e. f e) cont (map compileStmtTppl a.ifTrueStmts),		 
-        els    = foldr (lam f. lam e. f e) cont (map compileStmtTppl a.ifFalseStmts),	 
+        thn    = foldr (lam f. lam e. f e) cont (map (compileStmtTppl context) a.ifTrueStmts),		 
+        els    = foldr (lam f. lam e. f e) cont (map (compileStmtTppl context) a.ifFalseStmts),	 
         ty     = tyunknown_,
         info   = a.info
       }
@@ -219,12 +271,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst
 
 end
 
--- Version of parseMCoreFile needed to get input data into the program
-let parseMCoreFile = lam filename.
-  use BootParser in
-    parseMCoreFile
-      {defaultBootParserParseMCoreFileArg with eliminateDeadCode = false}
-        filename
+
 
 -- Parses a TreePPL file
 let parseTreePPLFile = lam filename.


### PR DESCRIPTION
This PR attempts to add externals support to TreePPL.

We introduce two new functions, which may need to be moved to `externals.mc`

	sem constructExternalMap : Expr -> Map String Name
	sem filterExternalMap: Set String -> Expr -> Expr

Then we parse a runtime, which only includes `dist-ext.mc` and `math-ext.mc`, we filter only the externals that we need, we run `symbolize` on the filtered externals, then we construct a map from the identifier strings to the Names for the externals, and finally we retrieve the Names of the externals that we need by searching this map. Finally, to use an external we utilize `(app_ (nvar_ NAME))`, whereas NAME is the name we just found and is passed around with a `TpplCompileContext` record.

Currently, there is an issue in `mexprCompile`. To reproduce the issue, attempt to compile any of the examples:

	miking-dppl/treeppl$ mi run src/tppl.mc -- models/externals/externals.tppl models/externals/data.mc 
	checkpoint 1

	FILE "/home/viktor/Dropbox/Work/miking/stdlib/ext/math-ext.mc" 25:0-25:37 ERROR: Error in exprName for CFA
	external externalLog : Float -> Float

	miking-dppl/treeppl$ 

