### PR TITLE
Limited support for subsampling the posterior distribution 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,9 @@
+# CHANGELOG.md
+
+## Support for subsampling of the posterior distribution to save memory
+
+  - addresses https://github.com/treeppl/treeppl/issues/47
+
+If you compile an SMC model with the flag `--subsample` and do not use
+`--no-print-samples`, the program produces only one sample.
+  

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,0 @@
-# CHANGELOG.md
-
-## Support for subsampling of the posterior distribution to save memory
-
-  - addresses https://github.com/treeppl/treeppl/issues/47
-
-If you compile an SMC model with the flag `--subsample` and do not use
-`--no-print-samples`, the program produces only one sample.
-  

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -171,12 +171,21 @@ lang RuntimeDistEmpirical = RuntimeDistBase
   -- TODO(dlunde,2022-10-18): Implement this?
   | DistEmpirical t -> error "Log observe not supported for empirical distribution"
 
-  -- TODO(vsenderov,2024-03-19): Implement for n != 1
-  sem constructDistEmpiricalSimplified n samples logWeights =
+  -- Creates an empirical distribution with a subsample of size n
+  -- NOTE(vsenderov, 2024-03-28): 
+  -- The log-weights are not normalized here. First, normalization in the 
+  -- returned sub-sample from the program is not strictly desirable.
+  -- In addition, as of now, constructDistEmpirical will normalize the weights,
+  -- anyway.  For reference, with comments I show how to normalize the weights. 
+  sem constructDistEmpiricalSubsample n samples logWeights =
   | extra ->
     let d = constructDistEmpirical samples logWeights extra in
-    let s = [sample d] in
-    let l = [0.0] in
+    let s = create n (lam. sample d) in
+    -- without normalizing the sample weights
+    let l = make n 0.0 in
+    -- with normalizing
+    --let w = negf (log (int2float n)) in
+    --let l = make n w in
     constructDistEmpirical s l extra
     
 end

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -170,6 +170,15 @@ lang RuntimeDistEmpirical = RuntimeDistBase
   sem logObserve =
   -- TODO(dlunde,2022-10-18): Implement this?
   | DistEmpirical t -> error "Log observe not supported for empirical distribution"
+
+  -- TODO(vsenderov,2024-03-19): Implement for n != 1
+  sem constructDistEmpiricalSimplified n samples logWeights =
+  | extra ->
+    let d = constructDistEmpirical samples logWeights extra in
+    let s = [sample d] in
+    let l = [0.0] in
+    constructDistEmpirical s l extra
+    
 end
 
 lang RuntimeDist = RuntimeDistElementary + RuntimeDistEmpirical

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -186,6 +186,7 @@ lang LoadRuntime =
       ("mcmcLightweightReuseLocal", bool_ options.mcmcLightweightReuseLocal),
       ("printAcceptanceRate", bool_ options.printAcceptanceRate),
       ("subsample", bool_ options.subsample),
+      ("subsampleSize", int_ options.subsampleSize),
 
       -- NOTE(dlunde,2022-11-04): Emulating option type
       ("seedIsSome",

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -185,6 +185,7 @@ lang LoadRuntime =
       ("mcmcLightweightGlobalProb", float_ options.mcmcLightweightGlobalProb),
       ("mcmcLightweightReuseLocal", bool_ options.mcmcLightweightReuseLocal),
       ("printAcceptanceRate", bool_ options.printAcceptanceRate),
+      ("subsample", bool_ options.subsample),
 
       -- NOTE(dlunde,2022-11-04): Emulating option type
       ("seedIsSome",

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
@@ -93,9 +93,10 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
   in
   let particles = start () in
   match runRec particles with (weights,samples) in
+
   -- Return
   if compileOptions.subsample then
-    constructDistEmpiricalSimplified 1 samples weights
+    constructDistEmpiricalSubsample compileOptions.subsampleSize samples weights
       (EmpNorm {normConst = normConstant weights})
   else
     constructDistEmpirical samples weights

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
@@ -94,5 +94,9 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
   let particles = start () in
   match runRec particles with (weights,samples) in
   -- Return
-  constructDistEmpirical samples weights
-    (EmpNorm {normConst = normConstant weights})
+  if compileOptions.subsample then
+    constructDistEmpiricalSimplified 1 samples weights
+      (EmpNorm {normConst = normConstant weights})
+  else
+    constructDistEmpirical samples weights
+      (EmpNorm {normConst = normConstant weights})

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/runtime.mc
@@ -95,5 +95,9 @@ let run : all a. all b. Unknown
   match runRec particles with (weights, samples) in
 
   -- Return
+  if compileOptions.subsample then
+    constructDistEmpiricalSimplified 1 samples weights
+      (EmpNorm {normConst = normConstant weights})
+  else
   constructDistEmpirical samples weights
     (EmpNorm {normConst = normConstant weights})

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/runtime.mc
@@ -96,7 +96,7 @@ let run : all a. all b. Unknown
 
   -- Return
   if compileOptions.subsample then
-    constructDistEmpiricalSimplified 1 samples weights
+    constructDistEmpiricalSubsample compileOptions.subsampleSize samples weights
       (EmpNorm {normConst = normConstant weights})
   else
   constructDistEmpirical samples weights

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -66,10 +66,14 @@ type Options = {
   odeSolverMethod: String,
 
   -- Size of fixed step-size ODE solvers
-  stepSize: Float
+  stepSize: Float,
+  
   -- Whether to subsample the posterior distribution
   -- used in conjuction with smc-apf and smc-bpf and without no-print-samples
-  subsample: Bool
+  subsample: Bool,
+
+  -- Used in conjuction with subsample, how many subsamples to take
+  subsampleSize: Int
 }
 
 -- Default values for options
@@ -97,12 +101,10 @@ let default = {
   pmcmcParticles = 2,
   seed = None (),
   extractSimplification = "none",
-<<<<<<< HEAD
   odeSolverMethod = "rk4",
-  stepSize = 1e-3
-=======
-  subsample = false
->>>>>>> 62309ea (Limited support for subsampling the posterior distribution of SMC models to save memory)
+  stepSize = 1e-3,
+  subsample = false,
+  subsampleSize = 1
 }
 
 -- Options configuration
@@ -220,7 +222,6 @@ let config = [
     join ["Temporary flag that decides the simplification approach after extraction in the MExpr compiler backend. The supported options are: none, inline, and peval. Default: ", default.extractSimplification, ". Eventually, we will remove this option and only use peval."],
     lam p: ArgPart Options.
       let o: Options = p.options in {o with extractSimplification = argToString p}),
-<<<<<<< HEAD
   ([("--ode-solve-method", " ", "<method>")],
     join [
       "The selected ODE solving method. The supported methods are: rk4. Default: ",
@@ -233,13 +234,20 @@ let config = [
      "The step-size for fixed step-size ODE solvers. Default: ",
      float2string default.stepSize, "."
    ],
-   lam p : ArgPart Options. let o : Options = p.options in {o with stepSize = argToFloatMin p 0. })
-=======
+   lam p : ArgPart Options. let o : Options = p.options in {o with stepSize = argToFloatMin p 0. }),
+
   ([("--subsample", "", "")],
     "Whether to subsample the posterior distribution. Use in conjuction with -m smc-apf or smc-bpf and without --no-print-samples",
     lam p: ArgPart Options.
-      let o: Options = p.options in {o with subsample = true})
->>>>>>> 62309ea (Limited support for subsampling the posterior distribution of SMC models to save memory)
+      let o: Options = p.options in {o with subsample = true}),
+
+  ([("-n", " ", "<subsample size>")],
+   join [
+        "The number of subsamples to draw if --subsample is selected. Default: ",
+    int2string default.subsampleSize, "."
+       ],
+       lam p: ArgPart Options.
+        let o: Options = p.options in {o with subsampleSize = argToIntMin p 1})
 ]
 
 -- Menu

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -67,6 +67,9 @@ type Options = {
 
   -- Size of fixed step-size ODE solvers
   stepSize: Float
+  -- Whether to subsample the posterior distribution
+  -- used in conjuction with smc-apf and smc-bpf and without no-print-samples
+  subsample: Bool
 }
 
 -- Default values for options
@@ -94,8 +97,12 @@ let default = {
   pmcmcParticles = 2,
   seed = None (),
   extractSimplification = "none",
+<<<<<<< HEAD
   odeSolverMethod = "rk4",
   stepSize = 1e-3
+=======
+  subsample = false
+>>>>>>> 62309ea (Limited support for subsampling the posterior distribution of SMC models to save memory)
 }
 
 -- Options configuration
@@ -213,6 +220,7 @@ let config = [
     join ["Temporary flag that decides the simplification approach after extraction in the MExpr compiler backend. The supported options are: none, inline, and peval. Default: ", default.extractSimplification, ". Eventually, we will remove this option and only use peval."],
     lam p: ArgPart Options.
       let o: Options = p.options in {o with extractSimplification = argToString p}),
+<<<<<<< HEAD
   ([("--ode-solve-method", " ", "<method>")],
     join [
       "The selected ODE solving method. The supported methods are: rk4. Default: ",
@@ -226,6 +234,12 @@ let config = [
      float2string default.stepSize, "."
    ],
    lam p : ArgPart Options. let o : Options = p.options in {o with stepSize = argToFloatMin p 0. })
+=======
+  ([("--subsample", "", "")],
+    "Whether to subsample the posterior distribution. Use in conjuction with -m smc-apf or smc-bpf and without --no-print-samples",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with subsample = true})
+>>>>>>> 62309ea (Limited support for subsampling the posterior distribution of SMC models to save memory)
 ]
 
 -- Menu


### PR DESCRIPTION
If you compile an SMC model with the flag `--subsample` and do not use
`--no-print-samples`, the program produces only one sample.

This addresses  partially https://github.com/treeppl/treeppl/issues/47.

The next step would be to introduce a parameter of _how many_ subsamples we want, but this is already useful and works with TreePPL

Note: this PR has been based on the latest Miking-dppl that still works with TreePPL, see https://github.com/treeppl/treeppl/wiki/Supported%20Miking%20versions and https://github.com/treeppl/treeppl/pull/67

Misc:   

- introduces a CHANGELOG