### PR TITLE
Add optimization to reuse empirical priors in BPF

### DIFF
--- a/coreppl/models/infer-loop.mc
+++ b/coreppl/models/infer-loop.mc
@@ -1,0 +1,39 @@
+include "common.mc"
+include "math.mc"
+include "string.mc"
+
+let inferModel = lam prior. lam.
+  let x = assume prior in
+  observe true (Bernoulli x);
+  x
+
+-- Repeatedly run inference on the prior until we get a 1 from randIntU.
+recursive let loop : Dist Float -> Dist Float = lam prior.
+  let posterior = infer (BPF {particles = 10}) (inferModel prior) in
+  if eqi (randIntU 0 2) 1 then
+    posterior
+  else loop posterior
+end
+
+let printRes = lam printFun. lam dist.
+  match distEmpiricalSamples dist with (samples, weights) in
+  recursive let work = lam samples. lam weights.
+    match (samples, weights) with ([s] ++ samples, [w] ++ weights) then
+      print (printFun s);
+      print " ";
+      print (float2string w);
+      print "\n";
+      work samples weights
+    else ()
+  in work samples weights
+
+let printDist = lam dist.
+  (if distEmpiricalDegenerate dist then
+    printLn "Empirical distribution has only negative infinity weights"
+  else printRes float2string dist);
+  printLn (create 20 (lam. '='))
+
+mexpr
+
+let dist = loop (Uniform 0.0 1.0) in
+printDist dist

--- a/coreppl/models/infer-loop.mc
+++ b/coreppl/models/infer-loop.mc
@@ -3,6 +3,7 @@ include "math.mc"
 include "string.mc"
 
 let inferModel = lam prior. lam.
+  match prior with prior in
   let x = assume prior in
   observe true (Bernoulli x); resample;
   x

--- a/coreppl/models/infer-loop.mc
+++ b/coreppl/models/infer-loop.mc
@@ -4,7 +4,7 @@ include "string.mc"
 
 let inferModel = lam prior. lam.
   let x = assume prior in
-  observe true (Bernoulli x);
+  observe true (Bernoulli x); resample;
   x
 
 -- Repeatedly run inference on the prior until we get a 1 from randIntU.

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -77,6 +77,7 @@ lang TransformDist = MExprPPL
   sem replaceTyDist =
   | t ->
     let t = smap_Expr_Type toRuntimeTyDist t in
+    let t = smap_Expr_TypeLabel toRuntimeTyDist t in
     let t = smap_Expr_Pat replaceTyDistPat t in
     let t = smap_Expr_Expr replaceTyDist t in
     withType (toRuntimeTyDist (tyTm t)) t

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -48,6 +48,11 @@ lang MExprPPLBPF =
   sem compile: Options -> (Expr,Expr) -> Expr
   sem compile options =
   | (_,t) ->
+
+    -- printLn ""; printLn "--- INITIAL ANF PROGRAM ---";
+    -- match pprintCode 0 pprintEnvEmpty t with (env,str) in
+    -- printLn (str);
+
     -- Static analysis and CPS transformation
     let t =
       let cont = (ulam_ "x" (conapp_ "End" (var_ "x"))) in

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -35,10 +35,7 @@ lang MExprPPLBPF =
   sem transformStopFirstAssume =
 
   -- Terms that cannot execute an assume internally (in ANF)
-  | TmLet ({
-      body = TmVar _ | TmLam _ | TmConst _ | TmSeq _
-           | TmRecord _ | TmType _ | TmConDef _ | TmExt _
-      } & r) ->
+  | TmLet ({body = TmVar _ | TmLam _ | TmConst _ | TmSeq _ | TmRecord _} & r) ->
       match transformStopFirstAssume r.inexpr with Some inexpr then
         Some (TmLet { r with inexpr = inexpr })
       else None ()
@@ -46,6 +43,21 @@ lang MExprPPLBPF =
   | TmRecLets r ->
     match transformStopFirstAssume r.inexpr with Some inexpr then
       Some (TmRecLets { r with inexpr = inexpr })
+    else None ()
+
+  | TmExt r ->
+    match transformStopFirstAssume r.inexpr with Some inexpr then
+      Some (TmExt {r with inexpr = inexpr})
+    else None ()
+
+  | TmType r ->
+    match transformStopFirstAssume r.inexpr with Some inexpr then
+      Some (TmType {r with inexpr = inexpr})
+    else None ()
+
+  | TmConDef r ->
+    match transformStopFirstAssume r.inexpr with Some inexpr then
+      Some (TmConDef {r with inexpr = inexpr})
     else None ()
 
   -- Allow tail call match with single branch

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -31,6 +31,39 @@ lang MExprPPLBPF =
     in
       i (appf1_ (i (var_ "resample")) k)
 
+  sem transformStopFirstAssume: Expr -> Option Expr
+  sem transformStopFirstAssume =
+
+  -- Terms that cannot execute an assume internally (in ANF)
+  | TmLet ({
+      body = TmVar _ | TmLam _ | TmConst _ | TmSeq _
+           | TmRecord _ | TmType _ | TmConDef _ | TmExt _
+      } & r) ->
+      match transformStopFirstAssume r.inexpr with Some inexpr then
+        Some (TmLet { r with inexpr = inexpr })
+      else None ()
+
+  | TmRecLets r ->
+    match transformStopFirstAssume r.inexpr with Some inexpr then
+      Some (TmRecLets { r with inexpr = inexpr })
+    else None ()
+
+  -- Allow tail call match with single branch
+  | TmLet ({ ident = ident, body = TmMatch ({ thn = thn, els = TmNever _ } & rm),
+            inexpr = TmVar { ident = varIdent } } & r) ->
+    if nameEq ident varIdent then
+      match transformStopFirstAssume thn with Some thn then
+        Some (TmLet { r with body = TmMatch { rm with thn = thn } })
+      else None ()
+    else None ()
+
+  -- If we reach an assume, do the transformation
+  | TmLet { ident = ident, body = TmAssume r, inexpr = inexpr, info = info } ->
+    let i = withInfo info in
+    Some (i (appf2_ (i (var_ "stopFirstAssume")) r.dist (i (nulam_ ident inexpr))))
+
+  | t -> None ()
+
   sem transformProb =
   | TmAssume t ->
     let i = withInfo t.info in
@@ -70,11 +103,28 @@ lang MExprPPLBPF =
       else
         error (join ["Invalid CPS option:", options.cps])
     in
+
+    -- Attempt to identify and stop at first assume to potentially reuse
+    -- previous empirical distribution (see runtime)
+    let t =
+      match transformStopFirstAssume t with Some t then t
+      else
+        let i = withInfo (infoTm t) in
+        i (app_ (i (var_ "stopInit")) (i (ulam_ "" t)))
+    in
+
+    -- printLn ""; printLn "--- AFTER ---";
+    -- match pprintCode 0 env t with (env,str) in
+    -- printLn (str);
+
     -- Transform distributions to MExpr distributions
     let t = mapPre_Expr_Expr transformTmDist t in
+
     -- Transform samples, observes, and weights to MExpr
     let t = mapPre_Expr_Expr transformProb t in
+
     t
+
 end
 
 let compilerBPF = lam options. use MExprPPLBPF in

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -60,13 +60,10 @@ lang MExprPPLBPF =
       Some (TmConDef {r with inexpr = inexpr})
     else None ()
 
-  -- Allow tail call match with single branch
-  | TmLet ({ ident = ident, body = TmMatch ({ thn = thn, els = TmNever _ } & rm),
-            inexpr = TmVar { ident = varIdent } } & r) ->
-    if nameEq ident varIdent then
-      match transformStopFirstAssume thn with Some thn then
-        Some (TmLet { r with body = TmMatch { rm with thn = thn } })
-      else None ()
+  -- Allow tail call match with single branch (e.g., `match ... with ... in ...`)
+  | TmMatch ({ thn = thn, els = TmLet { body = TmNever _ } & els } & r)->
+    match transformStopFirstAssume thn with Some thn then
+      Some (TmMatch { r with thn = thn, els = withInfo (infoTm els) never_ })
     else None ()
 
   -- If we reach an assume, do the transformation

--- a/coreppl/src/extract.mc
+++ b/coreppl/src/extract.mc
@@ -4,6 +4,7 @@ include "parser.mc"
 include "name.mc"
 include "mexpr/extract.mc"
 include "mexpr/lamlift.mc"
+include "pmexpr/utils.mc"
 
 lang DPPLExtract = DPPLParser + MExprExtract + MExprLambdaLift
   type ModelRepr = {
@@ -89,7 +90,8 @@ lang DPPLExtract = DPPLParser + MExprExtract + MExprLambdaLift
   sem extractInferAst inferId =
   | ast ->
     let ast = extractAst (setOfSeq nameCmp [inferId]) ast in
-    inlineInferBinding inferId ast
+    let ast = inlineInferBinding inferId ast in
+    inlineInexpr (mapEmpty nameCmp) ast
 
   -- Inlines the body of the infer binding without lambdas. This places the
   -- model code in the top-level of the program.
@@ -116,6 +118,49 @@ lang DPPLExtract = DPPLParser + MExprExtract + MExprLambdaLift
                         inexpr = inexpr}
     else TmRecLets {t with inexpr = inlineInferBinding inferId t.inexpr}
   | t -> smap_Expr_Expr (inlineInferBinding inferId) t
+
+  -- Performs repeated inlining of the final inexpr, which contains the actual
+  -- model, until we have inlined the function itself.
+  sem inlineInexpr : Map Name Expr -> Expr -> Expr
+  sem inlineInexpr env =
+  | TmLet t ->
+    TmLet {t with inexpr = inlineInexpr (mapInsert t.ident t.body env) t.inexpr}
+  | TmRecLets t ->
+    let env =
+      foldl (lam env. lam bind. mapInsert bind.ident bind.body env)
+        env t.bindings in
+    TmRecLets {t with inexpr = inlineInexpr env t.inexpr}
+  | TmType t -> TmType {t with inexpr = inlineInexpr env t.inexpr}
+  | TmConDef t -> TmConDef {t with inexpr = inlineInexpr env t.inexpr}
+  | TmUtest t -> TmUtest {t with next = inlineInexpr env t.next}
+  | TmExt t -> TmExt {t with inexpr = inlineInexpr env t.inexpr}
+  | t -> inlineDirectApplication env t
+
+  sem inlineDirectApplication : Map Name Expr -> Expr -> Expr
+  sem inlineDirectApplication env =
+  | t ->
+    recursive let replaceArgs = lam subMap. lam body. lam args.
+      switch (body, args)
+      case (TmLam t, [arg] ++ args) then
+        let subMap = mapInsert t.ident arg subMap in
+        replaceArgs subMap t.body args
+      case (t, []) then substitute subMap t
+      end
+    in
+    match collectAppArguments t with (TmVar {ident = id}, args & ![]) then
+      match mapLookup id env with Some body then
+        inlineDirectApplication env (replaceArgs (mapEmpty nameCmp) body args)
+      else
+        errorSingle [infoTm t]
+          (join ["Reference to undefined function ", nameGetStr id])
+    else t
+
+  sem substitute : Map Name Expr -> Expr -> Expr
+  sem substitute subMap =
+  | TmVar t ->
+    match mapLookup t.ident subMap with Some e then e
+    else TmVar t
+  | t -> smap_Expr_Expr (substitute subMap) t
 
   sem bodyWithoutLambdas : Expr -> Expr
   sem bodyWithoutLambdas =


### PR DESCRIPTION
This PR includes:
- An optimization that reuses empirical priors in BPF.
- Further fixes after recent changes to type checking in Miking.

This PR should be merged **simultaneously** with https://github.com/miking-lang/miking/pull/649.