### PR TITLE
Update for or-pattern and tyAnnot changes in Miking repo

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/backcompat.mc
+++ b/coreppl/src/coreppl-to-mexpr/backcompat.mc
@@ -89,6 +89,7 @@ lang CPPLBackcompat = LoadRuntime
         ulet_ "ast"
           (TmLam {
             ident = nameNoSym "",
+            tyAnnot = TyRecord {fields = mapEmpty cmpSID, info = infoTm ast},
             tyIdent = TyRecord {fields = mapEmpty cmpSID, info = infoTm ast},
             body = ast, ty = TyUnknown {info = infoTm ast}, info = infoTm ast
           }),

--- a/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
@@ -89,8 +89,8 @@ lang MExprPPLImportance =
   | TmResample t -> withInfo t.info unit_
 
   -- Should already have been removed by CPS!
-  | (TmObserve t | TmWeight t) ->
-    errorSingle [t.info] "Impossible in importance sampling with CPS"
+  | (TmObserve _ | TmWeight _) & tm ->
+    errorSingle [infoTm tm] "Impossible in importance sampling with CPS"
   | t -> t
 
   sem compileCps : Options -> (Expr,Expr) -> Expr

--- a/coreppl/src/extract.mc
+++ b/coreppl/src/extract.mc
@@ -69,9 +69,11 @@ lang DPPLExtract = DPPLParser + MExprExtract + MExprLambdaLift
     let info = t.info in
     let inferBinding = TmLet {
       ident = inferId,
+      tyAnnot = tyarrow_ tyunit_ (tyTm t.model),
       tyBody = tyarrow_ tyunit_ (tyTm t.model),
       body = TmLam {
         ident = nameNoSym "",
+        tyAnnot = tyunit_,
         tyIdent = tyunit_,
         body = TmApp {
           lhs = t.model, rhs = unit_, ty = tyTm t.model, info = info},


### PR DESCRIPTION
Updates the code to be compatible with PRs https://github.com/miking-lang/miking/pull/644 and https://github.com/miking-lang/miking/pull/646 in the main repo.

Should be merged after https://github.com/miking-lang/miking/pull/646.

For anyone who wants to compile miking-dppl before https://github.com/miking-lang/miking/pull/646 and this branch are merged, only apply the change to [coreppl/src/coreppl-to-mexpr/is-lw/compile.mc](https://github.com/miking-lang/miking-dppl/pull/119/files#diff-b6abbb67c88fc02b44c68edacb34034bc2803589ea226773943a952829cd883f).