### PR TITLE
Add a SolveODE term to miking-dppl

### DIFF
--- a/coreppl/models/ode-harmonic.mc
+++ b/coreppl/models/ode-harmonic.mc
@@ -1,0 +1,11 @@
+let model: () -> [Float] = lam.
+  let f = lam t. lam xs.
+    let x = get xs 0 in
+    let v = get xs 1 in
+    [v, (negf x)]
+  in
+  let x0 = [1., 0.] in
+  solveode (RK4 { stepSize = 1e-4 }) f x0 3.
+
+mexpr
+model ()

--- a/coreppl/src/coreppl-to-mexpr/backcompat.mc
+++ b/coreppl/src/coreppl-to-mexpr/backcompat.mc
@@ -7,7 +7,7 @@ lang CPPLBackcompat = LoadRuntime
   -- TODO(larshum, 2022-10-21): Add support for printing int and bool types.
   -- This is problematic as their pretty-print functions are not built-in, nor
   -- are they guaranteed to be included in the user code.
-  sem getTypePrintFunction : RuntimeEntry -> Type -> Expr
+  sem getTypePrintFunction : InferRuntimeEntry -> Type -> Expr
   sem getTypePrintFunction runtimeEntry =
   | TyInt _ -> var_ "int2string"
   | TyBool _ -> var_ "bool2string"
@@ -34,7 +34,7 @@ lang CPPLBackcompat = LoadRuntime
 
   -- Applies a transformation on full-program models, that allows them to be
   -- compiled in the same way as programs that use infer.
-  sem programModelTransform : Options -> Expr -> (Map InferMethod RuntimeEntry, Expr)
+  sem programModelTransform : Options -> Expr -> (Map InferMethod InferRuntimeEntry, Expr)
   sem programModelTransform options =
   | ast ->
       let inferMethod = inferMethodFromOptions options options.method in

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -154,7 +154,7 @@ lang MExprCompile =
     mexprCompile options inferRuntimes ast
 
 
-  sem mexprCompile : Options -> Runtimes -> Expr -> Expr
+  sem mexprCompile : Options -> InferRuntimes -> Expr -> Expr
   sem mexprCompile options runtimes =
   | corepplAst ->
     -- Symbolize and type-check the CorePPL AST.
@@ -212,7 +212,8 @@ lang MExprCompile =
     -- Return complete program
     prog
 
-  sem compileModels : Options -> Runtimes -> Map Name ModelRepr -> Map Name Expr
+  sem compileModels
+    : Options -> InferRuntimes -> Map Name ModelRepr -> Map Name Expr
   sem compileModels options runtimes =
   | models ->
     mapMapWithKey
@@ -274,7 +275,8 @@ lang MExprCompile =
     in
     t
 
-  sem compileModel : ((Expr,Expr) -> Expr) -> RuntimeEntry -> Name -> ModelRepr -> Expr
+  sem compileModel
+    : ((Expr,Expr) -> Expr) -> InferRuntimeEntry -> Name -> ModelRepr -> Expr
   sem compileModel compile entry modelId =
   | {ast = modelAst, params = modelParams} ->
 

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -279,6 +279,28 @@ lang DPPLExtract =
 
   | expr -> smapAccumL_Expr_Expr (inlineSingleUseH m) me expr
 
+  -- Extracts solveode terms to a map from ODE solver methods to names. Each
+  -- solveode term is replaced by an application of an identifier the named
+  -- according to the returned map.
+  sem extractSolveODE : Expr -> (Map ODESolverMethod Name, Expr)
+  sem extractSolveODE =| tm ->
+    recursive let inner = lam acc. lam tm.
+      match tm with TmSolveODE r then
+        let f : Name -> Expr = lam name.
+          appf4_ (nvar_ name)
+            (odeSolverMethodConfig r.info r.method) r.model r.init r.endTime
+        in
+        optionMapOrElse
+          (lam.
+            let name = nameSym (odeSolverMethodToString r.method) in
+            let acc = mapInsert r.method name acc in
+            (acc, f name))
+          (lam name. (acc, f name))
+          (mapLookup r.method acc)
+      else smapAccumL_Expr_Expr inner acc tm
+    in
+    inner (mapEmpty cmpODESolverMethod) tm
 end
 
 let extractInfer = use DPPLExtract in extractInfer
+let extractSolveODE = use DPPLExtract in extractSolveODE

--- a/coreppl/src/coreppl-to-mexpr/runtime-ode-wrapper.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-ode-wrapper.mc
@@ -1,0 +1,6 @@
+include "runtime-ode.mc"
+
+mexpr
+-- Allows us to use dead-code elimination without loosing the functions we want
+-- to keep. The downside is that we get an ugly printout when we test this file.
+dprint odeSolverRK4Solve

--- a/coreppl/src/coreppl-to-mexpr/runtime-ode.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-ode.mc
@@ -1,0 +1,125 @@
+include "math.mc"
+
+type ODEFnArg = {
+  t : Float,                    -- free variable t
+  xs : [Float],                 -- states x(t) ∈ ℝ^nx
+  us : [Float],                 -- inputs u(t) ∈ ℝ^nu
+  ps : [Float]                  -- parameters p ∈ ℝ^np
+}
+
+-- ** INTEGRATION STEP FUNCTION
+-- Fourth order explicit Runge Kutta (RK4) ODEs integration step.
+-- `f`    : function that computes x'(t) ∈ ℝ^nx
+-- `xidxs` : index vector of size nx
+-- `h`    : step-size of the integration
+-- `t`    : value of t
+-- `xs`   : values of the states x(t) ∈ ℝ^nx
+-- `us`   : inputs u ∈ ℝ^nu
+-- `ps`   : parameters p ∈ ℝ^np
+let odeSolverRK4Step :
+  (ODEFnArg -> [Float])
+   -> [Int]
+     -> Float
+       -> Float
+         -> [Float]
+           -> [Float]
+             -> [Float]
+               -> [Float] =
+  lam f. lam xidxs. lam h. lam t. lam xs. lam us. lam ps.
+    let _map2 = lam f. lam seq1. lam seq2.
+      create (length seq1) (lam i. f (get seq1 i) (get seq2 i))
+    in
+    let h2 = divf h 2. in
+    let t2 = addf t h2 in
+    let th = addf t h in
+    let k1s = f { t = t, xs = xs, us = us, ps = ps } in
+    let tmps = _map2 (lam x. lam k. addf x (mulf h2 k)) xs k1s in
+    let k2s = f { t = t2, xs = tmps, us = us, ps = ps} in
+    let tmps = _map2 (lam x. lam k. addf x (mulf h2 k)) xs k2s in
+    let k3s = f { t = t2, xs = tmps, us = us, ps = ps } in
+    let tmps = _map2 (lam x. lam k. addf x (mulf h k)) xs k3s in
+    let k4s = f { t = th, xs = tmps, us = us, ps = ps } in
+    map
+      (lam i.
+        let k1 = get k1s i in
+        let k2 = mulf 2. (get k2s i) in
+        let k3 = mulf 2. (get k3s i) in
+        let k4 = get k4s i in
+        let x = get xs i in
+          addf x (mulf h (divf (addf k1 (addf k2 (addf k3 k4))) 6.)))
+      xidxs
+
+let odeSolverRK4Solve :
+  { stepSize : Float }
+    -> (Float -> [Float] -> [Float])
+       -> [Float]
+         -> Float
+           -> [Float] =
+  lam opt. lam f. lam x0. lam tf.
+    if ltf tf 0. then
+      error "odeSolverRK4Solve: negative final time"
+    else
+      if ltf opt.stepSize 0. then
+        error "odeSolverRK4Solve: negative step size"
+      else
+        if eqf tf 0. then x0
+        else
+          let xidxs = mapi (lam i. lam. i) x0 in
+          recursive let recur = lam i. lam xs.
+            if gtf (absf i) 0. then
+              let h = minf i opt.stepSize in
+              let xs =
+                odeSolverRK4Step
+                  (lam arg. f arg.t arg.xs) xidxs h (subf tf i) xs [] []
+              in
+              recur (subf i h) xs
+            else xs
+          in
+          recur tf x0
+
+mexpr
+
+recursive let eqSeq = lam eq. lam seq1. lam seq2.
+  switch (seq1, seq2)
+    case ([],[]) then true
+    case ([a] ++ seq1,[b] ++ seq2) then
+      if eq a b then eqSeq eq seq1 seq2
+      else false
+    case _ then false
+  end
+in
+
+-- Harmonic oscillator
+let f = lam t. lam xs.
+  let x = get xs 0 in
+  let v = get xs 1 in
+  [
+    v,
+    (negf x)
+  ]
+in
+
+let x0 = [1., 0.] in
+
+-- Analytical solution
+let xs = lam t. [cos t, negf (sin t)] in
+
+let eq = eqSeq (eqfApprox 1e-7) in
+
+utest xs 0. with x0 using eq in
+
+
+-- ┌─────────────────┐
+-- │ Test RK4 Solver │
+-- └─────────────────┘
+
+utest xs 0. with x0 using eq in
+
+let opt = { stepSize = 1e-4 } in
+
+let xsHat = odeSolverRK4Solve opt f x0 in
+utest xsHat 1. with xs 1. using eq in
+utest xsHat 2. with xs 2. using eq in
+utest xsHat 3. with xs 3. using eq in
+
+()

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -15,7 +15,8 @@ include "mcmc-lightweight/compile.mc"
 include "pmcmc-pimh/compile.mc"
 
 lang LoadRuntime =
-  DPPLParser + MExprSym + MExprFindSym + MExprEliminateDuplicateCode
+  DPPLParser +
+  MExprSym + MExprFindSym + MExprSubstitute + MExprEliminateDuplicateCode
 
   type RuntimeEntry = {
     -- An AST representation of the runtime
@@ -74,17 +75,21 @@ lang LoadRuntime =
       mapInsert t.method (loadRuntimeEntry t.method runtime) acc
   | t -> sfold_Expr_Expr (loadRuntimesH options) acc t
 
-  sem loadRuntimeEntry : InferMethod -> String -> RuntimeEntry
-  sem loadRuntimeEntry method =
+  sem loadRuntime : Bool -> String -> Expr
+  sem loadRuntime eliminateDeadCode =
   | runtime ->
     let parse = use BootParser in parseMCoreFile {
       defaultBootParserParseMCoreFileArg with
-        eliminateDeadCode = false,
+        eliminateDeadCode = eliminateDeadCode,
         allowFree = true
       }
     in
-    let runtime = parse (join [corepplSrcLoc, "/coreppl-to-mexpr/", runtime]) in
-    let runtime = symbolizeAllowFree runtime in
+    parse (join [corepplSrcLoc, "/coreppl-to-mexpr/", runtime])
+
+  sem loadRuntimeEntry : InferMethod -> String -> RuntimeEntry
+  sem loadRuntimeEntry method =
+  | runtime ->
+    let runtime = symbolizeAllowFree (loadRuntime false runtime) in
     match findRequiredRuntimeIds method runtime with (runId, stateId) in
     let stateType = findStateType method stateId runtime in
     { ast = runtime, runId = runId, stateType = stateType
@@ -137,9 +142,37 @@ lang LoadRuntime =
     else findStateTypeH stateId acc inexpr
   | t -> sfold_Expr_Expr (findStateTypeH stateId) acc t
 
-  sem combineRuntimes : Options -> Map InferMethod RuntimeEntry -> Runtimes
-  sem combineRuntimes options =
-  | runtimes ->
+  -- Combines a sequence `runtimes` of runtime terms which are combined from
+  -- left to right, discarding the final "inexpr" term. Duplicated code is
+  -- removed from the combined runtime and all references are updated in the
+  -- term `tm`. This function assumes that all terms are symbolized.
+  sem combineRuntimes : [Expr] -> Expr -> (Expr, Expr)
+  sem combineRuntimes runtimes =| tm ->
+    match eliminateDuplicateCodeWithSummary (bindall_ runtimes)
+      with (replacements, runtime)
+    in
+    (runtime, substituteIdentifiers replacements tm)
+
+  -- Combines non-inference runtime with an inference runtime (from left to
+  -- right). Duplicated code is removed from the combined runtime and all
+  -- references are updated in the term `tm`.
+  sem combineRuntimeWithInferRuntime 
+    : Expr -> InferRuntime -> Expr -> (InferRuntime, Expr)
+  sem combineRuntimeWithInferRuntime runtime inferRuntime =| tm ->
+    match
+      eliminateDuplicateCodeWithSummary (bindall_ [runtime, inferRuntime.ast])
+      with (replacements, runtime)
+    in
+    ({
+      entries = _updateRuntimeEntriesSymEnv replacements inferRuntime.entries,
+      ast = runtime
+    },
+     substituteIdentifiers replacements tm)
+
+  -- Combines inference runtimes, removing duplicate code.
+  sem combineInferRuntimes : Options -> Map InferMethod RuntimeEntry -> Runtimes
+  sem combineInferRuntimes options =
+  | entries ->
     -- Construct record accessible at runtime
     -- NOTE(dlunde,2022-06-28): It would be nice if we automatically lift the
     -- options variable here to an Expr.
@@ -159,7 +192,7 @@ lang LoadRuntime =
 
     ]) in
 
-    let runtimeAsts = map (lam entry. entry.ast) (mapValues runtimes) in
+    let runtimeAsts = map (lam entry. entry.ast) (mapValues entries) in
 
     -- Concatenate the runtime record and the runtime ASTs.
     let ast = bindall_ (join [[pre], runtimeAsts]) in
@@ -167,16 +200,20 @@ lang LoadRuntime =
     -- Eliminate duplicate code in the combined AST of all runtimes, and update
     -- the symbolization environments of the individual runtimes accordingly.
     match eliminateDuplicateCodeWithSummary ast with (replacements, ast) in
-    let runtimes =
-      mapMapWithKey
-        (lam. lam runtime. updateSymEnv replacements runtime)
-        runtimes in
+    {entries = _updateRuntimeEntriesSymEnv replacements entries, ast = ast}
 
-    {entries = runtimes, ast = ast}
+  sem _updateRuntimeEntriesSymEnv
+    : Map Name Name -> Map InferMethod RuntimeEntry
+      -> Map InferMethod RuntimeEntry
+  sem _updateRuntimeEntriesSymEnv replacements =| entries ->
+    mapMapWithKey
+      (lam. lam entry.
+        {entry with topSymEnv = _updateSymEnv replacements entry.topSymEnv})
+      entries
 
-  sem updateSymEnv : Map Name Name -> RuntimeEntry -> RuntimeEntry
-  sem updateSymEnv replacements =
-  | entry ->
+  sem _updateSymEnv : Map Name Name -> SymEnv -> SymEnv
+  sem _updateSymEnv replacements =
+  | symEnv ->
     let replaceId = lam id.
       optionGetOrElse (lam. id) (mapLookup id replacements)
     in
@@ -186,5 +223,5 @@ lang LoadRuntime =
                    conEnv = replaceInEnv symEnv.conEnv,
                    tyConEnv = replaceInEnv symEnv.tyConEnv}
     in
-    {entry with topSymEnv = replaceInSymEnv entry.topSymEnv}
+    replaceInSymEnv symEnv
 end

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -19,6 +19,7 @@ include "mexpr/const-arity.mc"
 include "peval/peval.mc"
 
 include "string.mc"
+include "utest.mc"
 
 include "dist.mc"
 include "infer-method.mc"
@@ -437,6 +438,131 @@ lang ObserveWeightTranslation = Observe + Weight
 -/
 end
 
+lang SolveODE =
+  Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval
+
+  syn Expr =
+  | TmSolveODE { model: Expr,
+                 init: Expr,
+                 endTime: Expr,
+                 ty: Type,
+                 info: Info }
+
+  sem infoTm =
+  | TmSolveODE t -> t.info
+
+  sem tyTm =
+  | TmSolveODE t -> t.ty
+
+  sem withInfo (info: Info) =
+  | TmSolveODE t -> TmSolveODE { t with info = info }
+
+  sem withType (ty: Type) =
+  | TmSolveODE t -> TmSolveODE { t with ty = ty }
+
+  sem smapAccumL_Expr_Expr f acc =
+  | TmSolveODE t ->
+    match f acc t.model with (acc, model) in
+    match f acc t.init with (acc, init) in
+    match f acc t.endTime with (acc, endTime) in
+    (acc, TmSolveODE { t with model = model, init = init, endTime = endTime })
+
+  -- Pretty printing
+  sem isAtomic =
+  | TmSolveODE _ -> false
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmSolveODE t ->
+    let i = pprintIncr indent in
+    match printParen i env t.model with (env, model) in
+    match printParen i env t.init with (env, init) in
+    match printParen i env t.endTime with (env, endTime) in
+    (env, join [
+      "solveode",
+      pprintNewline i, model,
+      pprintNewline i, init,
+      pprintNewline i, endTime
+    ])
+
+  -- Equality
+  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
+  | TmSolveODE r ->
+    match lhs with TmSolveODE l then
+      optionFoldlM (lam free. uncurry (eqExprH free env)) free
+        [(l.model, r.model), (l.init, r.init), (l.endTime, r.endTime)]
+    else None ()
+
+  -- Symbolize
+  sem symbolizeExpr (env: SymEnv) =
+  | TmSolveODE t ->
+    TmSolveODE { t with
+                 model = symbolizeExpr env t.model,
+                 init = symbolizeExpr env t.init,
+                 endTime = symbolizeExpr env t.endTime,
+                 ty = symbolizeType env t.ty }
+
+  -- Type check
+  sem typeCheckExpr (env : TCEnv) =
+  | TmSolveODE t ->
+    let model = typeCheckExpr env t.model in
+    let init = typeCheckExpr env t.init in
+    let endTime = typeCheckExpr env t.endTime in
+    let tyModel = newvar env.currentLvl t.info in
+    let tyfloat_ = ityfloat_ t.info in
+    let tyseq_ = ityseq_ t.info tyfloat_ in
+    unify env [infoTm model]
+      (ityarrow_ t.info tyfloat_ (ityarrow_ t.info tyseq_ tyseq_))
+      (tyTm model);
+    unify env [infoTm init] tyseq_ (tyTm init);
+    unify env [infoTm endTime] tyfloat_ (tyTm endTime);
+    TmSolveODE { t with
+                 model = model,
+                 init = init,
+                 endTime = endTime,
+                 ty = tyseq_ }
+
+  -- ANF
+  sem normalize (k : Expr -> Expr) =
+  | TmSolveODE t ->
+    normalizeName (lam endTime.
+      normalizeName (lam init.
+        normalizeName (lam model.
+          k (TmSolveODE { t with
+                          model = model, init = init, endTime = endTime }))
+          t.model)
+        t.init)
+      t.endTime
+
+  -- Type lift
+  sem typeLiftExpr (env : TypeLiftEnv) =
+  | TmSolveODE t ->
+    match typeLiftExpr env t.model with (env, model) in
+    match typeLiftExpr env t.init with (env, init) in
+    match typeLiftExpr env t.endTime with (env, endTime) in
+    match typeLiftType env t.ty with (env, ty) in
+    (env, TmSolveODE { t with
+                       model = model,
+                       init = init,
+                       endTime = endTime,
+                       ty = ty })
+
+  -- Partial evaluation
+  sem pevalBindThis =
+  | TmSolveODE _ -> true
+
+  sem pevalEval ctx k =
+  | TmSolveODE r ->
+    pevalBind ctx (lam model.
+      pevalBind ctx (lam init.
+        pevalBind ctx (lam endTime.
+          k (TmSolveODE { r with
+                          model = model,
+                          init = init,
+                          endTime = endTime }))
+          r.endTime)
+        r.init)
+      r.model
+end
 
 -----------------
 -- AST BUILDER --
@@ -456,7 +582,10 @@ let observe_ = use Observe in
 let weight_ = use Weight in
   lam w. TmWeight {weight = w, ty = tyunknown_, info = NoInfo ()}
 
-
+let solveode_ = use SolveODE in
+  lam m. lam i. lam t.
+    TmSolveODE
+      { model = m, init = i, endTime = t, ty = tyunknown_, info = NoInfo () }
 
 ---------------------------
 -- LANGUAGE COMPOSITIONS --
@@ -472,10 +601,17 @@ let pplKeywords = [
   "Exponential", "Empirical", "Gaussian", "Binomial"
 ]
 
-let mexprPPLKeywords = concat mexprKeywords pplKeywords
+lang CoreDPL = Ast + SolveODE end
+
+let dplKeywords = [
+  "solveode"
+]
+
+let mexprPPLKeywords = join [mexprKeywords, pplKeywords, dplKeywords]
 
 lang MExprPPL =
-  CorePPL + MExprAst + MExprPrettyPrint + MExprEq + MExprSym +
+  CorePPL + CoreDPL +
+  MExprAst + MExprPrettyPrint + MExprEq + MExprSym +
   MExprTypeCheck + MExprTypeLift + MExprArity
 
   sem mexprPPLToString =
@@ -493,18 +629,30 @@ use Test in
 let tmAssume = assume_ (bern_ (float_ 0.7)) in
 let tmObserve = observe_ (float_ 1.5) (beta_ (float_ 1.0) (float_ 2.0)) in
 let tmWeight = weight_ (float_ 1.5) in
+let tmODE =
+  ulams_ ["t", "x"]
+    (seq_ [
+      get_ (var_ "x") (int_ 0),
+      subf_ (negf_ (get_ (var_ "x") (int_ 1))) (get_ (var_ "x") (int_ 0))
+    ])
+in
+let tmX0 = seq_ [float_ 1., float_ 0.] in
+let tmTEnd = float_ 1. in
+let tmSolveODE = solveode_ tmODE tmX0 tmTEnd in
 
 ------------------------
 -- PRETTY-PRINT TESTS --
 ------------------------
 -- TODO(dlunde,2021-04-28): TmInfer test
 
+let _toStr = utestDefaultToString (lam x. x) (lam x. x) in
+
 utest mexprPPLToString tmAssume
 with strJoin "\n" [
   "assume",
   "  (Bernoulli",
   "     0.7)"
-] using eqString in
+] using eqString else _toStr in
 
 utest mexprPPLToString tmObserve
 with strJoin "\n" [
@@ -513,54 +661,98 @@ with strJoin "\n" [
   "  (Beta",
   "     1.",
   "     2.)"
-] using eqString in
+] using eqString else _toStr in
 
 utest mexprPPLToString tmWeight
 with strJoin "\n" [
   "weight",
   "  1.5"
-] using eqString in
+] using eqString else _toStr in
+
+utest mexprPPLToString tmSolveODE
+with strJoin "\n" [
+  "solveode",
+  "  (lam t.",
+  "     lam x.",
+  "       [ get",
+  "           x",
+  "           0,",
+  "         subf",
+  "           (negf",
+  "              (get",
+  "                 x",
+  "                 1))",
+  "           (get",
+  "              x",
+  "              0) ])",
+  "  [ 1.,",
+  "    0. ]",
+  "  1."
+] using eqString else _toStr in
 
 --------------------
 -- EQUALITY TESTS --
 --------------------
 -- TODO(dlunde,2021-04-28): TmInfer test
 
-utest tmAssume with tmAssume using eqExpr in
-utest eqExpr tmAssume (assume_ (bern_ (float_ 0.6)))
-with false in
+let _toStr = utestDefaultToString mexprPPLToString mexprPPLToString in
+let neqExpr = lam l. lam r. not (eqExpr l r) in
 
-utest tmObserve with tmObserve using eqExpr in
-utest eqExpr tmObserve (observe_ (float_ 1.5) (beta_ (float_ 1.0) (float_ 2.1)))
-with false in
+utest tmAssume with tmAssume using eqExpr else _toStr in
+utest tmAssume with (assume_ (bern_ (float_ 0.6))) using neqExpr else _toStr in
 
-utest tmWeight with tmWeight using eqExpr in
-utest eqExpr tmWeight ((weight_ (float_ 1.6)))
-with false in
+utest tmObserve with tmObserve using eqExpr else _toStr in
+utest tmObserve with (observe_ (float_ 1.5) (beta_ (float_ 1.0) (float_ 2.1)))
+  using neqExpr else _toStr
+in
+
+utest tmWeight with tmWeight using eqExpr else _toStr in
+utest tmWeight with ((weight_ (float_ 1.6))) using neqExpr else _toStr in
+
+utest tmSolveODE with tmSolveODE using eqExpr else _toStr in
+utest tmSolveODE with solveode_ tmODE tmX0 (float_ 2.)
+  using neqExpr else _toStr
+in
 
 ----------------------
 -- SMAP/SFOLD TESTS --
 ----------------------
 -- TODO(dlunde,2021-04-28): TmInfer test
 
+let _tmsToStr = lam tms. strJoin "," (map mexprPPLToString tms) in
+let _seqToStr = utestDefaultToString _tmsToStr _tmsToStr in
+
 let tmVar = var_ "x" in
 let mapVar = (lam. tmVar) in
 let foldToSeq = lam a. lam e. cons e a in
 
-utest smap_Expr_Expr mapVar tmAssume with assume_ tmVar using eqExpr in
+utest smap_Expr_Expr mapVar tmAssume with assume_ tmVar using eqExpr
+  else _toStr
+in
 utest sfold_Expr_Expr foldToSeq [] tmAssume
-with [ bern_ (float_ 0.7) ] using eqSeq eqExpr in
+with [ bern_ (float_ 0.7) ] using eqSeq eqExpr else _seqToStr in
 
-utest smap_Expr_Expr mapVar tmObserve with observe_ tmVar tmVar using eqExpr in
+utest smap_Expr_Expr mapVar tmObserve with observe_ tmVar tmVar using eqExpr
+  else _toStr
+in
 utest sfold_Expr_Expr foldToSeq [] tmObserve
 with [
   (beta_ (float_ 1.0) (float_ 2.0)),
   (float_ 1.5)
-] using eqSeq eqExpr in
+] using eqSeq eqExpr else _seqToStr in
 
-utest smap_Expr_Expr mapVar tmWeight with weight_ tmVar using eqExpr in
+utest smap_Expr_Expr mapVar tmWeight with weight_ tmVar using eqExpr
+  else _toStr
+in
 utest sfold_Expr_Expr foldToSeq [] tmWeight
-with [ float_ 1.5 ] using eqSeq eqExpr in
+with [ float_ 1.5 ] using eqSeq eqExpr else _seqToStr in
+
+utest smap_Expr_Expr mapVar tmSolveODE
+  with solveode_ tmVar tmVar tmVar
+  using eqExpr else _toStr
+in
+utest sfold_Expr_Expr foldToSeq [] tmSolveODE
+with [ tmTEnd, tmX0, tmODE ] using eqSeq eqExpr else _seqToStr in
 
 ---------------------
 -- SYMBOLIZE TESTS --
@@ -570,6 +762,7 @@ with [ float_ 1.5 ] using eqSeq eqExpr in
 utest symbolize tmAssume with tmAssume using eqExpr in
 utest symbolize tmObserve with tmObserve using eqExpr in
 utest symbolize tmWeight with tmWeight using eqExpr in
+utest symbolize tmSolveODE with tmSolveODE using eqExpr in
 
 
 ----------------------
@@ -580,6 +773,7 @@ utest symbolize tmWeight with tmWeight using eqExpr in
 utest tyTm (typeCheck tmAssume) with tybool_ using eqType in
 utest tyTm (typeCheck tmObserve) with tyunit_ using eqType in
 utest tyTm (typeCheck tmWeight) with tyunit_ using eqType in
+utest tyTm (typeCheck tmSolveODE) with tyseq_ tyfloat_ using eqType in
 
 ---------------
 -- ANF TESTS --
@@ -592,16 +786,26 @@ utest _anf tmAssume with bindall_ [
   ulet_ "t" (bern_ (float_ 0.7)),
   ulet_ "t1" (assume_ (var_ "t")),
   var_ "t1"
-] using eqExpr in
+] using eqExpr else _toStr in
 utest _anf tmObserve with bindall_ [
   ulet_ "t" (beta_ (float_ 1.0) (float_ 2.0)),
   ulet_ "t1" (observe_ (float_ 1.5) (var_ "t")),
   var_ "t1"
-] using eqExpr in
+] using eqExpr else _toStr in
 utest _anf tmWeight with bindall_ [
   ulet_ "t" (weight_ (float_ 1.5)),
   var_ "t"
-] using eqExpr in
+] using eqExpr else _toStr in
+utest _anf (solveode_ (ulams_ ["t", "x"] (seq_ [float_ 1.])) tmX0 tmTEnd)
+  with bindall_ [
+    ulet_ "t" tmX0,
+    ulet_ "t1"
+      (solveode_
+         (ulams_ ["t", "x"]
+            (bind_ (ulet_ "t" (seq_ [float_ 1.])) (var_ "t"))) (var_ "t")
+         tmTEnd),
+    var_ "t1"
+] using eqExpr else _toStr in
 
 ---------------------
 -- TYPE-LIFT TESTS --
@@ -611,5 +815,6 @@ utest _anf tmWeight with bindall_ [
 utest (typeLift tmAssume).1 with tmAssume using eqExpr in
 utest (typeLift tmObserve).1 with tmObserve using eqExpr in
 utest (typeLift tmWeight).1 with tmWeight using eqExpr in
+utest (typeLift tmSolveODE).1 with tmSolveODE using eqExpr in
 
 ()

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -117,8 +117,8 @@ lang Infer =
     else never
 
   -- Partial evaluation
-  sem pevalIsValue =
-  | TmInfer _ -> false
+  sem pevalBindThis =
+  | TmInfer _ -> true
 
   sem pevalEval ctx k =
   | TmInfer r ->
@@ -203,8 +203,8 @@ lang Assume =
     else never
 
   -- Partial evaluation
-  sem pevalIsValue =
-  | TmAssume _ -> false
+  sem pevalBindThis =
+  | TmAssume _ -> true
 
   sem pevalEval ctx k =
   | TmAssume r ->
@@ -312,8 +312,8 @@ lang Observe =
     else never
 
   -- Partial evaluation
-  sem pevalIsValue =
-  | TmObserve _ -> false
+  sem pevalBindThis =
+  | TmObserve _ -> true
 
   sem pevalEval ctx k =
   | TmObserve r ->
@@ -410,8 +410,8 @@ lang Weight =
     else never
 
   -- Partial evaluation
-  sem pevalIsValue =
-  | TmWeight _ -> false
+  sem pevalBindThis =
+  | TmWeight _ -> true
 
   sem pevalEval ctx k =
   | TmWeight r ->

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -62,8 +62,9 @@ lang Infer =
 
   sem smapAccumL_Expr_Expr f acc =
   | TmInfer t ->
+    match inferSmapAccumL_Expr_Expr f acc t.method with (acc,method) in
     match f acc t.model with (acc,model) in
-    (acc, TmInfer { t with model = model })
+    (acc, TmInfer { t with method = method, model = model })
 
   -- Pretty printing
   sem isAtomic =
@@ -84,13 +85,6 @@ lang Infer =
         eqExprH env free l.model r.model
       else None ()
     else None ()
-
-  -- Symbolize
-  sem symbolizeExpr (env: SymEnv) =
-  | TmInfer t ->
-    TmInfer {{{ t with model = symbolizeExpr env t.model }
-                  with ty = symbolizeType env t.ty }
-                  with method = symbolizeInferMethod env t.method }
 
   -- Type check
   sem typeCheckExpr (env : TCEnv) =
@@ -172,12 +166,6 @@ lang Assume =
     match lhs with TmAssume l then
       eqExprH env free l.dist r.dist
     else None ()
-
-  -- Symbolize
-  sem symbolizeExpr (env: SymEnv) =
-  | TmAssume t ->
-    TmAssume {{ t with dist = symbolizeExpr env t.dist }
-                  with ty = symbolizeType env t.ty }
 
   -- Type check
   sem typeCheckExpr (env : TCEnv) =
@@ -267,13 +255,6 @@ lang Observe =
         eqExprH env free l.dist r.dist
       else None ()
     else None ()
-
-  -- Symbolize
-  sem symbolizeExpr (env: SymEnv) =
-  | TmObserve t ->
-    TmObserve {{{ t with value = symbolizeExpr env t.value }
-                    with dist = symbolizeExpr env t.dist }
-                    with ty = symbolizeType env t.ty }
 
   -- Type check
   sem typeCheckExpr (env : TCEnv) =
@@ -380,12 +361,6 @@ lang Weight =
     match lhs with TmWeight l then
       eqExprH env free l.weight r.weight
     else None ()
-
-  -- Symbolize
-  sem symbolizeExpr (env: SymEnv) =
-  | TmWeight t ->
-    TmWeight {{ t with weight = symbolizeExpr env t.weight }
-                  with ty = symbolizeType env t.ty }
 
   -- Type check
   sem typeCheckExpr (env : TCEnv) =

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -60,7 +60,13 @@ type Options = {
   seed: Option Int,
 
   -- (temporary option, the end-goal is that we should only ever use peval)
-  extractSimplification: String
+  extractSimplification: String,
+
+  -- ODE solver algorithm
+  odeSolverMethod: String,
+
+  -- Size of fixed step-size ODE solvers
+  stepSize: Float
 }
 
 -- Default values for options
@@ -87,7 +93,9 @@ let default = {
   printAcceptanceRate = false,
   pmcmcParticles = 2,
   seed = None (),
-  extractSimplification = "none"
+  extractSimplification = "none",
+  odeSolverMethod = "rk4",
+  stepSize = 1e-3
 }
 
 -- Options configuration
@@ -204,7 +212,20 @@ let config = [
   ([("--extract-simplification", " ", "<option>")],
     join ["Temporary flag that decides the simplification approach after extraction in the MExpr compiler backend. The supported options are: none, inline, and peval. Default: ", default.extractSimplification, ". Eventually, we will remove this option and only use peval."],
     lam p: ArgPart Options.
-      let o: Options = p.options in {o with extractSimplification = argToString p})
+      let o: Options = p.options in {o with extractSimplification = argToString p}),
+  ([("--ode-solve-method", " ", "<method>")],
+    join [
+      "The selected ODE solving method. The supported methods are: rk4. Default: ",
+      default.odeSolverMethod
+    ],
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with odeSolverMethod = argToString p}),
+  ([("--ode-step-size", " ", "<value>")],
+   join [
+     "The step-size for fixed step-size ODE solvers. Default: ",
+     float2string default.stepSize, "."
+   ],
+   lam p : ArgPart Options. let o : Options = p.options in {o with stepSize = argToFloatMin p 0. })
 ]
 
 -- Menu

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -1,62 +1,11 @@
 include "option.mc"
 include "stringid.mc"
-include "mexpr/ast.mc"
 include "mexpr/info.mc"
 include "mexpr/pprint.mc"
 include "mexpr/type-check.mc"
 
+include "method-helper.mc"
 include "dppl-arg.mc"
-
-lang InferMethodHelper = MExprAst + MExprSym
-  -- Extracts the fields corresponding to the provided sequence of strings, and
-  -- ensures that no additional fields have been defined.
-  sem getFields : Info -> Map SID Expr -> [(String, Expr)] -> [Expr]
-  sem getFields info bindings =
-  | fields ->
-    -- Construct a record containing the default values for all fields that may
-    -- occur.
-    match unzip fields with (fieldStrs, defaults) in
-    let defaultRecord =
-      mapFromSeq cmpSID (zip (map stringToSid fieldStrs) defaults) in
-
-    -- If the user-provided record defines fields that are not defined in the
-    -- default record, it means they are trying to set options that are not
-    -- supported.
-    let mapToSet = lam m. mapMapWithKey (lam. lam. ()) m in
-    let unknownFields = setSubtract (mapToSet bindings) (mapToSet defaultRecord) in
-    if mapIsEmpty unknownFields then
-
-      -- Update the record by replacing the default values with values provided
-      -- by the user.
-      let record =
-        mapFoldWithKey
-          (lam record. lam sid. lam expr.
-            if mapMem sid record then mapInsert sid expr record
-            else error "Unexpected field: " (sidToString sid))
-          defaultRecord bindings in
-
-      -- Return the values after updating according to the user-provided
-      -- values, in the same order as they were provided as input. The use of
-      -- filterOption will never result in an error as all fieldStrs are part
-      -- of the default record.
-      filterOption (map (lam s. mapLookup (stringToSid s) record) fieldStrs)
-
-    else
-      let msg = join
-        [ "Unexpected fields: "
-        , strJoin "," (map sidToString (setToSeq unknownFields)), "\n" ] in
-      errorSingle [info] msg
-
-  -- Converts the provided sequence of string-expression tuples to a record
-  -- expression, which is later passed to the runtime.
-  sem fieldsToRecord : Info -> [(String, Expr)] -> Expr
-  sem fieldsToRecord info =
-  | fields ->
-    let bindings =
-      mapFromSeq cmpSID
-        (map (lam f. match f with (str, e) in (stringToSid str, e)) fields) in
-    TmRecord {bindings = bindings, ty = TyUnknown {info = info}, info = info}
-end
 
 -- Defines the basic components required in the implementation of an inference
 -- method.
@@ -68,7 +17,8 @@ end
 -- 3. inferMethodFromOptions
 -- 4. inferMethodConfig
 -- 5. typeCheckInferMethod
-lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
+-- 6. inferSmapAccumL
+lang InferMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
   syn InferMethod =
   | Default { runs: Expr }
 
@@ -121,11 +71,14 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
     unify env [info, infoTm runs] int (tyTm runs);
     Default { runs = runs }
 
-  -- Symbolizes infer methods.
-  sem symbolizeInferMethod : SymEnv -> InferMethod -> InferMethod
-  sem symbolizeInferMethod env =
-  | Default r -> Default {r with runs = symbolizeExpr env r.runs}
-
   -- Overrides the number of runs/iterations/particles in the InferMethod
   sem setRuns : Expr -> InferMethod -> InferMethod
+
+  -- Map/Accum over expressions in inference method
+  sem inferSmapAccumL_Expr_Expr
+    : all a. (a -> Expr -> (a, Expr)) -> a -> InferMethod -> (a, InferMethod)
+  sem inferSmapAccumL_Expr_Expr f acc =
+  | Default r ->
+    match f acc r.runs with (acc, runs) in (acc, Default {r with runs = runs})
+  | m -> printLn (pprintInferMethod 0 pprintEnvEmpty m).1; error "fail"
 end

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -34,8 +34,10 @@ lang ImportanceSamplingMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     Importance {particles = particles}
 
-  sem symbolizeInferMethod env =
-  | Importance r -> Importance {r with particles = symbolizeExpr env r.particles}
+  sem inferSmapAccumL_Expr_Expr f acc =
+  | Importance r ->
+    match f acc r.particles with (acc, particles) in
+    (acc, Importance {r with particles = particles})
 
   sem setRuns expr =
   | Importance r -> Importance {r with particles = expr}

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -58,12 +58,12 @@ lang LightweightMCMCMethod = MExprPPL
       globalProb = globalProb
     }
 
-  sem symbolizeInferMethod env =
+  sem inferSmapAccumL_Expr_Expr f acc =
   | LightweightMCMC r ->
-    LightweightMCMC {r with
-      iterations = symbolizeExpr env r.iterations,
-      globalProb = symbolizeExpr env r.globalProb
-    }
+    match f acc r.iterations with (acc, iterations) in
+    match f acc r.globalProb with (acc, globalProb) in
+    (acc,
+     LightweightMCMC {r with iterations = iterations, globalProb = globalProb})
 
   sem setRuns expr =
   | LightweightMCMC r -> LightweightMCMC {r with iterations = expr}

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -44,9 +44,10 @@ lang NaiveMCMCMethod = MExprPPL
       iterations = iterations
     }
 
-  sem symbolizeInferMethod env =
+  sem inferSmapAccumL_Expr_Expr f acc =
   | NaiveMCMC r ->
-    NaiveMCMC {r with iterations = symbolizeExpr env r.iterations}
+    match f acc r.iterations with (acc, iterations) in
+    (acc, NaiveMCMC {r with iterations = iterations})
 
   sem setRuns expr =
   | NaiveMCMC r -> NaiveMCMC {r with iterations = expr}

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -44,9 +44,10 @@ lang TraceMCMCMethod = MExprPPL
       iterations = iterations
     }
 
-  sem symbolizeInferMethod env =
+  sem inferSmapAccumL_Expr_Expr f acc =
   | TraceMCMC r ->
-    TraceMCMC {r with iterations = symbolizeExpr env r.iterations}
+    match f acc r.iterations with (acc, iterations) in
+    (acc, TraceMCMC {r with iterations = iterations})
 
   sem setRuns expr =
   | TraceMCMC r -> TraceMCMC {r with iterations = expr}

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -47,11 +47,11 @@ lang PIMHMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     PIMH {iterations = iterations, particles = particles}
 
-  sem symbolizeInferMethod env =
-  | PIMH r -> PIMH {r with
-      iterations = symbolizeExpr env r.iterations,
-      particles = symbolizeExpr env r.particles
-    }
+  sem inferSmapAccumL_Expr_Expr f acc =
+  | PIMH r ->
+    match f acc r.iterations with (acc, iterations) in
+    match f acc r.particles with (acc, particles) in
+    (acc, PIMH {r with iterations = iterations, particles = particles})
 
   sem setRuns expr =
   | PIMH r -> PIMH {r with iterations = expr}

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -34,8 +34,10 @@ lang APFMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     APF {particles = particles}
 
-  sem symbolizeInferMethod env =
-  | APF r -> APF {r with particles = symbolizeExpr env r.particles}
+  sem inferSmapAccumL_Expr_Expr f acc =
+  | APF r ->
+    match f acc r.particles with (acc, particles) in
+    (acc, APF {r with particles = particles})
 
   sem setRuns expr =
   | APF r -> APF {r with particles = expr}

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -34,8 +34,10 @@ lang BPFMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     BPF {particles = particles}
 
-  sem symbolizeInferMethod env =
-  | BPF r -> BPF {r with particles = symbolizeExpr env r.particles}
+  sem inferSmapAccumL_Expr_Expr env =
+  | BPF r ->
+    match f acc r.particles with (acc, particles) in
+    (acc, BPF {r with particles = particles})
 
   sem setRuns expr =
   | BPF r -> BPF {r with particles = expr}

--- a/coreppl/src/method-helper.mc
+++ b/coreppl/src/method-helper.mc
@@ -1,0 +1,57 @@
+include "mexpr/info.mc"
+include "mexpr/ast.mc"
+include "error.mc"
+include "seq.mc"
+include "set.mc"
+
+
+lang MethodHelper = MExprAst
+  -- Extracts the fields corresponding to the provided sequence of strings, and
+  -- ensures that no additional fields have been defined.
+  sem getFields : Info -> Map SID Expr -> [(String, Expr)] -> [Expr]
+  sem getFields info bindings =
+  | fields ->
+    -- Construct a record containing the default values for all fields that may
+    -- occur.
+    match unzip fields with (fieldStrs, defaults) in
+    let defaultRecord =
+      mapFromSeq cmpSID (zip (map stringToSid fieldStrs) defaults) in
+
+    -- If the user-provided record defines fields that are not defined in the
+    -- default record, it means they are trying to set options that are not
+    -- supported.
+    let mapToSet = lam m. mapMapWithKey (lam. lam. ()) m in
+    let unknownFields = setSubtract (mapToSet bindings) (mapToSet defaultRecord) in
+    if mapIsEmpty unknownFields then
+
+      -- Update the record by replacing the default values with values provided
+      -- by the user.
+      let record =
+        mapFoldWithKey
+          (lam record. lam sid. lam expr.
+            if mapMem sid record then mapInsert sid expr record
+            else error "Unexpected field: " (sidToString sid))
+          defaultRecord bindings in
+
+      -- Return the values after updating according to the user-provided
+      -- values, in the same order as they were provided as input. The use of
+      -- filterOption will never result in an error as all fieldStrs are part
+      -- of the default record.
+      filterOption (map (lam s. mapLookup (stringToSid s) record) fieldStrs)
+
+    else
+      let msg = join
+        [ "Unexpected fields: "
+        , strJoin "," (map sidToString (setToSeq unknownFields)), "\n" ] in
+      errorSingle [info] msg
+
+  -- Converts the provided sequence of string-expression tuples to a record
+  -- expression, which is later passed to the runtime.
+  sem fieldsToRecord : Info -> [(String, Expr)] -> Expr
+  sem fieldsToRecord info =
+  | fields ->
+    let bindings =
+      mapFromSeq cmpSID
+        (map (lam f. match f with (str, e) in (stringToSid str, e)) fields) in
+    TmRecord {bindings = bindings, ty = TyUnknown {info = info}, info = info}
+end

--- a/coreppl/src/ode-solver-method.mc
+++ b/coreppl/src/ode-solver-method.mc
@@ -1,0 +1,68 @@
+include "option.mc"
+include "stringid.mc"
+include "mexpr/info.mc"
+include "mexpr/pprint.mc"
+include "mexpr/type-check.mc"
+include "mexpr/symbolize.mc"
+
+include "method-helper.mc"
+include "dppl-arg.mc"
+
+-- Defines the basic components required in the implementation of an ODE solver
+-- method.
+--
+-- To define a new ODE solver method constructor, the following semantic
+-- functions must be implemented for the constructor.
+lang ODESolverMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
+  syn ODESolverMethod =
+  | Default { stepSize: Expr }
+
+  -- NOTE(oerikss, 2024-03-08): Compares the inference methods tags only.
+  sem cmpODESolverMethod : ODESolverMethod -> ODESolverMethod -> Int
+  sem cmpODESolverMethod lhs =
+  | rhs -> subi (constructorTag lhs) (constructorTag rhs)
+
+  sem eqODESolverMethod : ODESolverMethod -> ODESolverMethod -> Bool
+  sem eqODESolverMethod lhs =
+  | rhs -> eqi (cmpODESolverMethod lhs rhs) 0
+
+  sem pprintODESolverMethod
+    : Int -> PprintEnv -> ODESolverMethod -> (PprintEnv, String)
+  sem pprintODESolverMethod indent env =
+  | Default { stepSize = stepSize } ->
+    let i = pprintIncr indent in
+    match pprintCode i env stepSize with (env, stepSize) in
+    (env, join ["(Default {stepSize = ", stepSize, "})"])
+
+  -- Constructs an ODE solver method from the arguments of a TmConApp.
+  sem inferMethodFromCon : Info -> Map SID Expr -> String -> ODESolverMethod
+  sem inferMethodFromCon info bindings =
+  | "Default" ->
+    let expectedFields = [
+      ("stepSize", float_ default.stepSize)
+    ] in
+    match getFields info bindings expectedFields with [stepSize] in
+    Default { stepSize = stepSize }
+  | s -> errorSingle [info] (concat "Unknown ODE solver method: " s)
+
+  -- Produces a record expression containing the configuration parameters of the
+  -- ODE solver method. This record is passed to the inference runtime function.
+  sem odeSolverMethodConfig : Info -> ODESolverMethod -> Expr
+  sem odeSolverMethodConfig info =
+  | Default { stepSize = stepSize } -> fieldsToRecord info [("stepSize", stepSize)]
+
+  -- Type checks the ODE solver method. This ensures that the provided arguments
+  -- have the correct types.
+  sem typeCheckODESolverMethod : TCEnv -> Info -> ODESolverMethod -> ODESolverMethod
+  sem typeCheckODESolverMethod env info =
+  | Default { stepSize = stepSize } ->
+    let float = TyFloat {info = info} in
+    let stepSize = typeCheckExpr env stepSize in
+    unify env [info, infoTm stepSize] float (tyTm stepSize);
+    Default { stepSize = stepSize }
+
+  -- Symbolizes infer methods.
+  sem symbolizeODESolverMethod : SymEnv -> ODESolverMethod -> ODESolverMethod
+  sem symbolizeODESolverMethod env =
+  | Default r -> Default {r with stepSize = symbolizeExpr env r.stepSize}
+end

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -52,6 +52,7 @@ lang DPPLParser =
   | TmInfer _ -> true
   | TmDist _ -> true
   | TmPlate _ -> true
+  | TmSolveODE _ -> true
 
   sem matchKeywordString (info: Info) =
   | "assume" -> Some (1, lam lst. TmAssume {dist = get lst 0,
@@ -110,6 +111,11 @@ lang DPPLParser =
   | "Binomial" -> Some (2, lam lst. TmDist {dist = DBinomial {n = get lst 0, p = get lst 1},
                                         ty = TyUnknown {info = info},
                                         info = info})
+  | "solveode" -> Some (3, lam lst. TmSolveODE {model = get lst 0,
+                                             init = get lst 1,
+                                             endTime = get lst 2,
+                                             ty = TyUnknown {info = info},
+                                             info = info})
 
   sem isTypeKeyword =
   | TyDist _ -> true

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -22,15 +22,20 @@ lang DPPLParser =
 
   ImportanceSamplingMethod + BPFMethod + APFMethod +
   LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod +
-	PIMHMethod
+  PIMHMethod
+
+  sem _interpretMethod : Expr -> (Info, String, Map SID Expr)
+  sem _interpretMethod =
+  | TmConApp {ident = ident, body = TmRecord r, info = info} ->
+    (info, nameGetStr ident, r.bindings)
+  | t -> errorSingle [infoTm t] "Expected a constructor application"
 
   -- Interprets the argument to infer which encodes the inference method and
   -- its configuration parameters.
   sem interpretInferMethod : Expr -> InferMethod
-  sem interpretInferMethod =
-  | TmConApp {ident = ident, body = TmRecord {bindings = bindings}, info = info} ->
-    inferMethodFromCon info bindings (nameGetStr ident)
-  | t -> errorSingle [infoTm t] "Expected a constructor application"
+  sem interpretInferMethod =| tm ->
+    match _interpretMethod tm with (info, ident, bindings) in
+    inferMethodFromCon info bindings ident
 
 
   sem replaceDefaultInferMethod : Options -> Expr -> Expr

--- a/coreppl/src/solveode/rk4.mc
+++ b/coreppl/src/solveode/rk4.mc
@@ -1,0 +1,42 @@
+include "../ode-solver-method.mc"
+
+lang RK4Method = ODESolverMethodBase
+  syn ODESolverMethod =
+  | RK4 { stepSize: Expr }
+
+  sem odeSolverMethodToString =
+  | RK4 _ -> "RK4"
+
+  sem pprintODESolverMethod indent env =
+  | RK4 { stepSize = stepSize } ->
+    let i = pprintIncr indent in
+    match pprintCode i env stepSize with (env, stepSize) in
+    (env, join ["(RK4 {stepSize = ", stepSize, "})"])
+
+  sem odeSolverMethodFromCon info bindings =
+  | "RK4" ->
+    let expectedFields = [
+      ("stepSize", float_ default.stepSize)
+    ] in
+    match getFields info bindings expectedFields with [stepSize] in
+    RK4 { stepSize = stepSize }
+
+  sem odeSolverMethodConfig info =
+  | RK4 { stepSize = stepSize } ->
+    fieldsToRecord info [("stepSize", stepSize)]
+
+  sem odeSolverMethodFromOptions options stepSize =
+  | "rk4" -> RK4 {stepSize = stepSize}
+
+  sem typeCheckODESolverMethod env info =
+  | RK4 { stepSize = stepSize } ->
+    let float = TyFloat {info = info} in
+    let stepSize = typeCheckExpr env stepSize in
+    unify env [info, infoTm stepSize] float (tyTm stepSize);
+    RK4 { stepSize = stepSize }
+
+  sem odeSolverMethodSmapAccumL_Expr_Expr f acc =
+  | RK4 r ->
+    match f acc r.stepSize with (acc, stepSize) in
+    (acc, RK4 {r with stepSize = stepSize})
+end

--- a/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
@@ -1,0 +1,36 @@
+include "../../../models/ode-harmonic.mc"
+include "../../cppl-test.mc"
+include "../../test.mc"
+
+mexpr
+
+let s = 2e-2 in
+let e = eqODEHarmonic s in
+let rhs = odeHarmonicTruth in
+let r = resODEHarmonic in
+
+let f = lam sample: [Float].
+  let j = strJoin " " in
+  j (map float2string sample)
+in
+let c = cpplResOfDist f in
+
+utest r (c 0   (infer (Default {}) model))
+with rhs using e in
+utest r (c 0   (infer (Importance { particles = 1000 }) model))
+with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000 }) model))
+with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000 }) model))
+with rhs using e in
+utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))
+with rhs using e in
+utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))
+with rhs using e in
+utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))
+with rhs using e in
+utest r (c 500
+  (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model))
+with rhs using e in
+
+()

--- a/coreppl/test/test.mc
+++ b/coreppl/test/test.mc
@@ -182,3 +182,17 @@ let resLda: CpplRes -> [Float] = lam cpplRes.
   ]
 let ldaTruth: [Float] = [0.5,0.5,0.5]
 let eqLda: Float -> [Float] -> [Float] -> Bool = lam s. eqSeq (eqfApprox s)
+
+--models/ode-harmonic.mc
+let tend = 3.
+let resODEHarmonic: CpplRes -> [Float] = lam cpplRes.
+  let samples = map (lam s. map string2float (strSplit " " s)) cpplRes.samples in
+  let x = map (lam t. get t 0) samples in
+  let v = map (lam t. get t 1) samples in
+  [
+    logWeightedMean cpplRes.lweights x,
+    logWeightedMean cpplRes.lweights v
+  ]
+let odeHarmonicTruth: [Float] = (lam t. [cos t, negf (sin t)]) tend
+let eqODEHarmonic: Float -> [Float] -> [Float] -> Bool =
+  lam eps. eqSeq (eqfApprox eps)


### PR DESCRIPTION
This PR adds a new term `solveode` to miking-dppl. This terms solves an ordinary differential equation (ODE) model. Currently, there is one solver method available (Fourth order Runge-Kutta). As part of this addition, handling runtimes on coreppl-to-mexpr is refactored a bit since runtime code no longer only concerns inference.

Moreover, there are some bug fixes, simplifications, and extensions for shallow maps, symbolize, and peval.

