### PR TITLE
Remove RootPPL isnan check on both CPU and GPU

### DIFF
--- a/rootppl/src/inference/smc/resample/systematic/kernels.cu
+++ b/rootppl/src/inference/smc/resample/systematic/kernels.cu
@@ -17,17 +17,11 @@ __global__ void scaleExpWeightsAndSquareWeightsKernel(floating_t* w, int numPart
 
     floating_t localW = w[idx];
 
-    if (isnan(localW))
-        localW = -INFINITY;
-
     localW = exp(localW - maxLogWeight);
 
     w[idx] = localW;
 
-    if (isnan(localW))
-        wSquared[idx] = 0;
-    else
-        wSquared[idx] = localW * localW;
+    wSquared[idx] = localW * localW;
 
 }
 

--- a/rootppl/src/inference/smc/resample/systematic/systematic_cpu.cu
+++ b/rootppl/src/inference/smc/resample/systematic/systematic_cpu.cu
@@ -22,8 +22,6 @@ HOST std::tuple<floating_t, floating_t> calcLogWeightSumAndESSCpu(floating_t* w,
     // Corresponds to ExpWeightsKernel used in the parallel implementation
     #pragma omp parallel for
     for(int i = 0; i < numParticles; i++) {
-        if (isnan(w[i]))
-            w[i] = -INFINITY;
         w[i] = exp(w[i] - maxLogWeight);
     }
 
@@ -50,8 +48,7 @@ HOST floating_t calcESSHelperCpu(floating_t* scaledW, floating_t scaledWeightSum
     floating_t wScaledSumOfSquares = 0;
     #pragma omp parallel for reduction (+:wScaledSumOfSquares)
     for(int i = 0; i < numParticles; i++) {
-        if (! isnan(scaledW[i]))
-            wScaledSumOfSquares += scaledW[i] * scaledW[i];
+      wScaledSumOfSquares += scaledW[i] * scaledW[i];
     }
 
     floating_t wSumSquared = scaledWeightSum * scaledWeightSum;


### PR DESCRIPTION
Currently, there is a check for `NaN` weights in the RootPPL SMC inference code that simply changes such weights to -infinity. This is not really a sound approach, as `NaN` weights are (arguably) an issue in the model itself. Furthermore, this check results in inconsistent behavior when running on CPU and GPU, as the GPU uses the Thrust library for many operations that are directly implemented (without a library) on the CPU.

This PR simply removes the check for both GPU and CPU, and transfers the `NaN`-check responsibility to the model developers.

Related issues that can be closed after this PR is merged: https://github.com/miking-lang/miking-dppl/issues/103, https://github.com/miking-lang/miking-dppl/issues/57, https://github.com/miking-lang/miking-dppl/issues/44