### PR TITLE
Backward compatibility updates after #109

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/apf/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/apf/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang APFMethod = InferMethodBase + MExprAst
+lang APFMethod = MExprPPL
   syn InferMethod =
   | APF {particles : Expr}
 
@@ -30,4 +29,11 @@ lang APFMethod = InferMethodBase + MExprAst
     let particles = typeCheckExpr env particles in
     unify [info, infoTm particles] env (tyTm particles) int;
     APF {particles = particles}
+
+  sem symbolizeInferMethod env =
+  | APF r -> APF {r with particles = symbolizeExpr env r.particles}
+
+  sem setRuns expr =
+  | APF r -> APF {r with particles = expr}
+
 end

--- a/coreppl/src/coreppl-to-mexpr/apf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/apf/runtime.mc
@@ -95,5 +95,4 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> Dist a =
   match runRec particles with (weights,samples) in
   -- Return
   constructDistEmpirical samples weights
-    -- TODO(dlunde,2022-10-20): Add normconst
-    (EmpNorm {normConst = negf 1.0})
+    (EmpNorm {normConst = normConstant weights})

--- a/coreppl/src/coreppl-to-mexpr/bpf/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/bpf/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang BPFMethod = InferMethodBase + MExprAst
+lang BPFMethod = MExprPPL
   syn InferMethod =
   | BPF {particles : Expr}
 
@@ -30,4 +29,11 @@ lang BPFMethod = InferMethodBase + MExprAst
     let particles = typeCheckExpr env particles in
     unify [info, infoTm particles] env (tyTm particles) int;
     BPF {particles = particles}
+
+  sem symbolizeInferMethod env =
+  | BPF r -> BPF {r with particles = symbolizeExpr env r.particles}
+
+  sem setRuns expr =
+  | BPF r -> BPF {r with particles = expr}
+
 end

--- a/coreppl/src/coreppl-to-mexpr/bpf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/bpf/runtime.mc
@@ -69,5 +69,4 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> Dist a =
 
   -- Return
   constructDistEmpirical samples weights
-    -- TODO(dlunde,2022-10-20): Add normconst
-    (EmpNorm {normConst = negf 1.0})
+    (EmpNorm {normConst = normConstant weights})

--- a/coreppl/src/coreppl-to-mexpr/importance/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang ImportanceSamplingMethod = InferMethodBase + MExprAst
+lang ImportanceSamplingMethod = MExprPPL
   syn InferMethod =
   | Importance {particles : Expr}
 
@@ -30,4 +29,11 @@ lang ImportanceSamplingMethod = InferMethodBase + MExprAst
     let particles = typeCheckExpr env particles in
     unify [info, infoTm particles] env (tyTm particles) int;
     Importance {particles = particles}
+
+  sem symbolizeInferMethod env =
+  | Importance r -> Importance {r with particles = symbolizeExpr env r.particles}
+
+  sem setRuns expr =
+  | Importance r -> Importance {r with particles = expr}
+
 end

--- a/coreppl/src/coreppl-to-mexpr/importance/runtime-cps.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/runtime-cps.mc
@@ -62,5 +62,4 @@ let run : all a. Unknown -> (State -> Stop a) -> Dist a = lam config. lam model.
 
   match foldl2 filterNone ([], []) states res with (weightsRev, resRev) in
   constructDistEmpirical (reverse resRev) weightsRev
-    -- TODO(dlunde,2022-10-19): Properly extract the normalizing constant
-    (EmpNorm { normConst = negf 1.0 })
+    (EmpNorm { normConst = normConstant weightsRev })

--- a/coreppl/src/coreppl-to-mexpr/importance/runtime-cps.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/runtime-cps.mc
@@ -60,6 +60,11 @@ let run : all a. Unknown -> (State -> Stop a) -> Dist a = lam config. lam model.
   let states = createList particles (lam. ref weightInit) in
   let res = mapReverse (importance model) states in
 
+  -- NOTE(dlunde,2022-10-27): It is very important that we compute the
+  -- normalizing constant _before_ discarding the None values in filterNone.
+  -- Otherwise the normalizing constant estimate is incorrect!
+  let normConst = normConstant weightsRev in
+
   match foldl2 filterNone ([], []) states res with (weightsRev, resRev) in
   constructDistEmpirical (reverse resRev) weightsRev
-    (EmpNorm { normConst = normConstant weightsRev })
+    (EmpNorm { normConst = normConst })

--- a/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/importance/runtime.mc
@@ -27,6 +27,6 @@ let run : all a. Unknown -> (State -> a) -> Dist a = lam config. lam model.
   let weightInit = 0.0 in
   let states = createList particles (lam. ref weightInit) in
   let res = mapReverse model states in
-  constructDistEmpirical (reverse res) (mapReverse deref states)
-    -- TODO(dlunde,2022-10-19): Properly extract the normalizing constant
-    (EmpNorm { normConst = negf 1.0 })
+  let weights = mapReverse deref states in
+  constructDistEmpirical (reverse res) weights
+    (EmpNorm { normConst = normConstant weights })

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang LightweightMCMCMethod = InferMethodBase + MExprAst
+lang LightweightMCMCMethod = MExprPPL
   syn InferMethod =
   | LightweightMCMC {
       iterations : Expr, -- Type Int
@@ -61,4 +60,15 @@ lang LightweightMCMCMethod = InferMethodBase + MExprAst
       aligned = aligned,
       globalProb = globalProb
     }
+
+  sem symbolizeInferMethod env =
+  | LightweightMCMC r ->
+    LightweightMCMC {r with
+      iterations = symbolizeExpr env r.iterations,
+      aligned = symbolizeExpr env r.aligned,
+      globalProb = symbolizeExpr env r.globalProb
+    }
+
+  sem setRuns expr =
+  | LightweightMCMC r -> LightweightMCMC {r with iterations = expr}
 end

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
@@ -247,10 +247,6 @@ let run : all a. Unknown -> (State -> a) -> Dist a =
     (reverse weights, reverse samples)
   in
 
-  (if compileOptions.printAcceptanceRate then
-    printLn (float2string (mcmcAcceptRate ()))
-  else ());
-
   -- Return
   use RuntimeDist in
   constructDistEmpirical res.1 (create runs (lam. 1.))

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime.mc
@@ -209,10 +209,6 @@ let run : all a. Unknown -> (State -> a) -> Dist a =
     (reverse weights, reverse samples)
   in
 
-  (if compileOptions.printAcceptanceRate then
-    printLn (float2string (mcmcAcceptRate ()))
-  else ());
-
   -- Return
   constructDistEmpirical res.1 (create runs (lam. 1.))
     (EmpMCMC { acceptRate = mcmcAcceptRate () })

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang NaiveMCMCMethod = InferMethodBase + MExprAst
+lang NaiveMCMCMethod = MExprPPL
   syn InferMethod =
   | NaiveMCMC {
       iterations : Expr -- Type Int
@@ -41,4 +40,12 @@ lang NaiveMCMCMethod = InferMethodBase + MExprAst
     NaiveMCMC {
       iterations = iterations
     }
+
+  sem symbolizeInferMethod env =
+  | NaiveMCMC r ->
+    NaiveMCMC {r with iterations = symbolizeExpr env r.iterations}
+
+  sem setRuns expr =
+  | NaiveMCMC r -> NaiveMCMC {r with iterations = expr}
+
 end

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/runtime.mc
@@ -56,11 +56,6 @@ let run : all a. Unknown -> (State -> a) -> Dist a =
     (reverse weights, reverse samples)
   in
 
-  (if compileOptions.printAcceptanceRate then
-    printLn (float2string (mcmcAcceptRate ()))
-  else ());
-
   -- Return
   constructDistEmpirical res.1 (create runs (lam. 1.))
-    -- TODO(dlunde,2022-10-20): Add normconst
     (EmpMCMC { acceptRate = mcmcAcceptRate () })

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/method.mc
@@ -1,7 +1,6 @@
-include "mexpr/ast.mc"
-include "../../infer-method.mc"
+include "../../coreppl.mc"
 
-lang TraceMCMCMethod = InferMethodBase + MExprAst
+lang TraceMCMCMethod = MExprPPL
   syn InferMethod =
   | TraceMCMC {
       iterations : Expr -- Type Int
@@ -41,4 +40,12 @@ lang TraceMCMCMethod = InferMethodBase + MExprAst
     TraceMCMC {
       iterations = iterations
     }
+
+  sem symbolizeInferMethod env =
+  | TraceMCMC r ->
+    TraceMCMC {r with iterations = symbolizeExpr env r.iterations}
+
+  sem setRuns expr =
+  | TraceMCMC r -> TraceMCMC {r with iterations = expr}
+
 end

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/runtime.mc
@@ -119,10 +119,6 @@ let run : all a. Unknown -> (State -> a) -> Dist a =
       (reverse weights, reverse samples)
     in
 
-    (if compileOptions.printAcceptanceRate then
-      printLn (float2string (mcmcAcceptRate ()))
-    else ());
-
   -- Return
   constructDistEmpirical res.1 (create runs (lam. 1.))
     -- TODO(dlunde,2022-10-20): Add normconst

--- a/coreppl/src/coreppl-to-mexpr/runtime-common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-common.mc
@@ -67,15 +67,10 @@ let systematicSample: all a. [a] -> [Float] -> Float -> Int -> [a] = lam seq. la
 
 -- Computing the normalization constant using the log-sum-exp trick
 let normConstant : [Float] -> Float = lam res.
-  let negInf = (divf (negf 1.) 0.) in
+  let negInf = divf (negf 1.) 0. in
   let max = foldl (lam acc. lam x. if geqf x acc then x else acc) negInf res in
-  match foldl
-    (lam acc. lam x.
-       if eqf x (negf inf) then acc else
-         (addf (exp (subf x max)) acc.0, addi 1 acc.1)
-    ) (0., 0) res
-  with (sum,count) in
-  subf (addf max (log sum)) (log (int2float count))
+  let sum = foldl (lam acc. lam x. addf (exp (subf x max)) acc) 0. res in
+  subf (addf max (log sum)) (log (int2float (length res)))
 
 -- Computes the expected value for all variables. Returns
 -- a list that excludes the weight component and only contains

--- a/coreppl/src/coreppl-to-mexpr/top.mc
+++ b/coreppl/src/coreppl-to-mexpr/top.mc
@@ -1,0 +1,39 @@
+-- This file containing _CorePPL_ (not MExpr) code defines functions used when
+-- compiling CorePPL in "global" mode, where `infer` is not used and the entire
+-- program is the model.
+
+-- Needed for int2string
+include "string.mc"
+
+-- Needed for bool2string
+include "bool.mc"
+
+-- Needed for repeat
+include "common.mc"
+
+-- Print samples
+let printSamples = lam printFun. lam dist.
+  recursive let rec = lam weights. lam samples.
+    match (weights, samples) with ([w] ++ weights, [s] ++ samples) then
+      print (printFun s);
+      print " ";
+      print (float2string w);
+      print "\n";
+      rec weights samples
+    else ()
+  in
+  match distEmpiricalSamples dist with (samples, weights) in
+  rec weights samples
+
+-- Print normalizing constant
+let printNormConst = lam dist.
+  print (float2string (distEmpiricalNormConst dist)); print "\n"
+
+-- Print accept rate
+let printAcceptRate = lam dist.
+  print (float2string (distEmpiricalAcceptRate dist)); print "\n"
+
+-- The number of particles/samples/executions and sweeps from the program argument
+let particles = if leqi (length argv) 1 then particles else string2int (get argv 1)
+
+let sweeps = if leqi (length argv) 2 then 1 else string2int (get argv 2)

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -85,8 +85,9 @@ lang Infer =
   -- Symbolize
   sem symbolizeExpr (env: SymEnv) =
   | TmInfer t ->
-    TmInfer {{ t with model = symbolizeExpr env t.model }
-                 with ty = symbolizeType env t.ty }
+    TmInfer {{{ t with model = symbolizeExpr env t.model }
+                  with ty = symbolizeType env t.ty }
+                  with method = symbolizeInferMethod env t.method }
 
   -- Type check
   sem typeCheckExpr (env : TCEnv) =

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -98,4 +98,10 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod
+
+  -- Symbolizes infer methods.
+  sem symbolizeInferMethod : SymEnv -> InferMethod -> InferMethod
+
+  -- Overrides the number of runs/iterations/particles in the InferMethod
+  sem setRuns : Expr -> InferMethod -> InferMethod
 end

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -125,7 +125,6 @@ let parseMCorePPLFile = lam filename.
   let ast = symbolizeAllowFree ast in
   makeKeywords ast
 
-
 let parseMCorePPLFileNoDeadCodeElimination = lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
@@ -137,6 +136,18 @@ let parseMCorePPLFileNoDeadCodeElimination = lam filename.
                    builtin = builtin} in
   let ast = parseMCoreFile config filename in
   let ast = symbolizeAllowFree ast in
+  makeKeywords ast
+
+let parseMCorePPLFileLib = lam filename.
+  use DPPLParser in
+  -- Read and parse the mcore file
+  let config = {defaultBootParserParseMCoreFileArg with
+                   keepUtests = false,
+                   keywords = pplKeywords,
+                   eliminateDeadCode = false,
+                   allowFree = true,
+                   builtin = builtin} in
+  let ast = parseMCoreFile config filename in
   makeKeywords ast
 
 -- Similar to getAst, but calls parseMExprString instead

--- a/test.mk
+++ b/test.mk
@@ -2,7 +2,7 @@
 
 # Include all .mc files but ignore files under coreppl-to-mexpr that starts
 # with "runtime" (they cannot be executed standalone)
-test-files=$(shell find coreppl/src -name "*.mc" -not \( -path "*coreppl-to-mexpr/*" -name "runtime*.mc" \))
+test-files=$(shell find coreppl/src -name "*.mc" -not \( -path "*coreppl-to-mexpr/*" \( -name "runtime*.mc" -or -name "top.mc" \) \))
 test-files+=coreppl/src/coreppl-to-mexpr/runtimes.mc
 
 # NOTE(dlunde,2021-10-27): Cannot yet be compiled


### PR DESCRIPTION
This PR contains various fixes after https://github.com/miking-lang/miking-dppl/pull/109, especially concerning backward compatibility.

- Make the top-level mode (the "old" mode without any `infer`s in the program) behave as before:
  - Print the normalizing constant before samples when using BPF, APF, and IS.
  - Print the accept rate for MCMC methods if `--print-accept-rate` is given to `cppl` when compiling.
  - Get the number of iterations/particles from the first argument on the command line to the compiled binary, and the number of "sweeps" from the second argument. The `-p` command used at compile time with `cppl` provides a default if there are no command line arguments. Some examples:
     - `cppl -m mexpr-importance -p 10`, `./out` => 10 particles, 1 sweep
     - `cppl -m mexpr-importance -p 10`, `./out 5` => 5 particles, 1 sweep
     - `cppl -m mexpr-importance -p 10`, `./out 20 3` => 20 particles, 3 sweeps.
  - Readd support for printing `TyInt` and `TyBool` results.
- Add missing `symbolizeInferMethod`.
- Add normalizing constant calculations to BPF, APF, and IS.
