### PR TITLE
Add support for higher-order constants in `cfa.mc`

### DIFF
--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -85,6 +85,18 @@ lang StochCFA = MExprCFA + MExprPPL + ConstAllCFA
   | CstrConstStochApp { lhs: IName, rhs: IName, res: IName }
   -- {ext} ⊆ lhs ⇒ ({stoch} ⊆ rhs ⇒ {stoch} ⊆ res)
   | CstrExtStochApp { lhs: IName, rhs: IName, res: IName }
+  -- TODO
+  -- (stoch in lhs1 ⇒ stoch in x) and
+  -- {lam _. lhs2} ⊆ lhs1 ⇒
+  --   (stoch in lhs2 ⇒ stoch in x) and
+  --   {lam _. lhs3} ⊆ lhs2 ⇒
+  --     (stoch in lhs3 ⇒ stoch in x) and
+  --     {lam _. lhs4} ⊆ lhs3 ⇒
+  --     ...
+  --       (stoch in lhs(n-1) ⇒ stoch in x) and
+  --       {lam _. lhsn} ⊆ lhs(n-1) ⇒
+  --         (stoch in lhsn ⇒ stoch in x)
+  -- | CstrStochConstInnerApp { lhs: IName, x: IName, arity: Int }
 
   sem cmpConstraintH =
   | (CstrConstStochApp { lhs = lhs1, rhs = rhs1, res = res1 },
@@ -249,6 +261,7 @@ lang AlignCFA = MExprCFA + MExprPPL + StochCFA + ConstAllCFA
   syn Constraint =
   -- {lam x. b} ⊆ lhs ⇒ {unaligned} ⊆ x
   | CstrAlignLamApp { lhs: IName }
+  -- TODO
   -- {lam y1. lhs2} ⊆ lhs1 ⇒
   --   ({stoch} ⊆ lhs1 ⇒ {unaligned} ⊆ y1) and
   --   ({unaligned} ⊆ x ⇒ {unaligned} ⊆ y1)
@@ -259,7 +272,7 @@ lang AlignCFA = MExprCFA + MExprPPL + StochCFA + ConstAllCFA
   --       ({lam yn. _} ⊆ lhsn ⇒
   --         ({stoch} ⊆ lhsn ⇒ {unaligned} ⊆ yn) and
   --         ({unaligned} ⊆ x ⇒ {unaligned} ⊆ yn)
-  -- | CstrAlignConstApp { x: IName, lhs: IName, arity: Int }
+  -- | CstrAlignConstInnerApp { lhs: IName, x: IName, arity: Int }
 
   sem cmpConstraintH =
   | (CstrAlignLamApp { lhs = lhs1 }, CstrAlignLamApp { lhs = lhs2 }) ->

--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -843,6 +843,26 @@ utest _test false t ["t", "res"] with [
   ("res",true)
 ] using eqTest in
 
+-- Stochastic higher-order constants
+let t = _parse "
+  let f = lam p. assume (Bernoulli p) in
+  let ls = [0.1,0.2,0.3] in
+  let t1 = map f ls in
+  let t2 = get t1 0 in
+  let t3 = foldl (lam acc. lam e.
+                    if ltf e 0.2 then assume (Bernoulli e)
+                    else false) 0. ls
+  in
+  ()
+------------------------" in
+utest _test false t ["p","ls","t1","t2","t3"] with [
+  ("p",  false),
+  ("ls", false),
+  ("t1", false),
+  ("t2", true),
+  ("t3", true)
+] using eqTest in
+
 ---------------------
 -- ALIGNMENT TESTS --
 ---------------------
@@ -959,7 +979,17 @@ utest _test false t ["t1", "t2", "res"] with [
   ("res", true)
 ] using eqTest in
 
--- Test in `models/coreppl/crbd/crbd-unaligned.mc`
+-- Higher-order constants
+--let t = _parse "
+
+--------------------------" in
+--utest _test false t ["t1", "t2", "res"] with [
+--  ("t1", false),
+--  ("t2", false),
+--  ("res", true)
+-- ] using eqTest in
+
+-- Test in `coreppl/models/diversification-models/crbd-synthetic.mc`
 let _testWithSymbolize: Bool -> Expr -> [String] -> [([Char], Bool)] =
   lam debug. lam t. lam vars.
     let tANF = normalizeTerm t in
@@ -974,7 +1004,7 @@ let _testWithSymbolize: Bool -> Expr -> [String] -> [([Char], Bool)] =
     map (lam var: String. (var, not (setMem var sSet))) vars
 in
 let t = symbolizeExpr symEnvEmpty
-          (parseMCorePPLFile "coreppl/models/diversification-models/crbd-synthetic.mc") in
+          (parseMCorePPLFile false "coreppl/models/diversification-models/crbd-synthetic.mc") in
 utest _testWithSymbolize false t ["w1","w2","w3", "w4", "w5"] with [
   ("w1", false),
   ("w2", false),

--- a/coreppl/src/coreppl-to-mexpr/backcompat.mc
+++ b/coreppl/src/coreppl-to-mexpr/backcompat.mc
@@ -48,7 +48,8 @@ lang CPPLBackcompat = LoadRuntime
       let tyPrintFun = getTypePrintFunction runtimeEntry resTy in
 
       let top =
-        parseMCorePPLFileLib (join [corepplSrcLoc, "/coreppl-to-mexpr/top.mc"])
+        parseMCorePPLFileLib options.test
+          (join [corepplSrcLoc, "/coreppl-to-mexpr/top.mc"])
       in
 
       -- We do not use the -p cppl option to determine the number of iterations

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
@@ -25,7 +25,7 @@ lang MExprPPLLightweightMCMC =
   -------------------------
   sem compileAligned : Options -> (Expr,Expr) -> Expr
   sem compileAligned options =
-  | (_,t) ->
+  | (t,_) ->
 
     -- Alignment analysis
     let alignRes = alignCfa t in

--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -52,7 +52,7 @@ match result with ParseOK r then
 
     -- Read and parse the file
     let filename = head r.strings in
-    let ast = parseMCorePPLFile filename in
+    let ast = parseMCorePPLFile options.test filename in
 
     let noInfer = not (hasInfer ast) in
 

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -9,6 +9,9 @@ type Options = {
   -- Backend
   target : String,
 
+  -- Whether or not to include utests
+  test : Bool,
+
   -- Number of samples/particles
   particles : Int,
 
@@ -64,6 +67,7 @@ type Options = {
 let default = {
   method = "is-lw",
   target = "mexpr",
+  test = false,
   particles = 5000,
   resample = "manual",
   align = false,
@@ -96,6 +100,10 @@ let config = [
     ],
     lam p: ArgPart Options.
       let o: Options = p.options in {o with method = argToString p}),
+  ([("--test", "", "")],
+    "Include utests",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with test = true}),
   ([("-t", " ", "<target>")],
     join [
       "The compilation target. The supported targets are: mexpr, rootppl. Default: ",

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -115,37 +115,27 @@ let builtin = use MExprPPL in concat
   , ("distEmpiricalAcceptRate", CDistEmpiricalAcceptRate ())
   ] builtin
 
-let parseMCorePPLFile = lam filename.
+let defaultBootParserParseCorePPLFileArg =
+  {defaultBootParserParseMCoreFileArg with
+     keywords = pplKeywords,
+     allowFree = true,
+     builtin = builtin}
+
+let parseMCorePPLFile = lam keepUtests. lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
-  let config = {defaultBootParserParseMCoreFileArg with
-                  keywords = pplKeywords,
-                  allowFree = true,
-                  builtin = builtin} in
+  let config =
+    {defaultBootParserParseCorePPLFileArg with keepUtests = keepUtests} in
   let ast = parseMCoreFile config filename in
   let ast = symbolizeAllowFree ast in
   makeKeywords ast
 
-let parseMCorePPLFileNoDeadCodeElimination = lam filename.
+let parseMCorePPLFileLib = lam keepUtests. lam filename.
   use DPPLParser in
   -- Read and parse the mcore file
-  let config = {defaultBootParserParseMCoreFileArg with
-                   keywords = pplKeywords,
-                   eliminateDeadCode = false,
-                   allowFree = true,
-                   builtin = builtin} in
-  let ast = parseMCoreFile config filename in
-  let ast = symbolizeAllowFree ast in
-  makeKeywords ast
-
-let parseMCorePPLFileLib = lam filename.
-  use DPPLParser in
-  -- Read and parse the mcore file
-  let config = {defaultBootParserParseMCoreFileArg with
-                   keywords = pplKeywords,
-                   eliminateDeadCode = false,
-                   allowFree = true,
-                   builtin = builtin} in
+  let config = {defaultBootParserParseCorePPLFileArg with
+                  keepUtests = keepUtests,
+                  eliminateDeadCode = false} in
   let ast = parseMCoreFile config filename in
   makeKeywords ast
 

--- a/make
+++ b/make
@@ -32,7 +32,7 @@ testmi () {
 testcppl () {
   set +e
   cpplout=$(mktemp)
-  compile_cmd="$2 --seed 0 --output $cpplout --output-mc --skip-final"
+  compile_cmd="$2 --seed 0 --test --output $cpplout --output-mc --skip-final"
   output=$1
   compile_output=$($compile_cmd $1 2>&1)
   exit_code=$?


### PR DESCRIPTION
- Update `cfa.mc` with support for higher-order constants. That is, add support for higher-order constants in the stochastic value, alignment, and checkpoint/suspension analyses. Made possible by https://github.com/miking-lang/miking/pull/764
- Added a `--test` option to `cppl`. Without the option, the compiler removes all `utest`s (this is the default).