### PR TITLE
Fix likelihood weighting bug

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/is-lw/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/runtime.mc
@@ -28,5 +28,5 @@ let run : all a. Unknown -> (State -> a) -> Dist a = lam config. lam model.
   let states = createList particles (lam. ref weightInit) in
   let res = mapReverse model states in
   let weights = mapReverse deref states in
-  constructDistEmpirical (reverse res) weights
+  constructDistEmpirical res weights
     (EmpNorm { normConst = normConstant weights })


### PR DESCRIPTION
This is a regression fix for a bug that affects the non-CPS runtime of the likelihood weighting inference algorithm (i.e., `-m mexpr-is-lw --cps none`).