### PR TITLE
Update after changes to Miking codebase

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/backcompat.mc
+++ b/coreppl/src/coreppl-to-mexpr/backcompat.mc
@@ -90,7 +90,7 @@ lang CPPLBackcompat = LoadRuntime
           (TmLam {
             ident = nameNoSym "",
             tyAnnot = TyRecord {fields = mapEmpty cmpSID, info = infoTm ast},
-            tyIdent = TyRecord {fields = mapEmpty cmpSID, info = infoTm ast},
+            tyParam = TyRecord {fields = mapEmpty cmpSID, info = infoTm ast},
             body = ast, ty = TyUnknown {info = infoTm ast}, info = infoTm ast
           }),
         ulet_ "particles" (int_ options.particles),

--- a/coreppl/src/coreppl-to-mexpr/is-lw/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/method.mc
@@ -31,7 +31,7 @@ lang ImportanceSamplingMethod = MExprPPL
   | Importance {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in
-    unify [info, infoTm particles] (tyTm particles) int;
+    unify env [info, infoTm particles] int (tyTm particles);
     Importance {particles = particles}
 
   sem symbolizeInferMethod env =

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/method.mc
@@ -56,11 +56,11 @@ lang LightweightMCMCMethod = MExprPPL
     let bool = TyBool {info = info} in
     let float = TyFloat {info = info} in
     let iterations = typeCheckExpr env t.iterations in
-    unify [info, infoTm iterations] (tyTm iterations) int;
+    unify env [info, infoTm iterations] int (tyTm iterations);
     let aligned = typeCheckExpr env t.aligned in
-    unify [info, infoTm aligned] (tyTm aligned) bool;
+    unify env [info, infoTm aligned] bool (tyTm aligned);
     let globalProb = typeCheckExpr env t.globalProb in
-    unify [info, infoTm globalProb] (tyTm globalProb) float;
+    unify env [info, infoTm globalProb] float (tyTm globalProb);
     LightweightMCMC {
       iterations = iterations,
       aligned = aligned,

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/method.mc
@@ -39,7 +39,7 @@ lang NaiveMCMCMethod = MExprPPL
   | NaiveMCMC t ->
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env t.iterations in
-    unify [info, infoTm iterations] (tyTm iterations) int;
+    unify env [info, infoTm iterations] int (tyTm iterations);
     NaiveMCMC {
       iterations = iterations
     }

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/method.mc
@@ -39,7 +39,7 @@ lang TraceMCMCMethod = MExprPPL
   | TraceMCMC t ->
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env t.iterations in
-    unify [info, infoTm iterations] (tyTm iterations) int;
+    unify env [info, infoTm iterations] int (tyTm iterations);
     TraceMCMC {
       iterations = iterations
     }

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/method.mc
@@ -43,8 +43,8 @@ lang PIMHMethod = MExprPPL
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env iterations in
     let particles = typeCheckExpr env particles in
-    unify [info, infoTm iterations] (tyTm iterations) int;
-    unify [info, infoTm particles] (tyTm particles) int;
+    unify env [info, infoTm iterations] int (tyTm iterations);
+    unify env [info, infoTm particles] int (tyTm particles);
     PIMH {iterations = iterations, particles = particles}
 
   sem symbolizeInferMethod env =

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -181,12 +181,10 @@ lang LoadRuntime =
       optionGetOrElse (lam. id) (mapLookup id replacements)
     in
     let replaceInEnv = lam env. mapMapWithKey (lam. lam id. replaceId id) env in
-    let replaceInTyConEnv =
-      lam env. mapMapWithKey (lam. lam v. (replaceId v.0, v.1, v.2)) env in
     let replaceInSymEnv = lam symEnv.
       {symEnv with varEnv = replaceInEnv symEnv.varEnv,
                    conEnv = replaceInEnv symEnv.conEnv,
-                   tyConEnv = replaceInTyConEnv symEnv.tyConEnv}
+                   tyConEnv = replaceInEnv symEnv.tyConEnv}
     in
     {entry with topSymEnv = replaceInSymEnv entry.topSymEnv}
 end

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/method.mc
@@ -31,7 +31,7 @@ lang APFMethod = MExprPPL
   | APF {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in
-    unify [info, infoTm particles] (tyTm particles) int;
+    unify env [info, infoTm particles] int (tyTm particles);
     APF {particles = particles}
 
   sem symbolizeInferMethod env =

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/method.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/method.mc
@@ -31,7 +31,7 @@ lang BPFMethod = MExprPPL
   | BPF {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in
-    unify [info, infoTm particles] (tyTm particles) int;
+    unify env [info, infoTm particles] int (tyTm particles);
     BPF {particles = particles}
 
   sem symbolizeInferMethod env =

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -95,7 +95,7 @@ lang Infer =
     let model = typeCheckExpr env t.model in
     let method = typeCheckInferMethod env t.info t.method in
     let tyRes = newvar env.currentLvl t.info in
-    unify [infoTm model] (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
+    unify env [infoTm model] (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
     TmInfer { t with model = model, method = method,
                      ty = TyDist {info = t.info, ty = tyRes} }
 
@@ -171,7 +171,7 @@ lang Assume = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   | TmAssume t ->
     let dist = typeCheckExpr env t.dist in
     let tyRes = newvar env.currentLvl t.info in
-    unify [infoTm dist] (TyDist { info = t.info, ty = tyRes }) (tyTm dist);
+    unify env [infoTm dist] (TyDist { info = t.info, ty = tyRes }) (tyTm dist);
     TmAssume {{ t with dist = dist }
                   with ty = tyRes }
 
@@ -253,8 +253,8 @@ lang Observe = Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
     let tyDistRes = newvar env.currentLvl t.info in
-    unify [infoTm dist] (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
-    unify [infoTm value] tyDistRes (tyTm value);
+    unify env [infoTm dist] (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
+    unify env [infoTm value] tyDistRes (tyTm value);
     TmObserve {{{ t with value = value }
                     with dist = dist }
                     with ty = tyWithInfo t.info tyunit_ }
@@ -337,7 +337,7 @@ lang Weight =
   sem typeCheckExpr (env : TCEnv) =
   | TmWeight t ->
     let weight = typeCheckExpr env t.weight in
-    unify [infoTm weight] (TyFloat { info = t.info }) (tyTm weight);
+    unify env [infoTm weight] (TyFloat { info = t.info }) (tyTm weight);
     TmWeight {{ t with weight = weight }
                   with ty = tyWithInfo t.info tyunit_ }
 

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -115,7 +115,7 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
     let dist = smapDist_Expr_Expr (typeCheckExpr env) t.dist in
     let innerTyDist = typeCheckDist env t.info dist in
     let innerTyDistVar = newvar env.currentLvl t.info in
-    unify [t.info] innerTyDistVar innerTyDist;
+    unify env [t.info] innerTyDistVar innerTyDist;
     TmDist {{ t with dist = dist }
                 with ty = TyDist { info = t.info, ty = innerTyDistVar } }
   sem unifyBase (env : UnifyEnv) =
@@ -224,8 +224,8 @@ lang UniformDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DUniform t ->
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.a] (tyTm t.a) float;
-    unify [info, infoTm t.b] (tyTm t.b) float;
+    unify env [info, infoTm t.a] float (tyTm t.a);
+    unify env [info, infoTm t.b] float (tyTm t.b);
     float
 
   -- ANF
@@ -281,7 +281,7 @@ lang BernoulliDist = Dist + PrettyPrint + Eq + Sym + BoolTypeAst + FloatTypeAst
   -- Type Check
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DBernoulli t ->
-    unify [info, infoTm t.p] (tyTm t.p) (TyFloat { info = info });
+    unify env [info, infoTm t.p] (TyFloat { info = info }) (tyTm t.p);
     TyBool { info = info }
 
   -- ANF
@@ -330,7 +330,7 @@ lang PoissonDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + FloatTypeAst
   -- Type Check
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DPoisson t ->
-    unify [info, infoTm t.lambda] (tyTm t.lambda) (TyFloat { info = info });
+    unify env [info, infoTm t.lambda] (TyFloat { info = info }) (tyTm t.lambda);
     TyInt { info = info }
 
   -- ANF
@@ -387,8 +387,8 @@ lang BetaDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DBeta t ->
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.a] (tyTm t.a) float;
-    unify [info, infoTm t.b] (tyTm t.b) float;
+    unify env [info, infoTm t.a] float (tyTm t.a);
+    unify env [info, infoTm t.b] float (tyTm t.b);
     float
 
   -- ANF
@@ -450,8 +450,8 @@ lang GammaDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DGamma t ->
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.k] (tyTm t.k) float;
-    unify [info, infoTm t.theta] (tyTm t.theta) float;
+    unify env [info, infoTm t.k] float (tyTm t.k);
+    unify env [info, infoTm t.theta] float (tyTm t.theta);
     float
 
   -- ANF
@@ -514,7 +514,7 @@ lang CategoricalDist =
   | DCategorical t ->
     let float = TyFloat { info = info } in
     let seq = TySeq { ty = TyFloat { info = info }, info = info } in
-    unify [info, infoTm t.p] (tyTm t.p) seq;
+    unify env [info, infoTm t.p] seq (tyTm t.p);
     TyInt { info = info }
 
   -- ANF
@@ -571,9 +571,9 @@ lang MultinomialDist =
   -- Type Check
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DMultinomial t ->
-    unify [info, infoTm t.n] (tyTm t.n) (TyInt { info = info });
-    unify [info, infoTm t.p] (tyTm t.p)
-      (TySeq { ty = TyFloat { info = info }, info = info });
+    unify env [info, infoTm t.n] (TyInt { info = info }) (tyTm t.n);
+    unify env [info, infoTm t.p]
+      (TySeq { ty = TyFloat { info = info }, info = info }) (tyTm t.p);
     TySeq { ty = TyInt { info = info }, info = info }
 
   -- ANF
@@ -630,7 +630,7 @@ lang DirichletDist = Dist + PrettyPrint + Eq + Sym + SeqTypeAst + FloatTypeAst
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DDirichlet t ->
     let seqTy = TySeq { ty = TyFloat { info = info }, info = info } in
-    unify [info, infoTm t.a] (tyTm t.a) seqTy; seqTy
+    unify env [info, infoTm t.a] seqTy (tyTm t.a); seqTy
 
   -- ANF
   sem normalizeDist (k : Dist -> Expr) =
@@ -676,7 +676,7 @@ lang ExponentialDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DExponential t ->
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.rate] (tyTm t.rate) float; float
+    unify env [info, infoTm t.rate] float (tyTm t.rate); float
 
   -- ANF
   sem normalizeDist (k : Dist -> Expr) =
@@ -729,8 +729,8 @@ lang EmpiricalDist =
   | DEmpirical t ->
     let resTy = newvar env.currentLvl info in
     let innerTy = tyWithInfo info (tytuple_ [TyFloat { info = info }, resTy]) in
-    unify [info, infoTm t.samples] (tyTm t.samples)
-      (TySeq { ty = innerTy, info = info });
+    unify env [info, infoTm t.samples]
+      (TySeq { ty = innerTy, info = info }) (tyTm t.samples);
     resTy
 
   -- ANF
@@ -786,8 +786,8 @@ lang GaussianDist =
   sem typeCheckDist (env: TCEnv) (info: Info) =
   | DGaussian t ->
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.mu] (tyTm t.mu) float;
-    unify [info, infoTm t.mu] (tyTm t.sigma) float; float
+    unify env [info, infoTm t.mu] float (tyTm t.mu);
+    unify env [info, infoTm t.mu] float (tyTm t.sigma); float
 
   -- ANF
   sem normalizeDist (k : Dist -> Expr) =
@@ -846,8 +846,8 @@ lang BinomialDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + SeqTypeAst + Bo
   | DBinomial t ->
     let int = TyInt { info = info } in
     let float = TyFloat { info = info } in
-    unify [info, infoTm t.n] (tyTm t.n) int;
-    unify [info, infoTm t.p] (tyTm t.p) float; int
+    unify env [info, infoTm t.n] int (tyTm t.n);
+    unify env [info, infoTm t.p] float (tyTm t.p); int
 
   -- ANF
   sem normalizeDist (k : Dist -> Expr) =

--- a/coreppl/src/extract.mc
+++ b/coreppl/src/extract.mc
@@ -75,7 +75,7 @@ lang DPPLExtract = DPPLParser + MExprExtract + MExprLambdaLift
       body = TmLam {
         ident = nameNoSym "",
         tyAnnot = tyunit_,
-        tyIdent = tyunit_,
+        tyParam = tyunit_,
         body = TmApp {
           lhs = t.model, rhs = unit_, ty = tyTm t.model, info = info},
         ty = tyarrow_ tyunit_ (tyTm t.model), info = info},

--- a/coreppl/src/pgm.mc
+++ b/coreppl/src/pgm.mc
@@ -5,7 +5,7 @@ include "name.mc"
 type Env = Map Name Expr
 let _emptyEnv = mapEmpty nameCmp
 
-lang Plate = Eq + Sym + TypeAnnot + ANF + PrettyPrint
+lang Plate = Eq + Sym + ANF + PrettyPrint
   syn Expr =
   | TmPlate { fun:Expr
             , lst:Expr

--- a/coreppl/src/transformation.mc
+++ b/coreppl/src/transformation.mc
@@ -953,8 +953,8 @@ let modifyGraph = use StaticAnalyzer in
 let analyze = lam prog.
   use StaticAnalyzer in
   let emptyG = digraphEmpty cmprVertex eqi in
-  let emptyM = mapEmpty nameCmp in
-  createPBN emptyG (setEmpty nameCmp) emptyM emptyM emptyM (None ()) prog
+  let emptyM = lam. mapEmpty nameCmp in
+  createPBN emptyG (setEmpty nameCmp) (emptyM ()) (emptyM ()) (emptyM ()) (None ()) prog
 
 let recreate = lam g:Digraph Vertex Label. lam m:Map Name Vertex.
   use StaticAnalyzer in


### PR DESCRIPTION
This is a small PR with compatibility changes after some updates to the Miking codebase.

- Add `env` parameter to `unify`
- Change name of `tyIdent` field for `TmLam` to `tyParam`
- Eta expand a definition to account for value restriction

This PR should be merged after https://github.com/miking-lang/miking/pull/726 and https://github.com/miking-lang/miking/pull/730 are merged to the Miking repo.