### PR TITLE
Fix arguments to `unify`

### DIFF
--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -95,7 +95,7 @@ lang Infer =
     let model = typeCheckExpr env t.model in
     let method = typeCheckInferMethod env t.info t.method in
     let tyRes = newvar env.currentLvl t.info in
-    unify [t.info] (tyTm model) (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes);
+    unify [infoTm model] (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
     TmInfer { t with model = model, method = method,
                      ty = TyDist {info = t.info, ty = tyRes} }
 
@@ -171,7 +171,7 @@ lang Assume = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   | TmAssume t ->
     let dist = typeCheckExpr env t.dist in
     let tyRes = newvar env.currentLvl t.info in
-    unify [t.info] (tyTm dist) (TyDist { info = t.info, ty = tyRes });
+    unify [infoTm dist] (TyDist { info = t.info, ty = tyRes }) (tyTm dist);
     TmAssume {{ t with dist = dist }
                   with ty = tyRes }
 
@@ -253,8 +253,8 @@ lang Observe = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
     let tyDistRes = newvar env.currentLvl t.info in
-    unify [t.info] (tyTm dist) (TyDist { info = t.info, ty = tyDistRes });
-    unify [t.info] (tyTm value) tyDistRes;
+    unify [infoTm dist] (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
+    unify [infoTm value] tyDistRes (tyTm value);
     TmObserve {{{ t with value = value }
                     with dist = dist }
                     with ty = tyWithInfo t.info tyunit_ }
@@ -337,7 +337,7 @@ lang Weight =
   sem typeCheckExpr (env : TCEnv) =
   | TmWeight t ->
     let weight = typeCheckExpr env t.weight in
-    unify [t.info] (tyTm weight) (TyFloat { info = t.info });
+    unify [infoTm weight] (TyFloat { info = t.info }) (tyTm weight);
     TmWeight {{ t with weight = weight }
                   with ty = tyWithInfo t.info tyunit_ }
 
@@ -547,4 +547,3 @@ utest (typeLift tmObserve).1 with tmObserve using eqExpr in
 utest (typeLift tmWeight).1 with tmWeight using eqExpr in
 
 ()
-


### PR DESCRIPTION
Fix arguments to `unify`

The recent PR in miking proper that changed the arguments to `unify` to be "expected" and "inferred" made some type errors print strangely when PPL constructs were involved. This change addresses that, and also takes the opportunity to use more specific `info` fields.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/miking-lang/miking-dppl/pull/127).
* #128 (12 commits)
* __->__ #127
