### PR TITLE
Updates related to ProbTime (RTPPL)

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -70,6 +70,8 @@ lang TransformDist = MExprPPL
     i (conapp_
         "RuntimeDistElementary_DistUniform"
         (i (urecord_ [("a", a), ("b", b)])))
+  | DEmpirical { samples = samples } ->
+    i (app_ (var_ "RunDistEmpirical_constructDistEmpiricalHelper") samples)
 
   -- We need to replace occurrences of TyDist after transforming to MExpr
   -- distributions.

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -71,7 +71,7 @@ lang TransformDist = MExprPPL
         "RuntimeDistElementary_DistUniform"
         (i (urecord_ [("a", a), ("b", b)])))
   | DEmpirical { samples = samples } ->
-    i (app_ (var_ "RunDistEmpirical_constructDistEmpiricalHelper") samples)
+    i (app_ (var_ "RuntimeDistEmpirical_constructDistEmpiricalHelper") samples)
 
   -- We need to replace occurrences of TyDist after transforming to MExpr
   -- distributions.

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -108,10 +108,6 @@ lang RuntimeDistEmpirical = RuntimeDistBase
     let logWeights = map (lam lw. subf lw lse) logWeights in
     -- print "LOG-NORMALIZED: "; printLn (strJoin "," (map float2string logWeights));
 
-    -- Compute standard weights
-    let weights = map exp logWeights in
-    -- print "NORMALIZED: "; printLn (strJoin "," (map float2string weights));
-
     -- Computes cumulative (non-log) weights
     let f = lam acc. lam x.
       let acc = addf acc (exp x) in

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -78,6 +78,12 @@ lang RuntimeDistEmpirical = RuntimeDistBase
   | EmpNorm { normConst: Float }
   | EmpMCMC { acceptRate: Float }
 
+  sem constructDistEmpiricalHelper =
+  | samples ->
+    match unzip samples with (logWeights, samples) in
+    let extra = EmpNorm {normConst = 0.0} in
+    constructDistEmpirical samples logWeights extra
+
   -- DistEmpirical should always be created via this function
   sem constructDistEmpirical samples logWeights =
   | extra ->

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -62,7 +62,7 @@ end
 lang RuntimeDistEmpirical = RuntimeDistBase
   syn Dist a =
   | DistEmpirical {
-      weights : [Float],
+      cumulativeWeights : [Float],
       logWeights : [Float],
       samples : [a],
       degenerate : Bool,
@@ -112,9 +112,17 @@ lang RuntimeDistEmpirical = RuntimeDistBase
     let weights = map exp logWeights in
     -- print "NORMALIZED: "; printLn (strJoin "," (map float2string weights));
 
+    -- Computes cumulative (non-log) weights
+    let f = lam acc. lam x.
+      let acc = addf acc (exp x) in
+      (acc, acc)
+    in
+    match mapAccumL f 0.0 logWeights with (_, cumulativeWeights) in
+    -- print "CUMULATIVE NORMALIZED: "; printLn (strJoin "," (map float2string cumulativeWeights));
+
     DistEmpirical {
-      weights = weights, logWeights = logWeights, degenerate = degenerate,
-      samples = samples, extra = extra
+      cumulativeWeights = cumulativeWeights, logWeights = logWeights,
+      degenerate = degenerate, samples = samples, extra = extra
     }
 
   sem empiricalSamples =
@@ -138,14 +146,22 @@ lang RuntimeDistEmpirical = RuntimeDistBase
 
   sem sample =
   | DistEmpirical t ->
-    -- TODO(dlunde,2022-10-19): Just taking exp directly could be numerically
-    -- unstable. We want sampling to be efficient, however, so appropriately
-    -- scaling the weights every time we want to sample the distribution is not
-    -- really an option. We should maybe even save the weights as
-    -- non-log-weights to not have to take the exponential of every weight all
-    -- the time.
-    let i: Int = externalCategoricalSample t.weights in
-    unsafeCoerce (get t.samples i)
+    -- NOTE(larshum, 2023-05-03): Sample by choosing a value in range [0, y)
+    -- and finding the index of the maximal cumulative weight which is less
+    -- than the chosen value. The sample at this index is returned. Note that
+    -- we use the final cumulative weight rather than 1 for y, to prevent
+    -- rounding errors from skewing the probability of the last sample.
+    let x = uniformContinuousSample 0.0 (last t.cumulativeWeights) in
+
+    -- NOTE(larshum, 2023-05-03): The sampled value 'x' cannot be greater than
+    -- the last element of the sequence of cumulative weights, so we should
+    -- always be able to find an index for which the comparison function
+    -- returns a non-negative number.
+    let cmp = lam y. if ltf (subf y x) 0.0 then negi 1 else 0 in
+    match lowerBoundBinarySearch cmp t.cumulativeWeights with Some idx then
+      unsafeCoerce (get t.samples idx)
+    else
+      error "Sampling from empirical distribution failed"
 
   sem logObserve =
   -- TODO(dlunde,2022-10-18): Implement this?

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -91,12 +91,15 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
   | TmDist r ->
     match lhs with TmDist l then eqExprHDist env free l.dist r.dist else None ()
 
-
   sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
   | TyDist r ->
     match unwrapType lhs with TyDist l then
       eqTypeH typeEnv free l.ty r.ty
     else None ()
+
+  sem cmpTypeH : Type -> Type -> Int
+  sem cmpTypeH =
+  | (TyDist l, TyDist r) -> cmpType l.ty r.ty
 
   -- Symbolize
   sem symbolizeDist (env: SymEnv) =

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -97,7 +97,7 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
       eqTypeH typeEnv free l.ty r.ty
     else None ()
 
-  sem cmpTypeH : Type -> Type -> Int
+  sem cmpTypeH : (Type, Type) -> Int
   sem cmpTypeH =
   | (TyDist l, TyDist r) -> cmpType l.ty r.ty
 


### PR DESCRIPTION
This PR consists of multiple minor changes and improvements I made to DPPL when developing RTPPL. Included in this PR:
* Improve performance of sampling from empirical distributions from O(n) to O(log n) by replacing sampling from the categorical distribution with storing cumulative weights and using binary search to find the appropriate value based on a uniform sample (as described at https://en.wikipedia.org/wiki/Categorical_distribution#Sampling).
* Added support for creating empirical distributions via `DEmpirical` and `constructDistEmpiricalHelper`.
* Made use of the `demoteRecursive` introduced in [the related Miking PR](https://github.com/miking-lang/miking/pull/746) as an improvement to the previous approach (which was not sufficient in my case).
* Add an implementation of `cmpTypeH` for `TyDist`.