### PR TITLE
Particle Independent Metropolis-Hastings inference method

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -311,5 +311,6 @@ utest compileModel "mexpr-bpf" simple with () using truefn in
 utest compileModel "mexpr-mcmc-naive" simple with () using truefn in
 utest compileModel "mexpr-mcmc-trace" simple with () using truefn in
 utest compileModel "mexpr-mcmc-lightweight" simple with () using truefn in
+utest compileModel "mexpr-pmcmc-pimh" simple with () using truefn in
 
 ()

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
@@ -1,0 +1,76 @@
+include "../dists.mc"
+include "../../inference-common/smc.mc"
+include "../../cfa.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/cps.mc"
+
+lang MExprPPLPIMH =
+  MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll + MExprPPLCFA
+
+  -- CPS compile
+  sem exprCps env k =
+  | TmLet ({ body = TmAssume _ } & t) ->
+    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmObserve _ } & t) ->
+    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmWeight _ } & t) ->
+    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmDist _ } & t) ->
+    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet { ident = ident, body = TmResample {},
+            inexpr = inexpr } & t ->
+    let i = withInfo (infoTm t) in
+    let k =
+      if tailCall t then
+        match k with Some k then
+          k
+        else
+          error "Something went wrong with partial CPS transformation"
+      else
+        i (nulam_ ident (exprCps env k inexpr))
+    in
+      i (appf1_ (i (var_ "resample")) k)
+
+  sem transformProb =
+  | TmAssume t ->
+    let i = withInfo t.info in
+    i (app_ (i (var_ "sample")) t.dist)
+  | TmResample t -> errorSingle [t.info] "Impossible"
+  | TmObserve t ->
+    let i = withInfo t.info in
+    let weight = i (appf2_ (i (var_ "logObserve")) t.dist t.value) in
+    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
+  | TmWeight t ->
+    let i = withInfo t.info in
+    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
+  | t -> t
+
+  sem compile: Options -> (Expr,Expr) -> Expr
+  sem compile options =
+  | (_,t) ->
+    -- Static analysis and CPS transformation
+    let t =
+      let cont = (ulam_ "x" (conapp_ "End" (var_ "x"))) in
+      match options.cps with "partial" then
+        let checkpoint = lam t.
+          match t with TmLet { ident = ident, body = body } then
+            match body with TmResample _ then true else false
+          else
+            errorSingle [infoTm t] "Impossible"
+        in
+        let checkPointNames: Set Name = extractCheckpoint (checkpointCfa checkpoint t) in
+        cpsPartialCont checkPointNames cont t
+      else match options.cps with "full" then
+        cpsFullCont cont t
+      else
+        error (join ["Invalid CPS option:", options.cps])
+    in
+    -- Transform distributions to MExpr distributions
+    let t = mapPre_Expr_Expr transformTmDist t in
+    -- Transform samples, observes, and weights to MExpr
+    let t = mapPre_Expr_Expr transformProb t in
+    t
+end
+
+let compilerPIMH = lam options. use MExprPPLPIMH in
+  ("pmcmc-pimh/runtime.mc", compile options)

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/method.mc
@@ -1,0 +1,55 @@
+include "../../coreppl.mc"
+
+lang PIMHMethod = MExprPPL
+  syn InferMethod =
+  | PIMH {
+      particles : Expr, -- Type Int
+      iterations : Expr -- Type Int
+    }
+
+  sem pprintInferMethod indent env =
+  | PIMH {iterations = iterations, particles = particles} ->
+    let i = pprintIncr indent in
+    match pprintCode i env particles with (env, particles) in
+    match pprintCode i env iterations with (env, iterations) in
+    (env, join [
+      "PIMH {interations = ", iterations, "particles = ", particles, "}"])
+
+  sem inferMethodFromCon info bindings =
+  | "PIMH" ->
+    match getFields info bindings ["particles"] with [particles] in
+    match getFields info bindings ["iterations"] with [iterations] in
+    PIMH {particles = particles, iterations = iterations}
+
+  sem inferMethodFromOptions options =
+  | "mexpr-pmcmc-pimh" ->
+    PIMH {
+      -- Reusing particles option for now for iterations, maybe we need a
+      -- better name
+      iterations = int_ options.particles,
+      particles = int_ options.pmcmcParticles
+    }
+
+  sem inferMethodConfig info =
+  | PIMH {iterations = iterations, particles = particles} ->
+    fieldsToRecord info [("iterations",iterations), ("particles", particles)]
+
+  sem typeCheckInferMethod env info =
+  | PIMH {iterations = iterations, particles = particles} ->
+    let int = TyInt {info = info} in
+    let iterations = typeCheckExpr env iterations in
+    let particles = typeCheckExpr env particles in
+    unify [info, infoTm iterations] env (tyTm iterations) int;
+    unify [info, infoTm particles] env (tyTm particles) int;
+    PIMH {iterations = iterations, particles = particles}
+
+  sem symbolizeInferMethod env =
+  | PIMH r -> PIMH {r with
+      iterations = symbolizeExpr env r.iterations,
+      particles = symbolizeExpr env r.particles
+    }
+
+  sem setRuns expr =
+  | PIMH r -> PIMH {r with iterations = expr}
+
+end

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/runtime.mc
@@ -1,0 +1,164 @@
+include "common.mc"
+include "ext/dist-ext.mc"
+include "ext/math-ext.mc"
+include "seq.mc"
+include "string.mc"
+
+include "../runtime-common.mc"
+include "../runtime-dists.mc"
+
+type Checkpoint a
+con Resample : all a. {k : () -> Checkpoint a} -> Checkpoint a
+con End : all a. a -> Checkpoint a
+
+type State = Ref Float
+
+let resample = lam k. Resample {k = k}
+
+let updateWeight = lam weight. lam state.
+  modref state (addf (deref state) weight)
+
+let run =
+  lam config. lam model.
+  use RuntimeDist in
+
+  let lse = lam xs.
+    let maxx =
+      foldl (lam acc. lam x. if geqf x acc then x else acc) (negf inf) xs
+    in
+    addf maxx (log (foldl (lam acc. lam x. addf acc (exp (subf x maxx))) 0. xs))
+  in
+
+  --------------
+  -- SMC PART --
+  --------------
+
+  -- Internal SMC Algorithm, for now the bootstrap particle filter.
+
+  -- TODO(oerikss, 2022-11-01): We could parametrize this algorithm by its
+  -- internal SMC algorithm.
+
+  -- WARNING: As of now, particles must be started and propagated sequentially
+  -- (they cannot run in parallel)!
+
+  let particleCount = config.particles in
+  let logParticleCount = log (int2float particleCount) in
+
+  let runSMC = lam.
+    let state = ref 0. in
+    let start = lam.
+      modref state 0.;
+      let checkpoint = model state in
+      {
+        weight = deref state,
+        checkpoint = checkpoint
+      }
+    in
+    let propagate = lam particle. lam contWeight.
+      modref state contWeight;
+      switch particle.checkpoint
+      case Resample {k = k} then
+        let checkpoint = k () in
+        {
+          weight = deref state,
+          checkpoint = checkpoint
+        }
+      case End _ then particle
+      end
+    in
+    recursive let runRec = lam t.
+      match t with (particles, evidence) in
+      if forAll
+          (lam p. match p.checkpoint with End _ then true else false) particles
+      then
+        (unzip
+          (mapReverse (lam p. (p.weight, match p.checkpoint with End a in a))
+            particles),
+        evidence)
+      else
+        let maxWeight =
+          foldl
+            (lam acc. lam p. if geqf p.weight acc then p.weight else acc)
+            (negf inf)
+            particles
+        in
+        let expWeights = map (lam p. exp (subf p.weight maxWeight)) particles in
+        let sums =
+          foldl
+            (lam acc. lam w. (addf acc.0 w, addf acc.1 (mulf w w)))
+            (0., 0.)
+            expWeights
+        in
+        let ess = divf (mulf sums.0 sums.0) sums.1 in
+        if ltf (mulf 0.7 (int2float particleCount)) ess then
+          let particles = mapReverse (lam p. propagate p p.weight) particles in
+          runRec (particles, evidence)
+        else
+          let contWeight =
+            subf (addf maxWeight (log sums.0)) logParticleCount
+          in
+          let resampled =
+            systematicSample particles expWeights sums.0 particleCount
+          in
+          let particles = mapReverse (lam p. propagate p contWeight) resampled in
+          runRec (particles, addf evidence contWeight)
+    in
+    let particles = createList particleCount start in
+    runRec (particles, 0.)
+  in
+
+  -------------
+  -- MH PART --
+  -------------
+
+  -- Metropolis Hastings iteration
+  recursive let mh =
+    lam evidences. lam weightss. lam sampless. lam iter.
+      if leqi iter 0 then (sampless, weightss, evidences)
+      else
+        -- Compute a new proposal with a particle filter sweep
+        match runSMC () with ((samples, weights), evidence) in
+        let prevEvidence = head evidences in
+        let prevSamples = head sampless in
+        let prevWeights = head weightss in
+        let logMhAcceptProb = minf 0. (subf evidence prevEvidence) in
+        let iter = subi iter 1 in
+        if bernoulliSample (exp logMhAcceptProb) then
+          mcmcAccept ();
+          mh
+            (cons evidence evidences)
+            (cons weights weightss)
+            (cons samples sampless)
+            iter
+        else
+          mh
+            (cons prevEvidence evidences)
+            (cons prevWeights weightss)
+            (cons prevSamples sampless)
+            iter
+  in
+
+  -- Initialization
+  let runs = config.iterations in
+
+  -- Used to keep track of acceptance ratio
+  mcmcAcceptInit runs;
+
+  -- Initial sample
+  match runSMC () with ((samples, weights), evidence) in
+  let iter = subi runs 1 in
+
+  -- Draw remaining samples
+  match mh [evidence] [weights] [samples] iter with (sampless, _, evidences) in
+
+  -- Reverse to get the correct order and flatten
+  let samples = join (reverse (sampless)) in
+  -- TODO(oerikss, 2022-11-02): what weights should we use
+  -- let weights = create runs (lam. 1.) in
+  let weights =
+    join (map (lam evidence. create particleCount (lam. evidence)) evidences)
+  in
+
+  -- Return
+  constructDistEmpirical samples weights
+    (EmpMCMC { acceptRate = mcmcAcceptRate () })

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -12,6 +12,7 @@ include "importance/compile.mc"
 include "mcmc-naive/compile.mc"
 include "mcmc-trace/compile.mc"
 include "mcmc-lightweight/compile.mc"
+include "pmcmc-pimh/compile.mc"
 
 lang LoadRuntime =
   DPPLParser + MExprSym + MExprFindSym + MExprEliminateDuplicateCode
@@ -53,6 +54,7 @@ lang LoadRuntime =
   | LightweightMCMC _ -> compilerLightweightMCMC options
   | NaiveMCMC _ -> compilerNaiveMCMC options
   | TraceMCMC _ -> compilerTraceMCMC options
+  | PIMH _ -> compilerPIMH options
   | _ -> error "Unsupported CorePPL to MExpr inference method"
 
   sem loadRuntimes : Options -> Expr -> Map InferMethod RuntimeEntry

--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -90,12 +90,18 @@ lang CPPLLang =
                 "mexpr-mcmc-naive"
               | "mexpr-mcmc-trace"
               | "mexpr-mcmc-lightweight"
+              | "mexpr-pmcmc-pimh"
             then
               if options.printAcceptanceRate then
                 app_ (var_ "printAcceptRate") (var_ "d")
               else
                 unit_
-            else error "Inference algorithm not supported in global mode"
+            else error
+              (join [
+                "Inference algorithm ",
+                options.method,
+                " not supported in global mode"
+              ])
           ),
 
         if options.printSamples then

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -36,7 +36,10 @@ type Options = {
   mcmcLightweightReuseLocal: Bool, -- Currently has no effect
 
   -- MCMC options,
-  printAcceptanceRate: Bool
+  printAcceptanceRate: Bool,
+
+  -- PMCMC particle count
+  pmcmcParticles: Int
 }
 
 -- Default values for options
@@ -57,7 +60,8 @@ let default = {
   debugMExprCompile = true,
   mcmcLightweightGlobalProb = 0.1,
   mcmcLightweightReuseLocal = true,
-  printAcceptanceRate = false
+  printAcceptanceRate = false,
+  pmcmcParticles = 2
 }
 
 -- Options configuration
@@ -139,7 +143,15 @@ let config = [
   ([("--print-accept-rate", "", "")],
     "Prints the acceptance rate of MCMC algorithms.",
     lam p: ArgPart Options.
-      let o: Options = p.options in {o with printAcceptanceRate = true})
+      let o: Options = p.options in {o with printAcceptanceRate = true}),
+  ([("--pmcmcParticles", " ", "<particles>")],
+    join [
+      "The number of particles for the smc proposal computation. The default is ",
+      (int2string default.pmcmcParticles),
+      ". This option is used if one of the following methods are used: mexpr-pmcmc-*."
+    ],
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with particles = argToIntMin p 1})
 ]
 
 -- Menu
@@ -149,4 +161,3 @@ let menu = lam. join [
   argHelpOptions config,
   "\n"
 ]
-

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -14,13 +14,15 @@ include "coreppl-to-mexpr/importance/method.mc"
 include "coreppl-to-mexpr/mcmc-lightweight/method.mc"
 include "coreppl-to-mexpr/mcmc-naive/method.mc"
 include "coreppl-to-mexpr/mcmc-trace/method.mc"
+include "coreppl-to-mexpr/pmcmc-pimh/method.mc"
 
 lang DPPLParser =
   BootParser + MExprPrettyPrint + MExprPPL + Resample +
   ProbabilisticGraphicalModel + KeywordMaker +
 
   ImportanceSamplingMethod + BPFMethod + APFMethod +
-  LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod
+  LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod +
+	PIMHMethod
 
   -- Interprets the argument to infer which encodes the inference method and
   -- its configuration parameters.


### PR DESCRIPTION
This PR adds the Particle Independent Metropolis-Hastings inference method to coreppl. The implementation is based on the one described in [A Compilation Target for Probabilistic Programming Languages, Brooks and Wood](http://arxiv.org/abs/1403.0504).

The method is currently only tested on a small hello world model. Before merge we should:
- [ ] Test the method on a more complicated model, e.g. CRBD.
- [ ] Decide on what weights we should provide for each outputted sample. Currently it is the evidence for each proposal. This is different compared to other MCMC methods that gives an equal weight to all samples. Someone with more experience can probably decide on this.
- [ ]  Add the algorithm to the help-text printed by the cppl executable to make it official.

Note that this PR add an additional parameter `--pmcmcParticles` that states the number of particles to use when computing proposals for PMCMC methods. The current state of the CLI argument configuration prevented me from using the option `-p` for this purpose. The CLI arguments configuration probably needs an overhaul when time is given.