### PR TITLE
Additional fixes after latest changes in Miking

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -220,7 +220,7 @@ lang MExprCompile =
     let stateVarId = nameNoSym "state" in
     let ast =
       nulet_ modelId
-        (nlams_ (snoc modelParams (stateVarId, ntycon_ entry.stateId)) ast) in
+        (nlams_ (snoc modelParams (stateVarId, entry.stateType)) ast) in
 
     -- Replace any occurrences of TyDist in the program with the runtime
     -- distribution type. This needs to be performed after the previous step as

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
@@ -161,7 +161,7 @@ let sampleUnaligned: all a. Int -> Dist a -> a = lam i. lam dist.
   unsafeCoerce sample
 
 -- Function to run new MH iterations.
-let runNext: all a. (State -> a) -> a = lam model.
+let runNext: all a. (State a -> a) -> a = lam model.
 
   -- Enable global modifications with probability gProb
   let gProb = compileOptions.mcmcLightweightGlobalProb in
@@ -224,7 +224,7 @@ let runNext: all a. (State -> a) -> a = lam model.
       emptyList emptyList
 
 -- General inference algorithm for aligned MCMC
-let run : all a. Unknown -> (State -> a) -> Dist a =
+let run : all a. Unknown -> (State a -> a) -> Dist a =
   lam config. lam model.
 
   recursive let mh : [Float] -> [a] -> Int -> ([Float], [a]) =

--- a/coreppl/src/inference-common/smc.mc
+++ b/coreppl/src/inference-common/smc.mc
@@ -106,7 +106,7 @@ let foldToSeq = lam a. lam e. cons e a in
 
 utest smap_Expr_Expr mapVar resample_ with resample_ using eqExpr in
 
-utest sfold_Expr_Expr foldToSeq [] resample_ with [] in
+utest sfold_Expr_Expr foldToSeq [] resample_ with [] using eqSeq eqExpr in
 
 
 ---------------------


### PR DESCRIPTION
This PR fixes a couple of errors that I found caused by the latest changes in Miking (`make test` passes after these changes, while it did not pass before):
1. A utest that compares with an empty sequence requires an explicit equality function following the updates to the utest generation.
2. The type alias `State` defined in the runtime code was used as a `TyCon` in the generated model function. To work with the recent aliasing updates, it is now constructed as a `TyAlias`, where the `display` field is the `TyCon` (as before), and the `content` is the aliased type.