### PR TITLE
Changes to Makefile and the BPF's and APF's runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ tppl_name=tpplc
 plot_name=dppl-plot
 bin_path=${HOME}/.local/bin
 src_path=${HOME}/.local/src/coreppl/
-cppl_src=coreppl/src/
+cppl_src=coreppl/src/.
 
 rootppl_bin_path = $(HOME)/.local/bin/rppl
 rootppl_src_path=$(HOME)/.local/src/rootppl/
 rootppl_bin = rootppl/rppl
-rootppl_src = rootppl/src/
+rootppl_src = rootppl/src/.
 
 all: build/${cppl_name}
 
@@ -37,7 +37,7 @@ install: build/${cppl_name}
 	mkdir -p $(bin_path) $(src_path);
 	cp build/${cppl_name} ${bin_path}/${exec_name}
 	chmod +x ${bin_path}/${exec_name}
-	cp -rfT $(cppl_src) $(src_path)
+	cp -rf $(cppl_src) $(src_path)
 
 # Scripts
 	cp -f scripts/${plot_name} ${bin_path}/.
@@ -46,7 +46,7 @@ install: build/${cppl_name}
 # RootPPL
 	mkdir -p $(dir $(rootppl_bin_path)) $(rootppl_src_path);
 	cp -f $(rootppl_bin) $(rootppl_bin_path)
-	cp -rfT $(rootppl_src) $(rootppl_src_path)
+	cp -rf $(rootppl_src) $(rootppl_src_path)
 
 uninstall:
 # CorePPL
@@ -82,7 +82,7 @@ test-boot:
 install-rootppl:
 	mkdir -p $(dir $(rootppl_bin_path)) $(rootppl_src_path);
 	cp -f $(rootppl_bin) $(rootppl_bin_path)
-	cp -rfT $(rootppl_src) $(rootppl_src_path)
+	cp -rf $(rootppl_src) $(rootppl_src_path)
 
 uninstall-rootppl:
 	rm -rf $(rootppl_bin_path)

--- a/coreppl/src/coreppl-to-mexpr/apf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/apf/runtime.mc
@@ -45,7 +45,7 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> Dist a =
   in
   let propagate = lam particles.
     let maxWeight = foldl (lam acc. lam p. if geqf p.weight acc then p.weight else acc) negInf particles in
-    let expWeights = map (lam p. exp (subf p.weight maxWeight)) particles in
+    let expWeights = reverse (mapReverse (lam p. exp (subf p.weight maxWeight)) particles) in
     let expWeightSum = foldl (lam acc. lam w. (addf acc w)) 0. expWeights in
     let propagations = foldl (lam acc. lam p. (addi acc p.propagations)) 0 particles in
     let contWeight = subf (addf maxWeight (log expWeightSum)) (log (int2float (subi propagations 1))) in

--- a/coreppl/src/coreppl-to-mexpr/bpf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/bpf/runtime.mc
@@ -52,7 +52,7 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> Dist a =
       unzip (mapReverse (lam p. (p.weight, match p.checkpoint with End a in a)) particles)
     else
       let maxWeight = foldl (lam acc. lam p. if geqf p.weight acc then p.weight else acc) (negf inf) particles in
-      let expWeights = map (lam p. exp (subf p.weight maxWeight)) particles in
+      let expWeights = reverse (mapReverse (lam p. exp (subf p.weight maxWeight)) particles) in
       let sums = foldl (lam acc. lam w. (addf acc.0 w, addf acc.1 (mulf w w))) (0., 0.) expWeights in
       let ess = divf (mulf sums.0 sums.0) sums.1 in
       if ltf (mulf 0.7 (int2float particleCount)) ess then


### PR DESCRIPTION
This PR fixes two issues:

- MacOS's cp does not support the -T parameter.
- Stack overflows when using the BFP and APF inference engines.