### PR TITLE
Add (experimental) support for partial evaluation to simplify models after extraction

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -122,7 +122,7 @@ lang MExprCompile =
     -- each infer is replaced with a call to the 'run' function provided by
     -- the chosen runtime. It also consists of one AST per inference method
     -- used in the program.
-    match extractInfer runtimes.entries corepplAst with (corepplAst, models) in
+    match extractInfer options runtimes.entries corepplAst with (corepplAst, models) in
 
     -- Compile the model ASTs.
     let modelAsts = compileModels options runtimes models in

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -101,7 +101,6 @@ lang DPPLExtract =
     -- printLn (mexprPPLToString ast);
     let ast = demoteRecursive ast in
     -- Suggestion by Johan and Oscar to do pattern lowering before peval
-    let ast = lowerAll ast in
     let ast =
       switch options.extractSimplification
       case "none" then ast
@@ -111,7 +110,11 @@ lang DPPLExtract =
         -- inlineSingleUse with something better. The current implementation is
         -- quite hacky and have not been properly analyzed or tested.
         inlineSingleUse (inlineSingleUse ast)
-      case "peval" then peval ast
+      case "peval" then
+        -- NOTE(2023-06-20,dlunde): Suggestion by Oscar and Johan to use
+        -- pattern lowering here. Required even?
+        -- let ast = lowerAll ast in
+        peval ast
       case _ then
         error (join ["Unknown extract simplification: ",
                      options.extractSimplification])

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -2,13 +2,16 @@ include "../coreppl.mc"
 include "../parser.mc"
 
 include "name.mc"
+include "peval/peval.mc"
 include "mexpr/demote-recursive.mc"
 include "mexpr/extract.mc"
 include "mexpr/lamlift.mc"
 include "pmexpr/utils.mc"
 
 lang DPPLExtract =
-  DPPLParser + MExprExtract + MExprLambdaLift + MExprDemoteRecursive
+  DPPLParser + MExprExtract + MExprLambdaLift + MExprDemoteRecursive +
+  MExprPEval
+
   type ModelRepr = {
     ast : Expr,
     method : InferMethod,
@@ -95,13 +98,8 @@ lang DPPLExtract =
     let ast = inlineInferBinding inferId ast in
     -- printLn (mexprPPLToString ast);
     let ast = demoteRecursive ast in
-    -- NOTE(dlunde,2023-05-22): Call inlineSingleUse twice to further simplify
-    -- some cases. We probably want to repeat it until fixpoint. Or, replace
-    -- inlineSingleUse with something better. The current implementation is
-    -- quite hacky and have not been properly analyzed or tested.
-    let ast = inlineSingleUse ast in
-    let ast = inlineSingleUse ast in
-    ---
+    -- let ast = peval ast in
+    -- printLn "-----------------------";
     -- printLn (mexprPPLToString ast);
     ast
 
@@ -182,83 +180,6 @@ lang DPPLExtract =
       else e
     else e
   | t -> smap_Expr_Expr (replaceInferApplication solutions inferData) t
-
-  sem bindingsUsed : Set Name -> Bool -> Expr -> Bool
-  sem bindingsUsed bs acc =
-  | TmVar t -> if setMem t.ident bs then true else acc
-  | expr ->
-    if acc then acc else
-      sfold_Expr_Expr (bindingsUsed bs) acc expr
-
-  -- Assumes proper symbolization and ANF
-  sem inlineSingleUse : Expr -> Expr
-  sem inlineSingleUse =
-  | expr ->
-    -- Count uses of lambdas
-    let m = determineInline (mapEmpty nameCmp) expr in
-    -- printLn (strJoin ",\n" (map
-    --   (lam t. join [(nameGetStr t.0), "->", (bool2string t.1)])
-    --   (mapToSeq m)));
-
-    -- Inline functions
-    match inlineSingleUseH m (mapEmpty nameCmp) expr with (_,expr) in
-    expr
-
-  sem determineInline : Map Name Bool -> Expr -> Map Name Bool
-  sem determineInline m =
-  | TmLet t ->
-    let m = determineInline m t.body in
-    let m =
-      -- Only inline certain things. In particular, do not move constructs with
-      -- side-effects
-      match t.body with TmLam _ | TmVar _ then mapInsert t.ident false m
-      else m
-    in
-    determineInline m t.inexpr
-  | TmVar t ->
-    match mapLookup t.ident m with Some b then
-      if b then mapRemove t.ident m -- More than a single use
-      else mapInsert t.ident true m -- First use
-    else m
-  | expr -> sfold_Expr_Expr determineInline m expr
-
-  sem inlineSingleUseH : Map Name Bool
-                         -> Map Name Expr -> Expr -> (Map Name Expr, Expr)
-  sem inlineSingleUseH m me =
-  | TmLet t ->
-    match inlineSingleUseH m me t.body with (me,body) in
-    let inline = match mapLookup t.ident m with Some true then true else false in
-    let me = if inline then mapInsert t.ident body me else me in
-    match inlineSingleUseH m me t.inexpr with (me,inexpr) in
-    if inline then
-      match mapLookup t.ident me with None _ then
-        -- The function was inlined, remove it
-        (me, inexpr)
-      else
-        (me, TmLet {t with body = body, inexpr = inexpr})
-    else
-      (me, TmLet {t with body = body, inexpr = inexpr})
-  | TmApp t & tm ->
-    recursive let rec = lam me. lam expr.
-      match expr with TmApp t then
-        let rhs = inlineSingleUseH m me t.rhs in
-        match rec rhs.0 t.lhs with (ls, me, lhs) in
-        match lhs with TmLam tl then
-          let l = nlet_ tl.ident tl.tyAnnot rhs.1 in
-          (cons l ls, me, tl.body)
-        else (ls, me, TmApp {t with lhs = lhs, rhs = rhs.1})
-      else
-        match inlineSingleUseH m me expr with (me, expr) in
-        ([], me, expr)
-    in
-    match rec me tm with (ls, me, tm) in
-    (me, foldr bind_ tm (reverse ls))
-
-  | TmVar t ->
-    match mapLookup t.ident me with Some expr then (mapRemove t.ident me, expr)
-    else (me, TmVar t)
-
-  | expr -> smapAccumL_Expr_Expr (inlineSingleUseH m) me expr
 
 end
 

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -4,13 +4,14 @@ include "../parser.mc"
 include "name.mc"
 include "peval/peval.mc"
 include "mexpr/demote-recursive.mc"
+include "mexpr/shallow-patterns.mc"
 include "mexpr/extract.mc"
 include "mexpr/lamlift.mc"
 include "pmexpr/utils.mc"
 
 lang DPPLExtract =
   DPPLParser + MExprExtract + MExprLambdaLift + MExprDemoteRecursive +
-  MExprPEval
+  MExprPEval + MExprLowerNestedPatterns
 
   type ModelRepr = {
     ast : Expr,
@@ -98,9 +99,9 @@ lang DPPLExtract =
     let ast = inlineInferBinding inferId ast in
     -- printLn (mexprPPLToString ast);
     let ast = demoteRecursive ast in
-    -- TODO(2023-06-15,dlunde): Might need pattern lowering here before peval?
-    -- Suggestion by Johan and Oscar
-    -- let ast = peval ast in
+    -- Suggestion by Johan and Oscar to do pattern lowering before peval
+    -- let ast = lowerAll ast in
+    let ast = peval ast in
     -- printLn "-----------------------";
     -- printLn (mexprPPLToString ast);
     ast

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -98,6 +98,8 @@ lang DPPLExtract =
     let ast = inlineInferBinding inferId ast in
     -- printLn (mexprPPLToString ast);
     let ast = demoteRecursive ast in
+    -- TODO(2023-06-15,dlunde): Might need pattern lowering here before peval?
+    -- Suggestion by Johan and Oscar
     -- let ast = peval ast in
     -- printLn "-----------------------";
     -- printLn (mexprPPLToString ast);

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -7,6 +7,8 @@ include "mexpr/type-check.mc"
 include "mexpr/anf.mc"
 include "mexpr/type-lift.mc"
 
+include "peval/peval.mc"
+
 include "string.mc"
 include "seq.mc"
 

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -10,7 +10,7 @@ include "mexpr/type-lift.mc"
 include "string.mc"
 include "seq.mc"
 
-lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
+lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval
   syn Expr =
   | TmDist { dist: Dist,
              ty: Type,
@@ -156,6 +156,16 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift
       (env, TyDist {t with ty = ty})
     else never
 
+  -- Partial evaluation
+  sem pevalIsValue =
+  | TmDist _ -> false
+
+  sem pevalDistEval ctx k =
+  -- Intentionally left blank
+
+  sem pevalEval ctx k =
+  | TmDist t ->
+    pevalDistEval ctx (lam dist. k (TmDist { t with dist = dist }) ) t.dist
 
   -- Builtin operations on distributions
   syn Const =
@@ -248,6 +258,16 @@ lang UniformDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
       else never
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DUniform t ->
+    pevalBind ctx
+      (lam a.
+        pevalBind ctx
+          (lam b. k (DUniform {t with a=a, b=b}))
+          t.b)
+      t.a
+
 end
 
 
@@ -299,6 +319,12 @@ lang BernoulliDist = Dist + PrettyPrint + Eq + Sym + BoolTypeAst + FloatTypeAst
       (env, DBernoulli {t with p = p})
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DBernoulli t ->
+    pevalBind ctx
+      (lam p. k (DBernoulli {t with p=p}))
+      t.p
 end
 
 
@@ -347,6 +373,12 @@ lang PoissonDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + FloatTypeAst
     match typeLiftExpr env lambda with (env, lambda) then
       (env, DPoisson {t with lambda = lambda})
     else never
+
+  sem pevalDistEval ctx k =
+  | DPoisson t ->
+    pevalBind ctx
+      (lam lambda. k (DPoisson {t with lambda=lambda}))
+      t.lambda
 
 end
 
@@ -411,6 +443,16 @@ lang BetaDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
       else never
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DBeta t ->
+    pevalBind ctx
+      (lam a.
+        pevalBind ctx
+          (lam b. k (DBeta {t with a=a, b=b}))
+          t.b)
+      t.a
+
 end
 
 
@@ -474,6 +516,16 @@ lang GammaDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
       else never
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DGamma t ->
+    pevalBind ctx
+      (lam k2.
+        pevalBind ctx
+          (lam theta. k (DGamma {t with k=k2, theta=theta}))
+          t.theta)
+      t.k
+
 end
 
 
@@ -531,6 +583,12 @@ lang CategoricalDist =
     match typeLiftExpr env p with (env, p) then
       (env, DCategorical {t with p = p})
     else never
+
+  sem pevalDistEval ctx k =
+  | DCategorical t ->
+    pevalBind ctx
+      (lam p. k (DCategorical {t with p=p}))
+      t.p
 
 end
 
@@ -596,6 +654,16 @@ lang MultinomialDist =
       else never
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DMultinomial t ->
+    pevalBind ctx
+      (lam n.
+        pevalBind ctx
+          (lam p. k (DMultinomial {t with n=n, p=p}))
+          t.p)
+      t.n
+
 end
 
 lang DirichletDist = Dist + PrettyPrint + Eq + Sym + SeqTypeAst + FloatTypeAst
@@ -647,6 +715,12 @@ lang DirichletDist = Dist + PrettyPrint + Eq + Sym + SeqTypeAst + FloatTypeAst
       (env, DDirichlet {t with a = a})
     else never
 
+  sem pevalDistEval ctx k =
+  | DDirichlet t ->
+    pevalBind ctx
+      (lam a. k (DDirichlet {t with a=a}))
+      t.a
+
 end
 
 lang ExponentialDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
@@ -692,6 +766,12 @@ lang ExponentialDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
     match typeLiftExpr env rate with (env, rate) then
       (env, DExponential {t with rate = rate})
     else never
+
+  sem pevalDistEval ctx k =
+  | DExponential t ->
+    pevalBind ctx
+      (lam rate. k (DExponential {t with rate=rate}))
+      t.rate
 
 end
 
@@ -748,6 +828,12 @@ lang EmpiricalDist =
     match typeLiftExpr env samples with (env, samples) then
       (env, DEmpirical {t with samples = samples})
     else never
+
+  sem pevalDistEval ctx k =
+  | DEmpirical t ->
+    pevalBind ctx
+      (lam samples. k (DEmpirical {t with samples=samples}))
+      t.samples
 
 end
 
@@ -809,6 +895,16 @@ lang GaussianDist =
       else never
     else never
 
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DGaussian t ->
+    pevalBind ctx
+      (lam mu.
+        pevalBind ctx
+          (lam sigma. k (DGaussian {t with mu=mu, sigma=sigma}))
+          t.sigma)
+      t.mu
+
 end
 
 lang BinomialDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + SeqTypeAst + BoolTypeAst + FloatTypeAst
@@ -868,6 +964,16 @@ lang BinomialDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + SeqTypeAst + Bo
                           with p = p })
       else never
     else never
+
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DBinomial t ->
+    pevalBind ctx
+      (lam n.
+        pevalBind ctx
+          (lam p. k (DBinomial {t with n=n, p=p}))
+          t.p)
+      t.n
 
 end
 

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -43,7 +43,10 @@ type Options = {
   pmcmcParticles: Int,
 
   -- The random seed to use
-  seed: Option Int
+  seed: Option Int,
+
+  -- (temporary option, the end-goal is that we should only ever use peval)
+  extractSimplification: String
 }
 
 -- Default values for options
@@ -67,7 +70,8 @@ let default = {
   mcmcLightweightReuseLocal = true,
   printAcceptanceRate = false,
   pmcmcParticles = 2,
-  seed = None ()
+  seed = None (),
+  extractSimplification = "inline"
 }
 
 -- Options configuration
@@ -172,7 +176,11 @@ let config = [
   ([("--seed", " ", "<seed>")],
     "The random seed to use. Initialized randomly if option is omitted.",
     lam p: ArgPart Options.
-      let o: Options = p.options in {o with seed = Some (argToInt p)})
+      let o: Options = p.options in {o with seed = Some (argToInt p)}),
+  ([("--extract-simplification", " ", "<option>")],
+    join ["Temporary flag that decides the simplification approach after extraction in the MExpr compiler backend. The supported options are: none, inline, and peval. Default: ", default.extractSimplification, ". Eventually, we will remove this option and only use peval."],
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with extractSimplification = argToString p})
 ]
 
 -- Menu


### PR DESCRIPTION
The current simplification phase after extraction in `extract.mc` is quite hacky and does not, e.g., preserve types correctly in all cases. Therefore, I have been working on replacing the simplification with partial evaluation. The partial evaluation currently works, but results in a code size explosion (@br4sco is planning to fix this in the futre). Therefore, we still use the old simplification as default. However, due to the issues with the old simplification, I also added an option to do no simplification at all after extraction. The `cppl` option is:
```
  --extract-simplification <option>  Temporary flag that decides the 
                                     simplification approach after extraction in
                                     the MExpr compiler backend. The supported 
                                     options are: none, inline, and peval. 
                                     Default: inline. Eventually, we will remove
                                     this option and only use peval.

```
The default `inline` value is the old simplification.