### PR TITLE
Add the Wiener process as a primitive distribution

### DIFF
--- a/coreppl/models/wiener.mc
+++ b/coreppl/models/wiener.mc
@@ -1,0 +1,6 @@
+let dt = 1.
+let ts = create 100 (lam i. mulf (int2float i) dt)
+let model : () -> [[Float]] = lam.
+  let w = assume (Wiener ()) in map (lam t. [t, w t]) ts
+mexpr
+model ()

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -69,7 +69,10 @@ lang TransformDist = MExprPPL
   | DUniform { a = a, b = b } ->
     i (conapp_
         "RuntimeDistElementary_DistUniform"
-        (i (urecord_ [("a", a), ("b", b)])))
+         (i (urecord_ [("a", a), ("b", b)])))
+  | DWiener {} ->
+    i (conapp_
+         "RuntimeDistElementary_DistWiener" (i unit_))
   | DEmpirical { samples = samples } ->
     i (app_ (var_ "vRuntimeDistEmpirical_constructDistEmpiricalHelper") samples)
 

--- a/coreppl/src/coreppl-to-mexpr/runtime-common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-common.mc
@@ -162,3 +162,6 @@ let mcmcAcceptInit = lam n. modref _mcmcSamples n; modref _mcmcAccepts 0
 let mcmcAccept = lam. modref _mcmcAccepts (addi (deref _mcmcAccepts) 1)
 let mcmcAcceptRate = lam.
   divf (int2float (deref _mcmcAccepts)) (int2float (deref _mcmcSamples))
+
+let seqToStr = lam elToStr. lam seq.
+  join ["[", strJoin "," (map elToStr seq), "]"]

--- a/coreppl/src/coreppl-to-rootppl/rootppl.mc
+++ b/coreppl/src/coreppl-to-rootppl/rootppl.mc
@@ -364,7 +364,6 @@ lang RootPPL = CAst + CPrettyPrint
       else never
     else never
 
-
   sem printRPProg (nameInit: [Name]) =
   | RPProg {
       includes = includes,

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -572,7 +572,7 @@ end
 let pplKeywords = [
   "assume", "observe", "weight", "resample", "plate", "Uniform", "Bernoulli",
   "Poisson", "Beta", "Gamma", "Categorical", "Multinomial", "Dirichlet",
-  "Exponential", "Empirical", "Gaussian", "Binomial"
+  "Exponential", "Empirical", "Gaussian", "Binomial", "Wiener"
 ]
 
 lang CoreDPL = Ast + SolveODE end

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -13,6 +13,7 @@ include "peval/peval.mc"
 
 include "string.mc"
 include "seq.mc"
+include "utest.mc"
 
 lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval +
             TyConst + ConstPrettyPrint + ConstArity
@@ -42,7 +43,7 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval +
 
   sem smapAccumLDist_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Dist -> (acc, Dist)
   sem smapAccumLDist_Expr_Expr f acc =
-  -- Intentionally left blank
+  | dist -> (acc, dist)
 
   sem smapDist_Expr_Expr : (Expr -> Expr) -> Dist -> Dist
   sem smapDist_Expr_Expr f =
@@ -983,6 +984,45 @@ lang BinomialDist = Dist + PrettyPrint + Eq + Sym + IntTypeAst + SeqTypeAst + Bo
 
 end
 
+
+
+lang WienerDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst
+  syn Dist =
+  | DWiener {}
+
+  -- Pretty printing
+  sem pprintDist (indent: Int) (env: PprintEnv) =
+  | DWiener t -> (env, "Wiener ()")
+
+  -- Equality
+  sem eqExprHDist (env : EqEnv) (free : EqEnv) (lhs : Dist) =
+  | DWiener r ->
+    match lhs with DWiener l then Some free
+    else None ()
+
+  -- Symbolize
+  sem symbolizeDist (env: SymEnv) =
+  | DWiener t -> DWiener t
+
+  -- Type Check
+  sem typeCheckDist (env: TCEnv) (info: Info) =
+  | DWiener t ->
+    let tyfloat = TyFloat { info = info } in
+    ityarrow_ info tyfloat tyfloat
+
+  -- ANF
+  sem normalizeDist (k : Dist -> Expr) =
+  | DWiener t -> k (DWiener t)
+
+  -- Type lift
+  sem typeLiftDist (env : TypeLiftEnv) =
+  | DWiener t -> (env, DWiener t)
+
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DWiener t -> k (DWiener t)
+end
+
 -----------------
 -- AST BUILDER --
 -----------------
@@ -1029,6 +1069,8 @@ let gaussian_ = use GaussianDist in
 let binomial_ = use BinomialDist in
   lam n. lam p. dist_ (DBinomial {n = n, p = p})
 
+let wiener_ = use WienerDist in dist_ (DWiener {})
+
 ---------------------------
 -- LANGUAGE COMPOSITIONS --
 ---------------------------
@@ -1036,7 +1078,7 @@ let binomial_ = use BinomialDist in
 lang DistAll =
   UniformDist + BernoulliDist + PoissonDist + BetaDist + GammaDist +
   CategoricalDist + MultinomialDist + DirichletDist +  ExponentialDist +
-  EmpiricalDist + GaussianDist + BinomialDist
+  EmpiricalDist + GaussianDist + BinomialDist + WienerDist
 end
 
 lang Test =
@@ -1066,6 +1108,7 @@ let tmEmpirical = empirical_ (seq_ [
 let tmDirichlet = dirichlet_ (seq_ [float_ 1.3, float_ 1.3, float_ 1.5]) in
 let tmGaussian = gaussian_ (float_ 0.0) (float_ 1.0) in
 let tmBinomial = binomial_ (int_ 5) (float_ 0.5) in
+let tmWiener = wiener_ in
 
 ------------------------
 -- PRETTY-PRINT TESTS --
@@ -1144,6 +1187,9 @@ utest mexprToString tmBinomial with strJoin "\n" [
   "  0.5"
 ] using eqString in
 
+utest mexprToString tmWiener with "Wiener ()"
+using eqString in
+
 --------------------
 -- EQUALITY TESTS --
 --------------------
@@ -1202,6 +1248,9 @@ utest eqExpr tmGaussian
 
 utest tmBinomial with tmBinomial using eqExpr in
 utest eqExpr tmBinomial (binomial_ (int_ 4) (float_ 0.5)) with false in
+
+utest tmWiener with tmWiener using eqExpr in
+utest eqExpr tmWiener tmBinomial with false in
 
 ----------------------
 -- SMAP/SFOLD TESTS --
@@ -1296,10 +1345,15 @@ utest tyTm (typeCheck tmEmpirical) with tydist_ tyfloat_ using eqType in
 utest tyTm (typeCheck tmDirichlet) with tydist_ (tyseq_ tyfloat_) using eqType in
 utest tyTm (typeCheck tmGaussian) with tydist_ tyfloat_ using eqType in
 utest tyTm (typeCheck tmBinomial) with tydist_ tyint_ using eqType in
+utest tyTm (typeCheck tmWiener) with tydist_ (tyarrow_ tyfloat_ tyfloat_)
+  using eqType
+in
 
 ---------------
 -- ANF TESTS --
 ---------------
+
+let toStr = utestDefaultToString expr2str expr2str in
 
 let _anf = compose normalizeTerm symbolize in
 
@@ -1325,7 +1379,7 @@ utest _anf tmEmpirical with bindall_ [
   ulet_ "t2" (seq_ [(var_ "t1"), (var_ "t")]),
   ulet_ "t3" (empirical_ (var_ "t2")),
   var_ "t3"
-] using eqExpr in
+] using eqExpr else toStr in
 -- print (mexprToString (_anf tmEmpirical)); print "\n";
 utest _anf tmDirichlet with bindall_ [
   ulet_ "t" (seq_ [float_ 1.3, float_ 1.3, float_ 1.5]),
@@ -1334,6 +1388,7 @@ utest _anf tmDirichlet with bindall_ [
 ] using eqExpr in
 utest _anf tmGaussian with bind_ (ulet_ "t" tmGaussian) (var_ "t") using eqExpr in
 utest _anf tmBinomial with bind_ (ulet_ "t" tmBinomial) (var_ "t") using eqExpr in
+utest _anf tmWiener with bind_ (ulet_ "t" tmWiener) (var_ "t") using eqExpr in
 
 ---------------------
 -- TYPE-LIFT TESTS --
@@ -1351,6 +1406,7 @@ utest (typeLift tmEmpirical).1 with tmEmpirical using eqExpr in
 utest (typeLift tmDirichlet).1 with tmDirichlet using eqExpr in
 utest (typeLift tmGaussian).1 with tmGaussian using eqExpr in
 utest (typeLift tmBinomial).1 with tmBinomial using eqExpr in
+utest (typeLift tmWiener).1 with tmWiener using eqExpr in
 
 ()
 

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -142,7 +142,10 @@ lang DPPLParser =
                                         info = info})
   | "Binomial" -> Some (2, lam lst. TmDist {dist = DBinomial {n = get lst 0, p = get lst 1},
                                         ty = TyUnknown {info = info},
-                                        info = info})
+                                         info = info})
+  | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {},
+                                       ty = TyUnknown {info = info},
+                                       info = info})
   | "solveode" -> Some (4, lam lst. TmSolveODE {method = interpretODESolverMethod (get lst 0),
                                              model = get lst 1,
                                              init = get lst 2,

--- a/scripts/dppl-plot-process
+++ b/scripts/dppl-plot-process
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import matplotlib.pyplot as plt
+import sys
+import math
+import argparse
+import numpy as np
+
+
+parser = argparse.ArgumentParser(
+    description="Plot Miking DPPL stochastic process from standard input. The samples are assumed to be on the form [[t1, x1], [t1, x2], ..., [tn, xn]], where ti are timestamps and xi the value at this time."
+)
+
+parser.add_argument("-m", "--mean", action="store_true", help="Plot mean")
+parser.add_argument("-e", "--median", action="store_true", help="Plot median")
+parser.add_argument(
+    "-d",
+    "--std",
+    action="store_true",
+    help="Plot standard deviation",
+)
+parser.add_argument(
+    "-l",
+    "--lines",
+    action="store_true",
+    help="Plot all trace samples as lines. More computationally heavy for large samples sizes.",
+)
+parser.add_argument(
+    "-a",
+    "--alpha-scale",
+    type=float,
+    default=10,
+    help="The alpha for each sample line is computed as alpha-scale*prob(sample). Default is 10",
+)
+parser.add_argument(
+    "file",
+    nargs="?",
+    type=argparse.FileType("r"),
+    default=sys.stdin,
+    help="File with samples (default: standard input)",
+)
+
+args = parser.parse_args()
+
+with args.file as file:
+    line_number = 0
+    traces = []
+    lws = []
+    for line in file:
+        line_number += 1
+
+        if line_number > 1:
+            data, lw = line.split(" ")
+            nested_array_str = data.strip("[]")
+            inner_arrays = nested_array_str.split("],[")
+            nested_array = [
+                [float(num) for num in inner.split(",")]
+                for inner in inner_arrays
+            ]
+            arr = np.asarray(nested_array)
+
+            if line_number == 2:
+                ts = arr[:, 0]
+
+            traces.append(arr[:, 1])
+            lws.append(float(lw))
+
+    traces = np.vstack(traces)
+    lws = np.asarray(lws)
+
+    if args.lines:
+        for i, trace in enumerate(traces):
+            plt.plot(
+                ts,
+                trace,
+                color="blue",
+                alpha=args.alpha_scale * np.exp(lws[i]),
+                label=None,
+            )
+
+    else:
+        # finding percentiles
+        pcts = np.array([45, 40, 35, 30, 25, 20, 15, 10, 5])
+        layers = np.empty([len(ts), len(pcts), 2])
+        for t in range(len(ts)):
+            for p in range(len(pcts)):
+                layers[t, p] = np.percentile(
+                    traces[:, t], [100 - pcts[p], pcts[p]]
+                )
+
+        # plot the layers
+        for i in range(len(pcts)):
+            if i == 0:
+                plt.fill_between(
+                    ts,
+                    layers[:, i, 0],
+                    layers[:, i, 1],
+                    color="blue",
+                    alpha=pcts[i] * 0.01,
+                    label=f"{pcts[i]}%",
+                )
+            else:
+                plt.fill_between(
+                    ts,
+                    layers[:, i - 1, 0],
+                    layers[:, i, 0],
+                    color="blue",
+                    alpha=pcts[i] * 0.01,
+                    label=f"{pcts[i]}%",
+                )
+                plt.fill_between(
+                    ts,
+                    layers[:, i - 1, 1],
+                    layers[:, i, 1],
+                    color="blue",
+                    alpha=pcts[i] * 0.01,
+                )
+
+    # Plot median
+    if args.median:
+        plt.plot(
+            ts,
+            np.median(traces, axis=0),
+            color="purple",
+            linestyle="-",
+            label="median",
+        )
+
+    # Plot mean
+    if args.mean:
+        plt.plot(
+            ts,
+            np.mean(traces, axis=0),
+            color="red",
+            linestyle="-",
+            label="mean",
+        )
+
+    # Plot standard deviation
+    if args.std:
+        std = np.std(traces, axis=0)
+        plt.plot(ts, std, color="red", linestyle="--", alpha=0.5, label="std")
+
+    plt.legend()
+    plt.xlabel("t")
+
+    plt.grid(
+        True,
+        which="major",
+        linestyle="-",
+        linewidth=0.5,
+        color="gray",
+        alpha=0.5,
+    )
+
+    plt.grid(
+        True,
+        which="minor",
+        linestyle="--",
+        linewidth=0.5,
+        color="gray",
+        alpha=0.2,
+    )
+
+    plt.minorticks_on()
+    plt.show()


### PR DESCRIPTION
This PR adds the Wiener process W(t) as a primitive distribution; for a definition, see https://en.wikipedia.org/wiki/Wiener_process. The implementation uses an in-memory map to ensure that an instance of W(t) is continuous. Hence, this has implications when running a Wiener process for a long time.

The Wiener distribution is typed as `Wiener () : Dist (Float -> Float)` and it is only possible to sample from this distribution and observing it will give a runtime error.

There is a demo model illustrating the Wiener process under `coreppl/models/wiener.mc`. Moreover, the CLI model version of `cppl` has been extended to handle the printing of sequences. A new plot script, `dppl-plot-process`, has been added to make visualizing stochastic processes more convenient.

For example

```
./build/cppl coreppl/models/wiener.mc && ./out 1000 | ./scripts/dppl-plot-process --mean --std --lines
```

produces

![wiener-demo](https://github.com/miking-lang/miking-dppl/assets/203474/2210e64e-d52c-4ccb-aa85-024f6f91cb67)

This PR depends on https://github.com/miking-lang/miking/pull/828 and https://github.com/miking-lang/miking/pull/831