### PR TITLE
Only eliminate duplicated externals between runtime and model code

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -145,12 +145,14 @@ lang MExprCompile =
     let corepplAst = replaceDpplKeywords corepplAst in
 
     -- Combine the CorePPL AST with the runtime AST, after extracting the
-    -- models, and eliminate duplicate code due to common dependencies.
+    -- models, and eliminate duplicated external definitions.
     let mainAst = bind_ runtimes.ast corepplAst in
-    match eliminateDuplicateCodeWithSummary mainAst with (replaced, mainAst) in
+    match eliminateDuplicateExternalsWithSummary mainAst
+      with (replaced, mainAst)
+    in
 
-    -- Apply the replacements performed by the duplicate code elimination on
-    -- the model ASTs.
+    -- Apply the replacements performed by the duplicate duplicated external
+    -- elimination on the model ASTs.
     let modelAsts = replaceIdentifiers replaced modelAsts in
 
     -- Insert all models into the main AST at the first point where any of the


### PR DESCRIPTION
This PR changes the compilation as follows:

Instead of eliminating all duplicate code between the runtime code and the model program, after this PR, only duplication of externals is eliminated. The problem with the previous approach was that because the model program is lambda-lifted but not the runtime code, a lambda-lifted version of one top-level let binding could be replaced by its non-lambda lifted version, resulting in an invalid final program.

Depends on https://github.com/miking-lang/miking/pull/834.