### PR TITLE
Change `Default {}` inference method to `Default { runs: Expr }`

### DIFF
--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -47,7 +47,7 @@ match result with ParseOK r then
   -- Print menu if not exactly one file argument
   if neqi (length r.strings) 1 then
     print (menu ());
-    exit 0
+    if gti (length r.strings) 1 then exit 1 else exit 0
   else
 
     -- Read and parse the file

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -82,6 +82,8 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   | rhs -> eqi (cmpInferMethod lhs rhs) 0
 
   sem pprintInferMethod : Int -> PprintEnv -> InferMethod -> (PprintEnv, String)
+  sem pprintInferMethod indent env =
+  | Default {} -> (env, join ["Default {}"])
 
   -- Constructs an inference method from the arguments of a TmConApp.
   sem inferMethodFromCon : Info -> Map SID Expr -> String -> InferMethod
@@ -98,6 +100,8 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   -- the inference method. This record is passed to the inference runtime
   -- function.
   sem inferMethodConfig : Info -> InferMethod -> Expr
+  sem inferMethodConfig info =
+  | Default {} -> fieldsToRecord info []
 
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -83,7 +83,7 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
 
   sem pprintInferMethod : Int -> PprintEnv -> InferMethod -> (PprintEnv, String)
   sem pprintInferMethod indent env =
-  | Default {} -> (env, join ["Default {}"])
+  | Default {} -> (env, join ["(Default {})"])
 
   -- Constructs an inference method from the arguments of a TmConApp.
   sem inferMethodFromCon : Info -> Map SID Expr -> String -> InferMethod

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -102,6 +102,7 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod
+  | Default {} -> Default {}
 
   -- Symbolizes infer methods.
   sem symbolizeInferMethod : SymEnv -> InferMethod -> InferMethod

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -102,6 +102,7 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod
+  sem typeCheckInferMethod env info =
   | Default {} -> Default {}
 
   -- Symbolizes infer methods.

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -7,7 +7,7 @@ include "mexpr/type-check.mc"
 
 include "dppl-arg.mc"
 
-lang InferMethodHelper = MExprAst
+lang InferMethodHelper = MExprAst + MExprSym
   -- Extracts the fields corresponding to the provided sequence of strings, and
   -- ensures that no additional fields have been defined.
   sem getFields : Info -> Map SID Expr -> [(String, Expr)] -> [Expr]
@@ -70,7 +70,7 @@ end
 -- 5. typeCheckInferMethod
 lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   syn InferMethod =
-  | Default {}
+  | Default { runs: Expr }
 
   -- NOTE(larshum, 2022-10-11): Compares the inference methods tags only.
   sem cmpInferMethod : InferMethod -> InferMethod -> Int
@@ -83,12 +83,20 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
 
   sem pprintInferMethod : Int -> PprintEnv -> InferMethod -> (PprintEnv, String)
   sem pprintInferMethod indent env =
-  | Default {} -> (env, join ["(Default {})"])
+  | Default { runs = runs } ->
+    let i = pprintIncr indent in
+    match pprintCode i env runs with (env, runs) in
+    (env, join ["(Default {runs = ", runs, "})"])
 
   -- Constructs an inference method from the arguments of a TmConApp.
   sem inferMethodFromCon : Info -> Map SID Expr -> String -> InferMethod
   sem inferMethodFromCon info bindings =
-  | "Default" -> Default {}
+  | "Default" ->
+    let expectedFields = [
+      ("runs", int_ default.particles)
+    ] in
+    match getFields info bindings expectedFields with [runs] in
+    Default { runs = runs }
   | s -> errorSingle [info] (concat "Unknown inference method: " s)
 
   -- Constructs an inference method from command-line options.
@@ -101,18 +109,22 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
   -- function.
   sem inferMethodConfig : Info -> InferMethod -> Expr
   sem inferMethodConfig info =
-  | Default {} -> fieldsToRecord info []
+  | Default { runs = runs } -> fieldsToRecord info [("runs", runs)]
 
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod
   sem typeCheckInferMethod env info =
-  | Default {} -> Default {}
+  | Default { runs = runs } ->
+    let int = TyInt {info = info} in
+    let runs = typeCheckExpr env runs in
+    unify env [info, infoTm runs] int (tyTm runs);
+    Default { runs = runs }
 
   -- Symbolizes infer methods.
   sem symbolizeInferMethod : SymEnv -> InferMethod -> InferMethod
   sem symbolizeInferMethod env =
-  | Default {} -> Default {}
+  | Default r -> Default {r with runs = symbolizeExpr env r.runs}
 
   -- Overrides the number of runs/iterations/particles in the InferMethod
   sem setRuns : Expr -> InferMethod -> InferMethod

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -9,7 +9,7 @@ lang ImportanceSamplingMethod = MExprPPL
   | Importance {particles = particles} ->
     let i = pprintIncr indent in
     match pprintCode i env particles with (env, particles) in
-    (env, join ["Importance {particles = ", particles, "}"])
+    (env, join ["(Importance {particles = ", particles, "})"])
 
   sem inferMethodFromCon info bindings =
   | "Importance" ->

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -13,8 +13,8 @@ lang LightweightMCMCMethod = MExprPPL
     let i = pprintIncr indent in
     match pprintCode i env t.iterations with (env, iterations) in
     match pprintCode i env t.globalProb with (env, globalProb) in
-    (env, join ["LightweightMCMC {iterations = ", iterations,
-                "globalProb =", globalProb, "}"])
+    (env, join ["(LightweightMCMC {iterations = ", iterations,
+                "globalProb =", globalProb, "})"])
 
   sem inferMethodFromCon info bindings =
   | "LightweightMCMC" ->

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -11,7 +11,7 @@ lang NaiveMCMCMethod = MExprPPL
   | NaiveMCMC t ->
     let i = pprintIncr indent in
     match pprintCode i env t.iterations with (env, iterations) in
-    (env, join ["NaiveMCMC {iterations = ", iterations, "}"])
+    (env, join ["(NaiveMCMC {iterations = ", iterations, "})"])
 
   sem inferMethodFromCon info bindings =
   | "NaiveMCMC" ->

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -11,7 +11,7 @@ lang TraceMCMCMethod = MExprPPL
   | TraceMCMC t ->
     let i = pprintIncr indent in
     match pprintCode i env t.iterations with (env, iterations) in
-    (env, join ["TraceMCMC {iterations = ", iterations, "}"])
+    (env, join ["(TraceMCMC {iterations = ", iterations, "})"])
 
   sem inferMethodFromCon info bindings =
   | methodStr & "TraceMCMC" ->

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -14,7 +14,7 @@ lang PIMHMethod = MExprPPL
     match pprintCode i env particles with (env, particles) in
     match pprintCode i env iterations with (env, iterations) in
     (env, join [
-      "PIMH {interations = ", iterations, "particles = ", particles, "}"])
+      "(PIMH {interations = ", iterations, "particles = ", particles, "})"])
 
   sem inferMethodFromCon info bindings =
   | "PIMH" ->

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -9,7 +9,7 @@ lang APFMethod = MExprPPL
   | APF {particles = particles} ->
     let i = pprintIncr indent in
     match pprintCode i env particles with (env, particles) in
-    (env, join ["APF {particles = ", particles, "}"])
+    (env, join ["(APF {particles = ", particles, "})"])
 
   sem inferMethodFromCon info bindings =
   | "APF" ->

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -9,7 +9,7 @@ lang BPFMethod = MExprPPL
   | BPF {particles = particles} ->
     let i = pprintIncr indent in
     match pprintCode i env particles with (env, particles) in
-    (env, join ["BPF {particles = ", particles, "}"])
+    (env, join ["(BPF {particles = ", particles, "})"])
 
   sem inferMethodFromCon info bindings =
   | "BPF" ->

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -37,8 +37,9 @@ lang DPPLParser =
   sem replaceDefaultInferMethod options =
   | expr ->
     let mf = lam expr.
-      match expr with TmInfer ({ method = Default _ } & t) then
-        TmInfer {t with method = inferMethodFromOptions options options.method }
+      match expr with TmInfer ({ method = Default d } & t) then
+        TmInfer { t with method = setRuns d.runs
+                          (inferMethodFromOptions options options.method) }
       else expr
     in
     mapPre_Expr_Expr mf expr


### PR DESCRIPTION
This PR changes the `Default` `InferMethod` to also include the number of runs. This feature is required in the [TreePPL](https://github.com/treeppl/treeppl) compiler, where we do not wish to specify an inference algorithm in the CorePPL program itself, but still want to make the number of runs/samples/iterations adjustable in the program.

Minor improvements:
- Fix incorrect pretty printing of all current `InferMethod`s (simply surround the printed `InferMethod`s with parentheses).
