### PR TITLE
Add diff construct to Miking DPPL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ uninstall-coreppl:
 test-coreppl: build/${CPPL_NAME}
 	@$(MAKE) -s -f test-coreppl.mk all
 
+.PHONY: test-coreppl-compiler
+test-coreppl-compiler:
+	@$(MAKE) -s -f test-coreppl.mk compiler
 
 #############
 ## RootPPL ##

--- a/coreppl/models/diff-confusion.mc
+++ b/coreppl/models/diff-confusion.mc
@@ -1,0 +1,13 @@
+-- This model tests that dual number pertubations are not confused.
+let model = lam.
+  -- scalar differentiation
+  let d : (Float -> Float) -> (Float -> Float) =
+    lam f. lam x. let t = diff f x in t 1.
+  in
+
+  -- Should be 2., pertubation confusion between the outer and inner derivative
+  -- will instead result in 3.
+  d (lam x. mulf x (d (lam y. mulf x y) 2.)) 1.
+
+mexpr
+model ()

--- a/coreppl/models/diff-demo.mc
+++ b/coreppl/models/diff-demo.mc
@@ -1,0 +1,97 @@
+-- This is a determinstic model that illustrates the `diff` construct
+
+let model : () -> () = lam.
+
+  let eqSeq = lam eq. lam seq1. lam seq2.
+    foldl (lam x. lam y. if x then y else false) true
+      (mapi (lam i. lam x. eq x (get seq2 i)) seq1)
+  in
+
+  let assert = lam msg. lam x.
+    if x then () else error (concat "Assertion failed: " msg)
+  in
+
+  -- ┌────────────────────┐
+  -- │ Scalar Derivatives │
+  -- └────────────────────┘
+
+  -- Total derivative for scalar functions
+  let d : (Float -> Float) -> Float -> (Float -> Float) =
+    lam f. lam x. diff f x
+  in
+
+  let f = lam x. mulf (sin x) (cos x) in
+  -- Analytic total derivative
+  let df = lam x. lam v.
+    mulf v (subf (mulf (cos x) (cos x)) (mulf (sin x) (sin x)))
+  in
+  let x = 2. in                 -- We compute the derivative in this point
+  assert "scalar derivative" (eqf (d f x 1.) (df x 1.));
+
+
+  -- ┌────────────────────────────────┐
+  -- │ Partial Derivatives, Example 1 │
+  -- └────────────────────────────────┘
+
+  let d : ([Float] -> [Float]) -> [Float] -> ([Float] -> [Float]) =
+    lam f. lam x. let t = diff f x in t
+  in
+
+  let g = lam x. [addf (f (get x 0)) (f (get x 1)), f (get x 1)] in
+  -- Analytic total derivative
+  let dg = lam x. lam v. [
+    addf (df (get x 0) (get v 0)) (df (get x 1) (get v 1)),
+    df (get x 1) (get v 1)
+  ] in
+  let xs = [2., 3.] in             -- We compute the derivative in this point
+
+  -- First partial derivative
+  let v = [1., 0.] in
+  assert "partial derivatives 1.1" (eqSeq eqf (d g xs v) (dg xs v));
+
+  -- Second partial derivative
+  let v = [0., 1.] in
+  assert "partial derivatives 1.2" (eqSeq eqf (d g xs v) (dg xs v));
+
+  -- Jacobian-vector-product
+  let v = [2., 3.] in
+  assert "partial derivatives 1.JvP" (eqSeq eqf (d g xs v) (dg xs v));
+
+
+  -- ┌────────────────────────────────┐
+  -- │ Partial Derivatives, Example 2 │
+  -- └────────────────────────────────┘
+
+  let d :
+    ((Float, [Float]) -> {a : [Float]}) -> (Float, [Float]) ->
+      ((Float, [Float]) -> {a : [Float]})
+    = lam f. lam x. let t = diff f x in t
+  in
+
+  let h = lam x. match x with (x0, [x1, x2]) in { a = [f x0, f x1, f x2] } in
+  -- Analytic total derivative
+  let dh = lam x. lam v.
+    match (x, v) with ((x0, [x1, x2]), (v0, [v1, v2])) in
+    { a = [df x0 v0, df x1 v1, df x2 v2] }
+  in
+  let x = (1., [2., 3.]) in    -- We compute the derivative in this point
+
+  -- First partial derivative
+  let v = (1., [0., 0.]) in
+  assert "partial derivatives 2.1"
+    (eqSeq eqf (d h x v).a (dh x v).a);
+
+  -- Second partial derivative
+  let v = (0., [1., 0.]) in
+  assert "partial derivatives 2.2"
+    (eqSeq eqf (d h x v).a (dh x v).a);
+
+  -- Third partial derivative
+  let v = (0., [0., 1.]) in
+  assert "partial derivatives 2.3"
+    (eqSeq eqf (d h x v).a (dh x v).a);
+
+  ()
+
+mexpr
+model ()

--- a/coreppl/models/diff-regression.mc
+++ b/coreppl/models/diff-regression.mc
@@ -1,0 +1,11 @@
+let model: () -> Float = lam.
+  let a = assume (Gaussian 0.5 1.) in
+  let f = lam x. addf (mulf a (pow x 2.)) x in
+  let df = lam x. let t = diff f x in t 1. in
+  observe (df 1.) (Gaussian 3. 1.);
+  observe (df 2.) (Gaussian 5. 1.);
+  observe (df 3.) (Gaussian 7. 1.);
+  a
+
+mexpr
+model ()

--- a/coreppl/models/ode-harmonic.mc
+++ b/coreppl/models/ode-harmonic.mc
@@ -1,3 +1,5 @@
+include "common.mc"
+
 let model: () -> [Float] = lam.
   let f = lam t. lam xs.
     let x = get xs 0 in
@@ -5,7 +7,7 @@ let model: () -> [Float] = lam.
     [v, (negf x)]
   in
   let x0 = [1., 0.] in
-  solveode (RK4 { stepSize = 1e-4 }) f x0 3.
+  solveode (RK4 { stepSize = 1e-3 }) f x0 3.
 
 mexpr
 model ()

--- a/coreppl/src/ad.mc
+++ b/coreppl/src/ad.mc
@@ -1,0 +1,812 @@
+-- Nested dual number Interface base on:
+-- Siskind, Jeffrey Mark, and Barak A. Pearlmutter. “Nesting Forward-Mode AD in
+-- a Functional Framework.” Higher-Order and Symbolic Computation 21, no. 4
+-- (December 1, 2008): 361–76. https://doi.org/10.1007/s10990-008-9037-1.
+
+include "utest.mc"
+
+include "mexpr/ast.mc"
+include "mexpr/type.mc"
+include "mexpr/eq.mc"
+include "mexpr/const-types.mc"
+include "mexpr/const-arity.mc"
+
+include "coreppl.mc"
+include "dist.mc"
+
+
+lang DualNumAst =
+  ConstArity + ConstSideEffectBase + ConstCFA + ConstPrettyPrint
+
+  -- ┌───────────────────────────────────────┐
+  -- │ Lifted constants and Dual number API  │
+  -- └───────────────────────────────────────┘
+
+  syn Const =
+  -- Represents a version of a constant lifted to dual numbers.
+  | CLifted Const
+
+  -- Generates a unique tag ε.
+  | CGenEpsilon {}
+
+  -- Returns ε₁ < ε₂ for two tags.
+  | CLtEpsilon {}
+
+  -- Boxes a float as a dual number, i.e.,
+  -- `createPrimal (x : Float) : Dual Float`.
+  | CCreatePrimal {}
+
+  -- `createDual ε (x : Dual Float) (x' : Dual Float)` creates a dual
+  -- number x+εx' with tag `ε`, primal `x`, and pertubation `x'`.
+  | CCreateDual {}
+
+  -- `isDualNum n` returns `false` if `n` is a boxed float and `true` if `n` is
+  -- a dual number with a primal and pertubation.
+  | CIsDualNum {}
+
+  -- `epsilon (n : Dual Float)` returns the tag ε from n = x+εx'. Runtime error
+  -- of if `n` is a boxed float.
+  | CEpsilon {}
+
+  -- `primal ε₁ (n : Dual Float)` returns x if n = x+ε₂x' and ε₁≤ε₂, otherwise
+  -- it returns `n`
+  | CPrimal {}
+
+  -- `primalRec (n : Dual Float) : Float` returns x in n = x+ε₁(x+ε₂(x+₃(...)))
+  -- and unboxes it to a float. I.e., it returns the innermost primal of a
+  -- nested dual number.
+  | CPrimalRec {}
+
+  -- `pertubation ε₁ (n : Dual Float)` returns x' if n = x+ε₂x' and ε₁≤ε₂,
+  -- otherwise it returns `0` boxed as a dual number.
+  | CPertubation {}
+
+
+  -- ┌──────────────┐
+  -- │ AST builders │
+  -- └──────────────┘
+
+  sem dualnumGenEpsilon : Info -> Expr
+  sem dualnumGenEpsilon =| info ->
+    let i = withInfo info in
+    i (appf1_ (i (uconst_ (CGenEpsilon ()))) (i unit_))
+
+  sem dualnumLtEpsilon : Info -> Expr -> Expr -> Expr
+  sem dualnumLtEpsilon info e1 =| e2 ->
+    let i = withInfo info in
+    i (appf2_ (i (uconst_ (CLtEpsilon ()))) e1 e2)
+
+
+  sem dualnumCreatePrimal : Info -> Expr -> Expr
+  sem dualnumCreatePrimal info =| x ->
+    let i = withInfo info in
+    i (appf1_ (i (uconst_ (CCreatePrimal ()))) x)
+
+  sem dualnumCreateDual : Info -> Expr -> Expr -> Expr -> Expr
+  sem dualnumCreateDual info e x =| xp ->
+    let i = withInfo info in
+    i (appf3_ (i (uconst_ (CCreateDual ()))) e x xp)
+
+  sem dualnumIsDualNum : Info -> Expr -> Expr
+  sem dualnumIsDualNum =| info ->
+    let i = withInfo info in
+    appf1_ (i (uconst_ (CIsDualNum ())))
+
+
+  sem dualnumEpsilon : Info -> Expr -> Expr
+  sem dualnumEpsilon info =| x ->
+    let i = withInfo info in
+    i (appf1_ (i (uconst_ (CEpsilon ()))) x)
+
+
+  sem dualnumPrimal : Info -> Expr -> Expr -> Expr
+  sem dualnumPrimal info e =| x ->
+    let i = withInfo info in
+    i (appf2_ (i (uconst_ (CPrimal ()))) e x)
+
+
+  sem dualnumPrimalRec : Info -> Expr -> Expr
+  sem dualnumPrimalRec info =| x ->
+    let i = withInfo info in
+    i (appf1_ (i (uconst_ (CPrimalRec ()))) x)
+
+
+  sem dualnumPertubation : Info -> Expr -> Expr -> Expr
+  sem dualnumPertubation info e =| x ->
+    let i = withInfo info in
+    i (appf2_ (i (uconst_ (CPertubation ()))) e x)
+
+
+  -- ┌───────────────────────────────────────────┐
+  -- │ Type directed dual number transformations │
+  -- └───────────────────────────────────────────┘
+
+  -- Returns a function that boxes the floats of a term as a primal number based
+  -- on its type. If the term does not need boxing or the function cannot
+  -- determine how to box the particular type, `None ()` is returned.
+  -- TODO(oerikss, 2024-04-16): Improve feedback when boxing is not posible.
+  sem dualnumCreatePrimalTypeDirected : Type -> Option (Expr -> Expr)
+  sem dualnumCreatePrimalTypeDirected =
+  | ty -> _convTypeDirected
+           (lam tm. dualnumCreatePrimal (infoTm tm) tm)
+           (lam tm. dualnumPrimalRec (infoTm tm) tm)
+           ty
+
+  -- Returns a function that unboxes a dual number into a float based on its
+  -- type, if it needs unboxing. Otherwise it returns `None ()`
+  sem dualnumPrimalRecTypeDirected : Type -> Option (Expr -> Expr)
+  sem dualnumPrimalRecTypeDirected =
+  | ty -> _convTypeDirected
+           (lam tm. dualnumPrimalRec (infoTm tm) tm)
+           (lam tm. dualnumCreatePrimal (infoTm tm) tm)
+           ty
+
+  -- `dualnumPertubationTypeDirected ty`, based on the type `ty`, returns a
+  -- function f whose first argument should be a dual number epsilon tag `e` and
+  -- the second argument should be a term `tm` of type `ty` before it is lifted
+  -- to dual numbers. The resulting expression recursivly retrieves the
+  -- pertubation of all dual numbers in the term `tm`, given `e`.
+  --
+  -- Examples:
+  -- `dualnumPertubationTypeDirected Float e x` = `pertubation e x`
+  -- `dualnumPertubationTypeDirected (Float, Float) e x` =
+  --   `(pertubation e x.0, pertubation e x.1)`
+  -- `dualnumPertubationTypeDirected (Float, [Float]) e x` =
+  --   `(pertubation e x.0, map (pertubation e) x.1)`
+  --
+  -- If the given type `ty` is not first order and does not contain `Float` in
+  -- its leafs, `None ()` is returned.
+  sem dualnumPertubationTypeDirected : Type -> Option (Expr -> Expr -> Expr)
+  sem dualnumPertubationTypeDirected =
+  | TyFloat _ -> Some (lam e. lam tm. dualnumPertubation (infoTm tm) e tm)
+  | TySeq r ->
+    optionMap
+      (lam f. lam e. _mapSeqTm (f e))
+      (dualnumPertubationTypeDirected r.ty)
+  | TyRecord r ->
+    optionMap
+      (lam ts. lam e. _mapRecordTm (map (lam t. (t.0, t.1 e)) ts))
+      (optionMapM
+         (lam t. match t with (key, ty) in
+               optionMap
+                 (lam f. (key, f))
+                 (dualnumPertubationTypeDirected ty))
+         (map (lam t. (sidToString t.0, t.1)) (mapBindings r.fields)))
+  | TyAlias r -> dualnumPertubationTypeDirected r.content
+  | _ -> None ()
+
+  -- Similar to `dualnumPertubationTypeDirected` but instead creates aggregated
+  -- dual numbers based on a type.
+  sem dualnumCreateDualTypeDirected : Type -> Option (Expr -> Expr -> Expr -> Expr)
+  sem dualnumCreateDualTypeDirected =
+  | TyFloat _ -> Some (lam e. lam x. lam xp. dualnumCreateDual (infoTm xp) e x xp)
+  | TySeq r ->
+    optionMap
+      (lam f. lam e. _map2SeqTm (f e))
+      (dualnumCreateDualTypeDirected r.ty)
+  | TyRecord r ->
+    optionMap
+      (lam ts. lam e. _map2RecordTm (map (lam t. (t.0, t.1 e)) ts))
+      (optionMapM
+         (lam t. match t with (key, ty) in
+               optionMap
+                 (lam f. (key, f))
+                 (dualnumCreateDualTypeDirected ty))
+         (map (lam t. (sidToString t.0, t.1)) (mapBindings r.fields)))
+  | TyAlias r -> dualnumCreateDualTypeDirected r.content
+  | _ -> None ()
+
+
+  -- ┌─────────┐
+  -- │ Helpers │
+  -- └─────────┘
+
+  sem _mapSeqTm f =| tm ->
+    let i = withInfo (infoTm tm) in
+    let _x = nameSym "x" in
+    i (map_ (i (nulam_ _x (f (i (nvar_ _x))))) tm)
+
+  sem _map2SeqTm f tm1 =| tm2 ->
+    let i = withInfo (infoTm tm1) in
+    let _x = nameSym "x" in
+    let _i = nameSym "i" in
+    i (mapi_
+         (i (nulams_ [_i, _x] (f (i (nvar_ _x)) (get_ tm2 (nvar_ _i)))))
+         tm1)
+
+  sem _mapRecordTm fs =| tm ->
+    let info = infoTm tm in
+    let i = withInfo info in
+    tmRecord info (TyUnknown { info = info })
+      (map (lam t. match t with (key, f) in (key, f (i (recordproj_ key tm)))) fs)
+
+  sem _map2RecordTm fs tm1 =| tm2 ->
+    let info = infoTm tm1 in
+    let i = withInfo info in
+    tmRecord info (TyUnknown { info = info })
+      (map (lam t. match t with (key, f) in
+                 (key, f (i (recordproj_ key tm1)) (i (recordproj_ key tm2))))
+         fs)
+
+  sem _hasFloatLeaf =| ty -> _hasFloatLeafH false ty
+
+  sem _hasFloatLeafH acc =
+  | TyFloat _ -> true
+  | ty -> sfold_Type_Type _hasFloatLeafH acc ty
+
+  sem _convTypeDirected from to =
+  | TyFloat _ -> Some from
+  | TySeq r -> optionMap _mapSeqTm (_convTypeDirected from to r.ty)
+  | ty & TyRecord r ->
+    let bs =
+      (map
+         (lam t. (sidToString t.0,
+                optionGetOr (lam x. x) (_convTypeDirected from to t.1)))
+         (mapBindings r.fields))
+    in
+    if not (_hasFloatLeaf ty) then None ()
+    else Some (_mapRecordTm bs)
+  | TyArrow r ->
+    let f = lam from. lam to.
+      let _x = nameSym "x" in Some (
+        lam tm.
+          let i = withInfo (infoTm tm) in
+          i (nulam_ _x (to (i (appf1_ tm (from (i (nvar_ _x))))))))
+    in
+    switch (_convTypeDirected to from r.from, _convTypeDirected from to r.to)
+    case (Some from, Some to) then f from to
+    case (Some from, None _) then f from (lam x. x)
+    case (None _, Some to) then f (lam x. x) to
+    case (None _, None _) then None ()
+    end
+  | TyAll r -> _convTypeDirected from to r.ty
+  | TyAlias r -> _convTypeDirected from to r.content
+  | _ -> None ()
+
+
+  -- ┌───────────────────────────────────────────────┐
+  -- │ Extension to const related semantic functions │
+  -- └───────────────────────────────────────────────┘
+
+  sem constArity =
+  | CLifted const -> constArity const
+  | CGenEpsilon _ | CCreatePrimal _ | CIsDualNum _ | CEpsilon _ | CPrimalRec _ -> 1
+  | CLtEpsilon _ | CPrimal _ | CPertubation _ -> 2
+  | CCreateDual _ -> 3
+
+  sem constHasSideEffect =
+  | CLifted const -> constHasSideEffect const
+  | CGenEpsilon _ -> true
+  | CLtEpsilon _
+  | CCreatePrimal _
+  | CCreateDual _
+  | CIsDualNum _
+  | CEpsilon _
+  | CPrimal _
+  | CPrimalRec _
+  | CPertubation _ -> false
+
+  sem generateConstraintsConst graph info ident =
+  | CLifted const -> generateConstraintsConst graph info ident const
+  | CGenEpsilon _
+  | CLtEpsilon _
+  | CCreatePrimal _
+  | CCreateDual _
+  | CIsDualNum _
+  | CEpsilon _
+  | CPrimal _
+  | CPrimalRec _
+  | CPertubation _ -> graph
+
+  sem getConstStringCode (indent : Int) =
+  | CLifted const -> join ["L(", getConstStringCode indent const, ")"]
+  | CGenEpsilon _ -> "genEpsilon"
+  | CLtEpsilon _ -> "ltEpsilon"
+  | CCreatePrimal _ -> "createPrimal"
+  | CCreateDual _ -> "createDual"
+  | CIsDualNum _ -> "isDualNum"
+  | CEpsilon _ -> "epsilon"
+  | CPrimal _ -> "primal"
+  | CPrimalRec _ -> "primalRec"
+  | CPertubation _ -> "pertubation"
+
+
+  -- ┌───────────────────────────────────────────┐
+  -- │ Lifted types and types of dual number API │
+  -- └───────────────────────────────────────────┘
+
+  syn Type =
+  | TyDualNum { info : Info }
+
+  sem itydualnum_ =| info -> TyDualNum { info = NoInfo () }
+  sem tydualnum_ =| () -> itydualnum_ ( NoInfo ())
+
+  sem withTypeInfo (info : Info) =
+  | TyDualNum r -> TyDualNum { r with info = info }
+
+  sem infoTy =
+  | TyDualNum r -> r.info
+
+  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
+  | TyDualNum _ -> (env, "DualNum")
+end
+
+lang DualNumDist = Dist + PrettyPrint + Eq + Sym
+  syn Dist =
+  | DDual Dist
+
+  sem smapAccumLDist_Expr_Expr f acc =
+  | DDual d ->
+    match smapAccumLDist_Expr_Expr f acc d with (acc, d) in (acc, DDual d)
+
+  -- Pretty printing, NOTE(oerikss, 2024-04-10): Because a lifted distribution
+  -- is internal, its string representation is not parseable.
+  sem pprintDist (indent: Int) (env: PprintEnv) =
+  | DDual d ->
+    match pprintDist indent env d with (env, d) in
+    (env, join ["<Dual>", d])
+
+  -- Equality
+  sem eqExprHDist (env : EqEnv) (free : EqEnv) (lhs : Dist) =
+  | DDual r ->
+    match lhs with DDual l then eqExprHDist env free l r else None ()
+
+  -- Symbolize
+  sem symbolizeDist (env: SymEnv) =
+  | DDual d -> DDual (symbolizeDist env d)
+
+  -- Type Check
+  sem typeCheckDist (env: TCEnv) (info: Info) =
+  | DDual d -> typeCheckDist env info d
+
+  -- ANF
+  sem normalizeDist (k : Dist -> Expr) =
+  | DDual d -> normalizeDist (lam d. k (DDual d)) d
+
+  -- Type lift
+  sem typeLiftDist (env : TypeLiftEnv) =
+  | DDual d -> match typeLiftDist env d with (env, d) in (env, DDual d)
+
+  -- Partial evaluation
+  sem pevalDistEval ctx k =
+  | DDual d -> pevalDistEval ctx (lam d. k (DDual d)) d
+end
+
+
+lang DualNumRuntimeBase = DualNumAst
+
+  -- ┌──────────────────────────────────────────────────────┐
+  -- │ Interface for runtime implementation of dual numbers │
+  -- └──────────────────────────────────────────────────────┘
+
+  -- The environment is decied by the runtime implementation.
+  syn DualNumRuntimeEnv =
+
+  -- `dualnumTransformAPIConst env tm const` provides runtime implementations
+  -- for the dual number API and constant functions lifted to dual numbers.
+  sem dualnumTransformAPIConst : DualNumRuntimeEnv -> Expr -> Const -> Expr
+
+  -- `dualnumTransformAPIConst env tm const` provides a runtime implementation
+  -- for the dual number type.
+  sem dualnumTransformTypeAPI : DualNumRuntimeEnv -> Type -> Type
+  sem dualnumTransformTypeAPI env =| ty ->
+    smap_Type_Type (dualnumTransformTypeAPI env) ty
+
+
+  -- `dualnumTransformAPIExpr env tm` replaces the dual number API and constants
+  -- lifted to dual numbers in `tm` with their runtime implementations.
+  sem dualnumTransformAPIExpr : DualNumRuntimeEnv -> Expr -> Expr
+  sem dualnumTransformAPIExpr env =
+  | tm & TmConst r ->
+    let tm = dualnumTransformAPIConst env tm r.val in
+    (smap_Expr_TypeLabel (dualnumTransformTypeAPI env)
+       (smap_Expr_Type (dualnumTransformTypeAPI env)
+          tm))
+  | tm ->
+    let tm = smap_Expr_Expr (dualnumTransformAPIExpr env) tm in
+    (smap_Expr_TypeLabel (dualnumTransformTypeAPI env)
+       (smap_Expr_Type (dualnumTransformTypeAPI env)
+          tm))
+end
+
+
+lang DualNumLift =
+  MExprPPL + DualNumAst + ElementaryFunctions + Diff + DualNumDist + TyConst
+
+
+  sem tyConstBase d =
+  -- NOTE(oerikss, 2024-04-25): The type of a lifted constant is its type lifted
+  -- to dual numbers.
+  | CLifted const -> dualnumLiftType (tyConstBase d const)
+  | CGenEpsilon _ -> tyarrows_ [tyunit_, tyint_]
+  | CLtEpsilon _ -> tyarrows_ [tyint_, tyint_]
+  | CCreatePrimal _ -> tyarrows_ [tyfloat_, tydualnum_ ()]
+  | CCreateDual _ -> let ty = tydualnum_ () in tyarrows_ [tyint_, ty, ty, ty]
+  | CIsDualNum _ -> tyarrows_ [tydualnum_ (), tybool_]
+  | CEpsilon _ -> tyarrows_ [tydualnum_ (), tyint_]
+  | CPrimal _ | CPertubation _ ->
+    let ty = tydualnum_ () in tyarrows_ [tyint_, ty, ty]
+  | CPrimalRec _ -> tyarrows_ [tydualnum_ (), tyfloat_]
+
+  -- ┌──────────────────────────────────────┐
+  -- │ Lift types and terms to dual numbers │
+  -- └──────────────────────────────────────┘
+
+  -- `dualnumLiftType ty` lifts a type to dual numbers.
+  sem dualnumLiftType : Type -> Type
+  sem dualnumLiftType =
+  | TyFloat r -> TyDualNum r
+  | ty -> smap_Type_Type dualnumLiftType ty
+
+  -- `dualnumLiftExpr tm` lifts the term `tm` to dual numbers. Any term that is
+  -- lifted using the dual number API above is independent of the runtime.
+  -- However, most elementary functions are mutually recursive so it is more
+  -- convenient to lift them in the runtime and then simply refer to its lifted
+  -- implementation in this semantic function.
+  sem dualnumLiftExpr : Expr -> Expr
+  sem dualnumLiftExpr =
+  | TmDiff r ->
+    match r.ty with TyArrow tyr then
+      optionMapOrElse
+        (lam.
+          errorSingle [r.info]
+            (join [
+              "Cannot differentiate functions with this return type: ",
+              type2str tyr.to
+            ]))
+        (lam pertubation.
+          optionMapOrElse
+            (lam.
+              errorSingle [r.info]
+                (join [
+                  "Cannot differentiate functions with this parameter type: ",
+                  type2str tyr.from
+                ]))
+            (lam createDual.
+              let i = withInfo r.info in
+              let e_ = nameSym "e" in
+              let x_ = nameSym "x" in
+              let v_ = nameSym "v" in
+              let d_ = nameSym "d" in
+              let fn = dualnumLiftExpr r.fn in
+              let arg = dualnumLiftExpr r.arg in
+              bind_
+                (i (nulet_ e_ (dualnumGenEpsilon r.info)))
+                (nulam_ v_
+                   (bindall_ [
+                     i (nulet_ x_ arg),
+                     i (nulet_ d_
+                          (i (appf1_ fn
+                                (createDual (i (nvar_ e_))
+                                   (i (nvar_ x_)) (i (nvar_ v_)))))),
+                     pertubation (i (nvar_ e_)) (i (nvar_ d_))
+                   ])))
+            (dualnumCreateDualTypeDirected tyr.from))
+        (dualnumPertubationTypeDirected tyr.to)
+    else error "impossible"
+  | TmExt r ->
+    optionMapOrElse
+      (lam. TmExt { r with inexpr = dualnumLiftExpr r.inexpr })
+      (lam createPrimal.
+        let id1 = nameSetNewSym r.ident in
+        -- NOTE(oerikss, 2024-04-16): We us an intermediate eta expanded alias
+        -- because externals needs to be fully applied.
+        let id2 = nameSetNewSym r.ident in
+        let i = withInfo r.info in
+        TmExt {
+          r with
+          ident = id2,
+          inexpr =
+            bindall_ [
+              i (nulet_ id1
+                   (let ps = create (arityFunType r.tyIdent) (lam. nameSym "p") in
+                    foldl
+                      (lam body. lam p. i (nulam_ p body))
+                      (foldr
+                         (lam p. lam fn. i (appf1_ fn p))
+                         (nvar_ id2)
+                         (map (lam p. i (nvar_ p)) ps))
+                      ps)),
+              i (nulet_ r.ident
+                   (dualnumLiftExpr (createPrimal (i (nvar_ id1))))),
+              dualnumLiftExpr r.inexpr
+            ]
+        })
+      (dualnumCreatePrimalTypeDirected r.tyIdent)
+  | TmDist (r & { dist = ! DEmpirical _ }) ->
+    let dist =
+      smapDist_Expr_Expr
+        (lam tm.
+          optionMapOrElse
+            (lam. dualnumLiftExpr tm)
+            (lam primal. primal (dualnumLiftExpr tm))
+            (dualnumPrimalRecTypeDirected (tyTm tm)))
+        r.dist
+    in
+    TmDist { r with dist = DDual dist }
+  | TmWeight r -> TmWeight {
+    r with weight = dualnumPrimalRec r.info (dualnumLiftExpr r.weight)
+  }
+  | TmInfer r ->
+    let method =
+      inferSmap_Expr_Expr
+        (lam tm.
+          optionMapOrElse
+            (lam. dualnumLiftExpr tm)
+            (lam primal. primal (dualnumLiftExpr tm))
+            (dualnumPrimalRecTypeDirected (tyTm tm)))
+        r.method
+    in
+    TmInfer { r with model = dualnumLiftExpr r.model, method = method }
+  | tm & TmConst r ->
+    let tm = dualnumLiftConst tm r.val in
+    (smap_Expr_TypeLabel dualnumLiftType
+       (smap_Expr_Type dualnumLiftType tm))
+  | tm ->
+    let tm = smap_Expr_Expr dualnumLiftExpr tm in
+    (smap_Expr_TypeLabel dualnumLiftType
+       (smap_Expr_Type dualnumLiftType tm))
+
+  -- We handle constants in this semantic function. `dualnumLiftConst env tm c`
+  -- lifts the constant `c`, where `tm` is the term holding the constant.
+  sem dualnumLiftConst : Expr -> Const -> Expr
+  sem dualnumLiftConst tm =
+  -- Lift elementary functions
+  | const & (
+    CFloat _
+  | CAddf _
+  | CMulf _
+  | CNegf _
+  | CSubf _
+  | CDivf _
+  | CEqf _
+  | CLtf _
+  | CLeqf _
+  | CGtf _
+  | CGeqf _
+  | CSin _
+  | CCos _
+  | CSqrt _
+  | CExp _
+  | CLog _
+  | CPow _)
+    -> withInfo (infoTm tm) (uconst_ (CLifted const))
+  -- Lift remaining constants based on their type signature
+  | const ->
+    optionMapOr tm
+      (lam createPrimal. createPrimal tm)
+      (dualnumCreatePrimalTypeDirected (tyConst const))
+end
+
+
+lang TestLang = DualNumLift + MExprAst + MExprEq + MExprPrettyPrint
+  -- We implement som additional constants to make testing easier and more
+  -- accurate.
+
+  syn Const =
+  | CTmPlaceholder { str : String } -- Represents an arbritrary term
+
+  sem getConstStringCode (indent : Int) =
+  | CTmPlaceholder r -> join ["<", r.str, ">"]
+end
+
+
+mexpr
+
+use TestLang in
+
+let createPrimal_ = appf1_ (uconst_ (CCreatePrimal ())) in
+let primalRec_ = appf1_ (uconst_ (CPrimalRec ())) in
+let pertubation_ = appf2_ (uconst_ (CPertubation ())) in
+let createDual_ = appf3_ (uconst_ (CCreateDual ())) in
+let tm_ = uconst_ (CTmPlaceholder { str = "term" } ) in
+let e_ = uconst_ (CTmPlaceholder { str = "e" } ) in
+
+-- ┌──────────────────────────────────────┐
+-- │ Test dualnumCreatePrimalTypeDirected │
+-- └──────────────────────────────────────┘
+
+let _createPrimal = lam ty.
+  optionMapOr tm_ (lam primal. primal tm_)
+    (dualnumCreatePrimalTypeDirected ty)
+in
+let failToString = utestDefaultToString expr2str expr2str in
+
+-- Base types
+
+utest _createPrimal tyfloat_ with createPrimal_ tm_
+  using eqExpr else failToString
+in
+
+utest _createPrimal tyint_ with tm_
+  using eqExpr else failToString
+in
+
+utest _createPrimal tybool_ with tm_
+  using eqExpr else failToString
+in
+
+utest _createPrimal tychar_ with tm_
+  using eqExpr else failToString
+in
+
+-- Sequences
+
+utest _createPrimal (tyseq_ tyfloat_) with
+  map_ (ulam_ "x" (createPrimal_ (var_ "x"))) tm_
+  using eqExpr else failToString
+in
+
+utest _createPrimal (tyseq_ (tyseq_ tyfloat_)) with
+  map_ (ulam_ "x" (map_ (ulam_ "x" (createPrimal_ (var_ "x"))) (var_ "x"))) tm_
+  using eqExpr else failToString
+in
+
+utest _createPrimal (tyseq_ tyint_) with tm_
+  using eqExpr else failToString
+in
+
+-- Records
+
+-- NOTE(oerikss, 2024-04-16): We define the record type outside the unit-test so
+-- that the label ordering is stable.
+let ty = tyrecord_ [
+  ("a", tyfloat_),
+  ("b", tyint_),
+  ("c", tyrecord_ [("d", tyfloat_), ("e", tyint_)])
+] in
+utest
+  _createPrimal ty
+  with
+  urecord_ [
+    ("a", createPrimal_ (recordproj_ "a" tm_)),
+    ("b", recordproj_ "b" tm_),
+    ("c", urecord_ [
+      ("d", createPrimal_ (recordproj_ "d" (recordproj_ "c" tm_))),
+      ("e", recordproj_ "e" (recordproj_ "c" tm_))
+    ])
+  ]
+  using eqExpr else failToString
+in
+
+-- Functions
+
+utest _createPrimal (tyarrow_ tyfloat_ tyfloat_) with
+  ulam_ "x" (createPrimal_ (appf1_ tm_ (primalRec_ (var_ "x"))))
+  using eqExpr else failToString
+in
+
+utest _createPrimal (tyarrows_ [tyfloat_, tyfloat_, tyfloat_]) with
+  ulam_ "x"
+    (ulam_ "y"
+       (createPrimal_
+          (appf2_ tm_ (primalRec_ (var_ "x")) (primalRec_ (var_ "y")))))
+  using eqExpr else failToString
+in
+
+utest _createPrimal (tyarrows_ [tyfloat_, tyint_, tyfloat_]) with
+  ulam_ "x"
+    (ulam_ "y"
+       (createPrimal_ (appf2_ tm_ (primalRec_ (var_ "x")) (var_ "y"))))
+  using eqExpr else failToString
+in
+
+-- ┌─────────────────────────────────────┐
+-- │ Test dualnumPertubationTypeDirected │
+-- └─────────────────────────────────────┘
+
+let _pertubation = lam ty.
+  optionMapOr tm_ (lam pertubation.  pertubation e_ tm_)
+    (dualnumPertubationTypeDirected ty)
+in
+
+-- Base types
+
+utest _pertubation tyfloat_ with pertubation_ e_ tm_
+  using eqExpr else failToString
+in
+
+utest _pertubation tyint_ with tm_
+  using eqExpr else failToString
+in
+
+utest _pertubation tybool_ with tm_
+  using eqExpr else failToString
+in
+
+utest _pertubation tychar_ with tm_
+  using eqExpr else failToString
+in
+
+-- Sequences
+
+utest _pertubation (tyseq_ tyfloat_) with
+  map_ (ulam_ "x" (pertubation_ e_ (var_ "x"))) tm_
+  using eqExpr else failToString
+in
+
+utest _pertubation (tyseq_ (tyseq_ tyfloat_)) with
+  map_ (ulam_ "x" (map_ (ulam_ "x" (pertubation_ e_ (var_ "x"))) (var_ "x"))) tm_
+  using eqExpr else failToString
+in
+
+utest _pertubation (tyseq_ tyint_) with tm_
+  using eqExpr else failToString
+in
+
+-- Records
+
+-- NOTE(oerikss, 2024-04-16): We define the record type outside the unit-test so
+-- that the label ordering is stable.
+let ty = tyrecord_ [
+  ("a", tyfloat_),
+  ("b", tyrecord_ [("c", tyfloat_)])
+] in
+utest
+  _pertubation ty
+  with
+  urecord_ [
+    ("a", pertubation_ e_ (recordproj_ "a" tm_)),
+    ("b", urecord_ [
+      ("c", pertubation_ e_ (recordproj_ "c" (recordproj_ "b" tm_)))
+    ])
+  ]
+  using eqExpr else failToString
+in
+
+let ty = tyrecord_ [
+  ("a", tyfloat_),
+  ("b", tyrecord_ [("c", tyint_)])
+] in
+utest _pertubation ty with tm_
+  using eqExpr else failToString
+in
+
+
+-- ┌────────────────────────────────────┐
+-- │ Test dualnumCreateDualTypeDirected │
+-- └────────────────────────────────────┘
+
+let tm1_ = uconst_ (CTmPlaceholder { str = "term1" } ) in
+let tm2_ = uconst_ (CTmPlaceholder { str = "term2" } ) in
+
+let _createDual = lam ty.
+  optionMapOr tm1_ (lam createDual.  createDual e_ tm1_ tm2_)
+    (dualnumCreateDualTypeDirected ty)
+in
+
+-- Base types
+
+utest _createDual tyfloat_ with createDual_ e_ tm1_ tm2_
+  using eqExpr else failToString
+in
+
+utest _createDual tyint_ with tm_
+  using eqExpr else failToString
+in
+
+utest _createDual tybool_ with tm_
+  using eqExpr else failToString
+in
+
+utest _createDual tychar_ with tm_
+  using eqExpr else failToString
+in
+
+-- Sequences
+
+-- utest _createDual (tyseq_ tyfloat_) with
+--   map_ (ulam_ "x" (pertubation_ e_ (var_ "x"))) tm_
+--   using eqExpr else failToString
+-- in
+
+-- utest _createDual (tyseq_ (tyseq_ tyfloat_)) with
+--   map_ (ulam_ "x" (map_ (ulam_ "x" (pertubation_ e_ (var_ "x"))) (var_ "x"))) tm_
+--   using eqExpr else failToString
+-- in
+
+-- utest _createDual (tyseq_ tyint_) with tm_
+--   using eqExpr else failToString
+-- in
+
+()

--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -2,12 +2,13 @@
 
 include "coreppl.mc"
 include "parser.mc"
+include "ad.mc"
 
 include "mexpr/cfa.mc"
 include "mexpr/type.mc"
 include "mexpr/const-types.mc"
 
-lang ConstAllCFA = MExprCFA + MExprPPL
+lang ConstAllCFA = MExprCFA + MExprPPL + DualNumLift
 
   -- The below ensures all constants are tracked as needed for the CorePPL
   -- analyses.  In the base CFA fragment in Miking, constraints for constants

--- a/coreppl/src/coreppl-to-mexpr/ad/dual-tree.mc
+++ b/coreppl/src/coreppl-to-mexpr/ad/dual-tree.mc
@@ -1,0 +1,89 @@
+-- This is an implementation of the tree-based dual-number API described in the
+-- paper:
+
+-- Siskind, Jeffrey Mark, and Barak A. Pearlmutter. “Nesting Forward-Mode AD in
+-- a Functional Framework.” Higher-Order and Symbolic Computation 21, no. 4
+-- (December 1, 2008): 361–76. https://doi.org/10.1007/s10990-008-9037-1.
+
+-- Functions part of the API are prefixed with dual. Other functions are
+-- internal.
+
+include "math.mc"
+
+type Eps = Int
+
+-- Dual's can be nested and are implemented as explicit trees.
+type Dual a
+con Dual : all a. {e : Eps, x : Dual a, xp : Dual a} -> Dual a
+con Primal : all a. a -> Dual a
+
+-- Epsilons are ordered.
+let dualLtE : Eps -> Eps -> Bool = lti
+let dualEqE : Eps -> Eps -> Bool = eqi
+
+-- false if x' = 0 in x+ex'
+let dualIsDual : all a. Dual a -> Bool =
+lam n.
+  switch n
+  case Primal _ then false
+  case Dual _ then true
+  end
+
+-- x if x' = 0 otherwise x+ex'
+let dualCreateDual : all a. (a -> Bool) -> Eps -> Dual a -> Dual a -> Dual a =
+lam isZero. lam e. lam x. lam xp.
+  match xp with Primal v then
+    if isZero v then x else Dual { e = e, x = x, xp = xp }
+  else Dual { e = e, x = x, xp = xp }
+
+-- e in x+ex'
+let dualEpsilon : all a. Dual a -> Eps =
+lam n.
+  match n with Dual dn then dn.e
+  else error "Operand not a dual number"
+
+-- x in x+ex' given e
+let dualPrimal : all a. Eps -> Dual a -> Dual a =
+lam e. lam n.
+  switch n
+  case Primal _ then n
+  case Dual dn then if dualLtE dn.e e then n else dn.x
+  end
+
+-- x in x+e1(x+e2(x+e3(...)))
+recursive
+let dualPrimalRec : all a. Dual a -> a =
+lam n.
+  switch n
+  case Primal n then n
+  case Dual {x = x} then dualPrimalRec x
+  end
+end
+
+-- x' in x+ex' given e
+let dualPertubation : all a. a -> Eps -> Dual a -> Dual a =
+lam zero. lam e. lam n.
+  switch n
+  case Primal _ then Primal zero
+  case Dual dn then if dualLtE dn.e e then Primal zero else dn.xp
+  end
+
+-- generate a unique epsilon e1 that fulfills the invariant e1 > e for all
+-- previously generated epsilons e.
+let e = ref 0
+let dualGenEpsilon : () -> Eps =
+lam. modref e (succ (deref e)); deref e
+
+-- Structural equality function for duals
+let dualEq : all a. (a -> a -> Bool) -> Dual a -> Dual a -> Bool =
+  lam eq.
+  recursive let recur = lam n1. lam n2.
+    switch (n1, n2)
+    case (Primal r1, Primal r2) then eq r1 r2
+    case (Dual {e = e1, x = x1, xp = xp1}, Dual {e = e2, x = x2, xp = xp2}) then
+      if dualEqE e1 e2 then
+        if recur x1 x2 then recur xp1 xp2 else false
+      else false
+    case (_, _) then false
+    end
+  in recur

--- a/coreppl/src/coreppl-to-mexpr/ad/dualnum-lift.mc
+++ b/coreppl/src/coreppl-to-mexpr/ad/dualnum-lift.mc
@@ -1,0 +1,442 @@
+-- This is an implementation of functions lifting operators over reals to nested
+-- dual-bers described in the paper:
+
+-- Siskind, Jeffrey Mark, and Barak A. Pearl mutter. “Nesting Forward-Mode AD in
+-- a Functional Framework.” Higher-Order and Symbolic Computation 21, no. 4
+-- (December 1, 2008): 361–76. https://doi.org/10.1007/s10990-008-9037-1.
+
+-- Public functions are prefixed with dualnum. Other functions are internal.
+
+
+
+include "dualnum-tree.mc"
+include "bool.mc"
+include "math.mc"
+include "common.mc"
+
+-------------
+-- ALIASES --
+-------------
+
+let _dnum = dualnumCreateDual
+let _ltE = dualLtE
+let _isDualNum = dualnumIsDualNum
+let _epsilon = dualnumEpsilon
+let _primal = dualnumPrimal
+let _primalRec = dualnumPrimalRec
+let _pertubation = dualnumPertubation
+-- let _lift2 = dualnumLift2
+-- let _lift1 = dualnumLift1
+let _genEpsilon = dualGenEpsilon
+
+let _num0 = Primal 0.
+let _num1 = Primal 1.
+let _num2 = Primal 2.
+let _num3 = Primal 3.
+let _num4 = Primal 4.
+let _num6 = Primal 6.
+let _num8 = Primal 8.
+let _num10 = Primal 10.
+
+let _e0 = _genEpsilon ()
+let _e1 = _genEpsilon ()
+let _e2 = _genEpsilon ()
+let _e3 = _genEpsilon ()
+
+let _dnum0 = _dnum _e0
+let _dnum1 = _dnum _e1
+let _dnum010 = _dnum0 _num1 _num0
+let _dnum011 = _dnum0 _num1 _num1
+let _dnum012 = _dnum0 _num1 _num2
+let _dnum020 = _dnum0 _num2 _num0
+let _dnum021 = _dnum0 _num2 _num1
+let _dnum022 = _dnum0 _num2 _num2
+let _dnum031 = _dnum0 _num3 _num1
+let _dnum034 = _dnum0 _num3 _num4
+let _dnum036 = _dnum0 _num3 _num6
+let _dnum040 = _dnum0 _num4 _num0
+let _dnum044 = _dnum0 _num4 _num4
+let _dnum048 = _dnum0 _num4 _num8
+let _dnum111 = _dnum1 _num1 _num1
+let _dnum112 = _dnum1 _num1 _num2
+let _dnum122 = _dnum1 _num2 _num2
+let _dnum134 = _dnum1 _num3 _num4
+
+
+----------------------------------
+-- LIFTING OF BINARY OPERATORS  --
+----------------------------------
+
+type Cmp2 = Float -> Float -> Bool
+
+-- lifts compare function to nested dual-numbers. The compare functions is
+-- applied to x in x+(en)x', where x and x' are reals, e.g. x+(en)x' is the
+-- deepest element in the nested dual-number y+(e1)y'.
+-- cmp : real compare function
+let dualnumLiftBoolFun2 : Cmp2 -> (DualNum -> DualNum -> Bool) =
+lam cmp. lam p1. lam p2. cmp (_primalRec p1) (_primalRec p2)
+
+let _liftBool = dualnumLiftBoolFun2
+
+
+----------------
+-- CONSTANTS  --
+----------------
+
+let epsn = Primal 1.e-15
+
+
+-----------------------
+-- BOOLEAN OPERATORS  --
+-----------------------
+
+let eqn = _liftBool eqf -- lifted ==
+
+utest eqn _num1 _num1 with true
+utest eqn _num1 _num2 with false
+utest eqn (_dnum _e2 _dnum112 _num3) _num1 with true
+utest eqn (_dnum _e2 _dnum112 _num3) _num2 with false
+
+
+let neqn = _liftBool neqf -- lifted !=
+
+utest neqn _num1 _num1 with false
+utest neqn _num1 _num2 with true
+utest neqn (_dnum _e2 _dnum112 _num3) _num1 with false
+utest neqn (_dnum _e2 _dnum112 _num3) _num2 with true
+
+
+let ltn = _liftBool ltf -- lifted <
+
+utest ltn _num1 _num1 with false
+utest ltn _num1 _num2 with true
+utest ltn _num2 _num1 with false
+utest ltn (_dnum _e2 _dnum112 _num3) _num1 with false
+utest ltn (_dnum _e2 _dnum112 _num3) _num2 with true
+utest ltn _num2 (_dnum _e2 _dnum112 _num3) with false
+
+
+let leqn = _liftBool leqf -- lifted <=
+
+utest leqn _num1 _num1 with true
+utest leqn _num1 _num2 with true
+utest leqn _num2 _num1 with false
+utest leqn (_dnum _e2 _dnum112 _num3) _num1 with true
+utest leqn (_dnum _e2 _dnum112 _num3) _num2 with true
+utest leqn _num2 (_dnum _e2 _dnum112 _num3) with false
+
+
+let gtn = _liftBool gtf -- lifted >
+
+utest gtn _num1 _num1 with false
+utest gtn _num1 _num2 with false
+utest gtn _num2 _num1 with true
+utest gtn (_dnum _e2 _dnum112 _num3) _num1 with false
+utest gtn (_dnum _e2 _dnum112 _num3) _num2 with false
+utest gtn _num2 (_dnum _e2 _dnum112 _num3) with true
+
+
+let geqn = _liftBool geqf -- lifted >=
+
+utest geqn _num1 _num1 with true
+utest geqn _num1 _num2 with false
+utest geqn _num2 _num1 with true
+utest geqn (_dnum _e2 _dnum112 _num3) _num1 with true
+utest geqn (_dnum _e2 _dnum112 _num3) _num2 with false
+utest geqn _num2 (_dnum _e2 _dnum112 _num3) with true
+
+
+----------------------------------
+-- ADDITION AND MULTIPLICATION  --
+----------------------------------
+
+let _eqfApprox = eqfApprox 1.e-6
+
+-- lifted addition
+recursive let addn = lam p1. lam p2.
+  switch (p1, p2)
+  case (Primal p1, Primal p2) then Primal (addf p1 p2)
+  case (p & Primal _, Dual r) | (Dual r, p & Primal _) then
+    Dual { r with x = addn p r.x }
+  case (Dual r1, Dual r2) then
+    if _ltE r1.e r2.e then Dual { r2 with x = addn p1 r2.x }
+    else if _ltE r2.e r1.e then Dual { r1 with x = addn r1.x p2 }
+    else Dual { r1 with x = addn r1.x r2.x, xp = addn r1.xp r2.xp }
+  end
+end
+
+utest addn _num1 _num2 with _num3 using dualnumEq _eqfApprox
+utest addn _dnum010 _num2 with _dnum0 _num3 _num0 using dualnumEq _eqfApprox
+utest addn _dnum011 _num2 with _dnum031 using dualnumEq _eqfApprox
+utest addn _dnum011 _dnum011 with _dnum022 using dualnumEq _eqfApprox
+utest addn _dnum011 _dnum111 with _dnum1 _dnum021 _num1 using dualnumEq _eqfApprox
+
+-- lifted multiplication
+recursive let muln = lam p1. lam p2.
+  switch (p1, p2)
+  case (Primal p1, Primal p2) then Primal (mulf p1 p2)
+  case (p & Primal _, Dual r) | (Dual r, p & Primal _) then
+    Dual { r with x = muln p r.x, xp = muln p r.xp }
+  case (Dual r1, Dual r2) then
+    if _ltE r1.e r2.e then
+      Dual { r2 with x = muln p1 r2.x, xp = muln p1 r2.xp }
+    else if _ltE r2.e r1.e then
+      Dual { r1 with x = muln r1.x p2, xp = muln p2 r1.xp }
+    else
+      Dual {
+        r1 with
+        x = muln r1.x r2.x,
+        xp = addn (muln r2.x r1.xp) (muln r1.x r2.xp)
+      }
+  end
+end
+
+utest muln _num1 _num2 with _num2 using dualnumEq _eqfApprox
+utest muln _dnum010 _num2 with _dnum0 _num2 _num0 using dualnumEq _eqfApprox
+utest muln _dnum011 _num2 with _dnum022 using dualnumEq _eqfApprox
+utest muln _dnum012 _dnum034 with _dnum0 _num3 _num10 using dualnumEq _eqfApprox
+utest muln _dnum012 _dnum134 with _dnum1 _dnum036 _dnum048 using dualnumEq _eqfApprox
+
+
+---------------------------
+-- DERIVATIVE OPERATORS  --
+---------------------------
+
+-- We define the scalar derivative operator over dual numbers
+let der : (DualNum -> DualNum) -> DualNum -> DualNum =
+  lam f. lam x.
+  let e = _genEpsilon () in
+  _pertubation e (f (_dnum e x (Primal 1.)))
+
+utest der (lam. _num2) _num2 with _num0 using dualnumEq eqf
+utest der (lam x. muln x x) (_num2) with _num4 using dualnumEq eqf
+
+-- As well as scalar higher order derivatives
+recursive
+let nder
+  : Int -> (DualNum -> DualNum) -> DualNum -> DualNum =
+  lam n. lam f.
+    if lti n 0 then error "Negative derivative order"
+    else if eqi n 0 then f
+    else nder (subi n 1) (der f)
+end
+
+utest nder 0 (lam x. muln x x) (_num2) with _num4 using dualnumEq eqf
+utest nder 1 (lam x. muln x x) (_num4) with _num8 using dualnumEq eqf
+utest nder 2 (lam x. muln x x) (_num4) with _num2 using dualnumEq eqf
+
+
+-------------------------------------
+-- REAMINING ARITHMETIC OPERATORS  --
+-------------------------------------
+
+-- lifted negation
+recursive let negn = lam p.
+  switch p
+  case Primal p then Primal (negf p)
+  case Dual r then Dual { r with x = negn r.x, xp = negn r.xp }
+  end
+end
+
+utest negn _num1 with Primal (negf 1.) using dualnumEq _eqfApprox
+utest negn _num0 with Primal (negf 0.) using dualnumEq _eqfApprox
+utest negn _dnum010 with _dnum0 (Primal (negf 1.)) _num0 using dualnumEq _eqfApprox
+utest negn _dnum012 with _dnum0 (Primal (negf 1.)) (Primal (negf 2.))
+using dualnumEq _eqfApprox
+
+utest der negn _num1 with negn _num1 using dualnumEq _eqfApprox
+
+-- lifted subtraction
+recursive let subn = lam p1. lam p2.
+  switch (p1, p2)
+  case (Primal p1, Primal p2) then Primal (subf p1 p2)
+  case (Primal _, Dual r) then
+    Dual { r with x = subn p1 r.x }
+  case(Dual r, Primal _) then
+    Dual { r with x = subn r.x p2, xp = negn r.xp }
+  case (Dual r1, Dual r2) then
+    if _ltE r1.e r2.e then
+      Dual { r2 with x = subn p1 r2.x }
+    else if _ltE r2.e r1.e then
+      Dual { r1 with x = subn r1.x p2, xp = negn r1.xp }
+    else
+      Dual { r1 with x = subn r1.x r2.x, xp = subn r1.xp r2.xp }
+  end
+end
+
+utest subn _num2 _num1 with _num1 using dualnumEq _eqfApprox
+utest subn _dnum020 _num1 with _dnum0 _num1 _num0 using dualnumEq _eqfApprox
+utest subn _dnum021 _num1 with _dnum0 _num1 (Primal (negf 1.))
+  using dualnumEq _eqfApprox
+utest subn _dnum022 _dnum011 with _dnum011 using dualnumEq _eqfApprox
+
+utest
+  let r = subn _dnum122 _dnum011 in
+  dualnumPrimal _e1 r
+with _dnum011 using dualnumEq _eqfApprox
+
+
+-- lifted abs
+let absn = lam p. if ltn p _num0 then negn p else p
+
+-- lifted approximate compare function
+let eqnEps = lam l. lam r.
+  ltn (absn (subn l r)) epsn
+
+
+-- lifted division
+recursive let divn = lam p1. lam p2.
+  let dfdx1 = lam x2. divn (Primal 1.) x2 in
+  let dfdx2 = lam x1. lam x2. divn (negn x1) (muln x2 x2) in
+  switch (p1, p2)
+  case (Primal p1, Primal p2) then Primal (divf p1 p2)
+  case (Primal _, Dual r) then
+    Dual { r with x = divn p1 r.x, xp = muln (dfdx2 p1 r.x) r.xp }
+  case (Dual r, Primal _) then
+    Dual { r with x = divn r.x p2, xp = muln (dfdx1 p2) r.xp }
+  case (Dual r1, Dual r2) then
+    if _ltE r1.e r2.e then
+      Dual { r2 with x = divn p1 r2.x, xp = muln (dfdx2 p1 r2.x) r2.xp }
+    else if _ltE r2.e r1.e then
+      Dual { r1 with x = divn r1.x p2, xp = muln (dfdx1 p2) r1.xp }
+    else
+      Dual {
+        r1 with
+        x = divn r1.x r2.x,
+        xp = addn (muln (dfdx1 r2.x) r1.xp) (muln (dfdx2 r1.x r2.x) r2.xp)
+      }
+  end
+end
+
+utest divn _num4 _num2 with _num2 using dualnumEq _eqfApprox
+utest divn _dnum040 _num2 with _dnum0 _num2 _num0 using dualnumEq _eqfApprox
+utest divn _dnum044 _num2 with _dnum022 using dualnumEq _eqfApprox
+
+utest divn _dnum012 _dnum034
+with _dnum0 (Primal (divf 1. 3.)) (Primal (divf 2. 9.)) using dualnumEq _eqfApprox
+
+utest divn _dnum012 _dnum134
+with _dnum1 (_dnum0 (Primal (divf 1. 3.))
+                    (Primal (divf 2. 3.)))
+            (_dnum0 (Primal (divf (negf 4.) 9.))
+                    (Primal (divf (negf 8.) 9.)))
+using dualnumEq _eqfApprox
+
+----------------
+-- CONSTANTS  --
+----------------
+
+let pin = Primal pi
+
+---------------------------
+-- ELEMENTARY FUNCTIONS  --
+---------------------------
+
+-- Trigonometric functions
+recursive
+  let sinn = lam p.
+    switch p
+    case Primal p then Primal (sin p)
+    case Dual r then Dual { r with x = sinn r.x, xp = muln (cosn r.x) r.xp }
+    end
+  let cosn = lam p.
+    switch p
+    case Primal p then Primal (cos p)
+    case Dual r then
+      Dual { r with x = cosn r.x, xp = negn (muln (sinn r.x) r.xp)}
+    end
+end
+
+utest sinn (divn pin _num2) with _num1 using eqnEps
+utest sinn _num0 with _num0 using eqnEps
+
+utest cosn (divn pin _num2) with _num0 using eqnEps
+utest cosn _num0 with _num1 using eqnEps
+
+utest addn (muln (sinn _num1) (sinn _num1)) (muln (cosn _num1) (cosn _num1))
+with _num1 using eqnEps
+
+utest der sinn _num1 with cosn _num1 using eqnEps
+utest der cosn _num1 with negn (sinn _num1) using eqnEps
+
+-- Exponential function
+recursive
+  let expn = lam p.
+    switch p
+    case Primal p then Primal (exp p)
+    case Dual r then Dual { r with x = expn r.x, xp = muln (expn r.x) r.xp }
+    end
+end
+
+utest expn _num0 with _num1 using eqnEps
+utest der expn _num1 with expn _num1 using eqnEps
+
+-- Natural logarithm
+recursive
+  let logn = lam p.
+    switch p
+    case Primal p then Primal (log p)
+    case Dual r then Dual { r with x = logn r.x, xp = divn r.xp r.x }
+    end
+end
+
+utest logn _num1 with _num0 using eqnEps
+utest logn (expn _num3) with _num3 using eqnEps
+utest expn (logn _num3) with _num3 using eqnEps
+utest der logn _num1 with _num1 using eqnEps
+
+
+-- Power function
+recursive
+  let pown = lam p1. lam p2.
+  let dfdx1 = lam x1. lam x2. muln x2 (pown x1 (subn x2 (Primal 1.))) in
+  let dfdx2 = lam x1. lam x2.
+    if eqn x1 (Primal 0.) then
+      if gtn x2 (Primal 0.) then Primal 0.
+      else Primal nan
+    else
+      muln (pown x1 x2) (logn x1)
+  in
+  switch (p1, p2)
+  case (Primal p1, Primal p2) then Primal (pow p1 p2)
+  case (Primal _, Dual r) then
+    Dual { r with x = pown p1 r.x, xp = muln (dfdx2 p1 r.x) r.xp }
+  case (Dual r, Primal _) then
+    Dual { r with x = pown r.x p2, xp = muln (dfdx1 r.x p2) r.xp }
+  case (Dual r1, Dual r2) then
+    if _ltE r1.e r2.e then
+      Dual { r2 with x = pown p1 r2.x, xp = muln (dfdx2 p1 r2.x) r2.xp }
+    else if _ltE r2.e r1.e then
+      Dual { r1 with x = pown r1.x p2, xp = muln (dfdx1 r1.x p2) r1.xp }
+    else
+      Dual {
+        r1 with
+        x = pown r1.x r2.x,
+        xp = addn (muln (dfdx1 r1.x r2.x) r1.xp) (muln (dfdx2 r1.x r2.x) r2.xp)
+      }
+  end
+end
+
+utest pown _num3 _num2 with Primal 9. using eqnEps
+utest der (lam x. pown x _num2) _num3 with _num6 using eqnEps
+utest der (pown (expn _num1)) _num2 with expn _num2 using eqnEps
+utest der (pown _num0) _num2 with _num0 using eqnEps
+utest der (pown _num1) _num0 with _num0 using eqnEps
+utest der (pown _num1) _num1 with _num0 using eqnEps
+
+-- Square root
+recursive
+  let sqrtn = lam p.
+    switch p
+    case Primal p then Primal (sqrt p)
+    case Dual r then
+      Dual {
+        r with
+        x = sqrtn r.x,
+        xp = divn r.xp (muln (Primal 2.) (sqrtn r.x))
+      }
+    end
+end
+
+utest sqrtn (Primal 9.) with _num3 using eqnEps
+utest der sqrtn (Primal 9.) with divn _num1 _num6 using eqnEps

--- a/coreppl/src/coreppl-to-mexpr/ad/dualnum-tree.mc
+++ b/coreppl/src/coreppl-to-mexpr/ad/dualnum-tree.mc
@@ -1,0 +1,61 @@
+include "dual-tree.mc"
+
+type DualNum = Dual Float
+
+let dualnumGenEpsilon : () -> Eps = lam. dualGenEpsilon ()
+let dualnumLtEpsilon : Eps -> Eps -> Bool = lam l. lam r. dualGenEpsilon l r
+let dualnumIsDualNum : DualNum -> Bool = lam x. dualIsDual x
+let dualnumEpsilon : DualNum -> Eps = lam x. dualEpsilon x
+let dualnumCreatePrimal : Float -> DualNum = lam x. Primal x
+let dualnumCreateDual : Eps -> DualNum -> DualNum -> DualNum =
+  lam e. lam x. lam xp. dualCreateDual (eqf 0.) e x xp
+let dualnumPrimal : Eps -> DualNum -> DualNum = lam e. lam x. dualPrimal e x
+let dualnumPrimalRec : DualNum -> Float = lam x. dualPrimalRec x
+let dualnumPertubation : Eps -> DualNum -> DualNum =
+  lam e. lam x. dualPertubation 0. e x
+let dualnumEq = lam l. lam r. dualEq l r
+
+-----------------
+-- FOR BREVITY --
+-----------------
+
+let _dnum = dualnumCreateDual
+let _ltE = dualLtE
+
+mexpr
+
+let eq = dualnumEq eqf in
+
+let e0 = 0 in
+let e1 = 1 in
+let e2 = 2 in
+let e3 = 3 in
+
+let num0 = Primal 0. in
+let num1 = Primal 1. in
+let num2 = Primal 2. in
+let num3 = Primal 3. in
+let num4 = Primal 4. in
+let num6 = Primal 6. in
+let num8 = Primal 8. in
+let dnum112 = _dnum e1 num1 num2 in
+let dnum212 = _dnum e2 num3 num4 in
+let dnum0 = _dnum e0 in
+let dnum1 = _dnum e1 in
+let dnum134 = dnum1 num3 num4 in
+let dnum036 = dnum0 num3 num6 in
+let dnum048 = dnum0 num4 num8 in
+
+utest dualPrimalRec num0 with 0. using eqf in
+utest dualPrimalRec dnum134 with 3. using eqf in
+utest dualPrimalRec (dnum1 dnum036 dnum048) with 3. using eqf in
+utest dualIsDual num1 with false in
+utest dualIsDual dnum112 with true in
+utest dualEpsilon dnum112 with e1 in
+utest dualEpsilon (_dnum e3 dnum112 dnum212) with e3 in
+utest dualPrimal e1 dnum112 with num1 using eq in
+utest dualnumPertubation e1 dnum112 with num2 using eq in
+utest dualPrimal e2 dnum112 with dnum112 using eq in
+utest dualnumPertubation e2 dnum112 with num0 using eq in
+
+()

--- a/coreppl/src/coreppl-to-mexpr/ad/dualnum.mc
+++ b/coreppl/src/coreppl-to-mexpr/ad/dualnum.mc
@@ -1,0 +1,1 @@
+include "dualnum-lift.mc"

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -3,15 +3,18 @@ include "mexpr/externals.mc"
 include "mexpr/boot-parser.mc"
 include "mexpr/type.mc"
 include "mexpr/utils.mc"
+include "mexpr/free-vars.mc"
 include "sys.mc"
 include "map.mc"
 
+include "../ad.mc"
 include "../coreppl.mc"
 include "../inference/smc.mc"
 include "../parser.mc"
 include "../dppl-arg.mc"
 include "../transformation.mc"
 include "../src-location.mc"
+
 
 include "extract.mc"
 include "backcompat.mc"
@@ -106,6 +109,124 @@ lang DPPLTransformCancel = DPPLParser
   | t -> smap_Expr_Expr replaceCancel t
 end
 
+lang ADTransform =
+  DPPLParser +
+  LoadRuntime +
+  DualNumRuntimeBase +
+  DualNumLift
+
+  sem adHasDiff : Expr -> Bool
+  sem adHasDiff =| tm -> adHasDiffExpr false tm
+
+  sem adHasDiffExpr : Bool -> Expr -> Bool
+  sem adHasDiffExpr hasDiff =
+  | TmDiff _ -> true
+  | tm -> sfold_Expr_Expr adHasDiffExpr hasDiff tm
+
+  type ADTransformEnv = {
+    lty : Type -> Type,
+    s2n : String -> Name
+  }
+
+  syn DualNumRuntimeEnv =
+  | Env ADTransformEnv
+
+  sem adProvideRuntimeImplementation : Options -> Expr -> (Expr, Expr)
+  sem adProvideRuntimeImplementation options =| tm ->
+    let runtimeFile = "runtime-ad-wrapper.mc" in
+
+    -- load AD runtime
+    let runtime = symbolize (loadRuntime true runtimeFile) in
+
+    -- Define function that maps string identifiers to names
+    let s2n = makeRuntimeNameMap runtime (_adTransformRuntimeIds ()) in
+
+    -- Define function that constructs dual number types
+    let tyDualName = s2n "Dual" in
+    let lty = lam ty. TyApp {
+      lhs = TyCon { ident = tyDualName, data = tyunknown_, info = infoTy ty },
+      rhs = ty,
+      info = infoTy ty
+    } in
+
+    let tm = dualnumTransformAPIExpr (Env { lty = lty, s2n = s2n }) tm in
+
+    (runtime, tm)
+
+  sem dualnumTransformAPIConst env tm =
+  | CGenEpsilon _ -> withInfo (infoTm tm) (_var env "dualnumGenEpsilon")
+  | CLtEpsilon _ -> withInfo (infoTm tm) (_var env "dualnumLtEpsilon")
+  | CCreatePrimal _ -> withInfo (infoTm tm) (_var env "dualnumCreatePrimal")
+  | CCreateDual _ -> withInfo (infoTm tm) (_var env "dualnumCreateDual")
+  | CIsDualNum _ -> withInfo (infoTm tm) (_var env "dualnumIsDualNum")
+  | CEpsilon _ -> withInfo (infoTm tm) (_var env "dualnumEpsilon")
+  | CPrimal _ -> withInfo (infoTm tm) (_var env "dualnumPrimal")
+  | CPrimalRec _ -> withInfo (infoTm tm) (_var env "dualnumPrimalRec")
+  | CPertubation _ -> withInfo (infoTm tm) (_var env "dualnumPertubation")
+  | CLifted (CFloat r) ->
+    let i = withInfo (infoTm tm) in
+    withInfo (infoTm tm) (nconapp_ (_name env "Primal") (i (float_ r.val)))
+  | CLifted (CAddf _) -> withInfo (infoTm tm) (_var env "addn")
+  | CLifted (CMulf _) -> withInfo (infoTm tm) (_var env "muln")
+  | CLifted (CNegf _) -> withInfo (infoTm tm) (_var env "negn")
+  | CLifted (CSubf _) -> withInfo (infoTm tm) (_var env "subn")
+  | CLifted (CDivf _) -> withInfo (infoTm tm) (_var env "divn")
+  | CLifted (CEqf _) -> withInfo (infoTm tm) (_var env "eqn")
+  | CLifted (CNeqf _) -> withInfo (infoTm tm) (_var env "neqn")
+  | CLifted (CLtf _) -> withInfo (infoTm tm) (_var env "ltn")
+  | CLifted (CLeqf _) -> withInfo (infoTm tm) (_var env "leqn")
+  | CLifted (CGtf _) -> withInfo (infoTm tm) (_var env "gtn")
+  | CLifted (CGeqf _) -> withInfo (infoTm tm) (_var env "geqn")
+  | CLifted (CSin _) -> withInfo (infoTm tm) (_var env "sinn")
+  | CLifted (CCos _) -> withInfo (infoTm tm) (_var env "cosn")
+  | CLifted (CSqrt _) -> withInfo (infoTm tm) (_var env "sqrtn")
+  | CLifted (CExp _) -> withInfo (infoTm tm) (_var env "expn")
+  | CLifted (CLog _) -> withInfo (infoTm tm) (_var env "logn")
+  | CLifted (CPow _) -> withInfo (infoTm tm) (_var env "pown")
+  | CLifted const -> withInfo (infoTm tm) (uconst_ const)
+  | _ -> tm
+
+  sem dualnumTransformTypeAPI env =
+  | TyDualNum r -> match env with Env env in env.lty (TyFloat r)
+
+  sem _name : DualNumRuntimeEnv -> String -> Name
+  sem _name env =| str ->
+    match env with Env env in env.s2n str
+
+  sem _var : DualNumRuntimeEnv -> String -> Expr
+  sem _var env =| str -> nvar_ (_name env str)
+
+  sem _adTransformRuntimeIds =| _ -> [
+    "Dual",
+    "Primal",
+    "dualnumCreatePrimal",
+    "dualnumCreateDual",
+    "dualnumIsDualNum",
+    "dualnumLtEpsilon",
+    "dualnumGenEpsilon",
+    "dualnumPrimal",
+    "dualnumPrimalRec",
+    "dualnumPertubation",
+    "addn",
+    "muln",
+    "eqn",
+    "neqn",
+    "ltn",
+    "leqn",
+    "gtn",
+    "geqn",
+    "negn",
+    "subn",
+    "divn",
+    "sinn",
+    "cosn",
+    "sqrtn",
+    "expn",
+    "logn",
+    "pown"
+  ]
+end
+
 -- Provides runtime implementations for elementary functions that are not MExpr
 -- intrisics.
 lang ElementaryFunctionsTransform = ElementaryFunctions + LoadRuntime
@@ -163,6 +284,7 @@ lang MExprCompile =
   MExprANFAll + CPPLBackcompat +
   ODETransform + DPPLTransformCancel + DPPLPruning +
   ElementaryFunctionsTransform
+  + ADTransform
 
   sem transformModelAst : Options -> Expr -> Expr
   sem transformModelAst options =
@@ -220,15 +342,6 @@ lang MExprCompile =
     -- symbolization environment.
     let inferRuntimes = combineInferRuntimes options inferRuntimes in
 
-    -- Transform solveode terms and add the ODE solver runtime code and add it
-    -- to the program.
-    let ast =
-      switch odeTransform options ast
-      case (Some odeRuntime, ast) then
-        eliminateDuplicateCode (bind_ odeRuntime ast)
-      case (None _, ast) then ast
-      end
-    in
     mexprCompile options inferRuntimes ast
 
 
@@ -238,6 +351,26 @@ lang MExprCompile =
     -- Symbolize and type-check the CorePPL AST.
     let corepplAst = symbolize corepplAst in
     let corepplAst = typeCheck corepplAst in
+
+    -- Transform solveode terms and add the ODE solver runtime code and add it
+    -- to the program.
+    let corepplAst =
+      switch odeTransform options corepplAst
+      case (Some odeRuntime, corepplAst) then
+        eliminateDuplicateExternals (bind_ odeRuntime corepplAst)
+      case (None _, corepplAst) then corepplAst
+      end
+    in
+
+    -- Does the program contain differentiation?
+    let hasDiff = adHasDiff corepplAst in
+
+    -- Transform diff terms and lift to dual numbers if necessary.
+    let corepplAst =
+      if hasDiff then dualnumLiftExpr corepplAst
+      else corepplAst
+    in
+
     -- Extract the infer expressions to separate ASTs, one per inference
     -- method. The result consists of the provided AST, updated such that
     -- each infer is replaced with a call to the 'run' function provided by
@@ -288,6 +421,16 @@ lang MExprCompile =
     --   -- Check that the combined program type checks
     --   typeCheck prog; ()
     -- else ());
+
+    -- Provide a dual number runtime implementations
+    let prog =
+      if hasDiff then
+        match adProvideRuntimeImplementation options prog with
+          (adRuntime, prog)
+        in
+        eliminateDuplicateExternals (bind_ adRuntime prog)
+      else prog
+    in
 
     -- Finally we provide runtime implementations for elementary functions that
     -- are not MExpr intrinsics.

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -3,11 +3,12 @@
 -- common/dists.mc
 
 include "../coreppl.mc"
+include "../ad.mc"
 include "mexpr/ast-builder.mc"
 
 -- TODO(dlunde,2022-05-11): The common case where the user writes, e.g., assume
 -- (Bernoulli x), can also be optimized to not create an intermediate record.
-lang TransformDist = MExprPPL
+lang TransformDist = MExprPPL + DualNumDist
   sem transformTmDist: Expr -> Expr
   sem transformTmDist =
   | TmDist t -> transformDist (withInfo t.info) t.dist
@@ -75,6 +76,8 @@ lang TransformDist = MExprPPL
          "RuntimeDistElementary_DistWiener" (i unit_))
   | DEmpirical { samples = samples } ->
     i (app_ (var_ "vRuntimeDistEmpirical_constructDistEmpiricalHelper") samples)
+  | DDual d ->
+    i (conapp_ "RuntimeDistElementaryDual_DistDual" (transformDist i d))
 
   -- We need to replace occurrences of TyDist after transforming to MExpr
   -- distributions.

--- a/coreppl/src/coreppl-to-mexpr/pruning/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/compile.mc
@@ -1,3 +1,6 @@
+include "mexpr/externals.mc"
+
+include "../../parser.mc"
 include "../dists.mc"
 
 -- ANF for pruning --

--- a/coreppl/src/coreppl-to-mexpr/runtime-ad-wrapper.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-ad-wrapper.mc
@@ -1,0 +1,36 @@
+-- NOTE(oerikss, 2024-04-25): This files wraps the dual number implementation
+-- and allows us to use dead-code elimination when parsing this runtiume code.
+
+include "./ad/dualnum.mc"
+
+mexpr
+-- Allows us to use dead-code elimination without loosing the functions we want
+-- to keep. The downside is that we get an ugly printout when we test this file.
+dprint (
+  dualnumLtEpsilon,
+  dualnumGenEpsilon,
+  Primal 0.,
+  dualnumCreatePrimal,
+  dualnumCreateDual,
+  dualnumIsDualNum,
+  dualnumPrimal,
+  dualnumPrimalRec,
+  dualnumPertubation,
+  addn,
+  muln,
+  eqn,
+  neqn,
+  ltn,
+  leqn,
+  gtn,
+  geqn,
+  negn,
+  subn,
+  divn,
+  sinn,
+  cosn,
+  sqrtn,
+  expn,
+  logn,
+  pown
+  )

--- a/coreppl/src/coreppl-to-mexpr/runtime-elementary-wrapper.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-elementary-wrapper.mc
@@ -1,0 +1,12 @@
+include "math.mc"
+
+mexpr
+
+dprint (
+  sin,
+  cos,
+  sqrt,
+  exp,
+  log,
+  pow
+  )

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -473,6 +473,7 @@ lang Weight =
 
 end
 
+
 -- Translations in between weight and observe terms
 lang ObserveWeightTranslation = Observe + Weight
 /-
@@ -485,6 +486,7 @@ lang ObserveWeightTranslation = Observe + Weight
   | TmWeight -> unit_ -- TODO
 -/
 end
+
 
 lang SolveODE =
   Ast + Dist + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval +
@@ -928,7 +930,114 @@ lang Cancel = Observe
   
   sem getDistCancel =
   | TmObserve t -> t.dist
+end
 
+-- Assume defines a new random variable
+lang Diff =
+  Ast + PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval
+
+  syn Expr =
+  | TmDiff { fn: Expr,
+             arg: Expr,
+             ty: Type,
+             info: Info }
+
+  sem infoTm =
+  | TmDiff t -> t.info
+
+  sem tyTm =
+  | TmDiff t -> t.ty
+
+  sem withInfo (info: Info) =
+  | TmDiff t -> TmDiff { t with info = info }
+
+  sem withType (ty: Type) =
+  | TmDiff t -> TmDiff { t with ty = ty }
+
+  sem smapAccumL_Expr_Expr f acc =
+  | TmDiff t ->
+    match f acc t.fn with (acc, fn) in
+    match f acc t.arg with (acc, arg) in
+    (acc, TmDiff { t with fn = fn, arg = arg })
+
+  -- Pretty printing
+  sem isAtomic =
+  | TmDiff _ -> false
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmDiff t ->
+    let i = pprintIncr indent in
+    match printParen i env t.fn with (env, fn) in
+    match printParen i env t.arg with (env, arg) in
+    (env, join ["diff", pprintNewline i, fn, pprintNewline i, arg])
+
+  -- Equality
+  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
+  | TmDiff r ->
+    match lhs with TmDiff l then
+      optionBind (eqExprH env free l.fn r.fn)
+        (lam free. eqExprH env free l.arg r.arg)
+    else None ()
+
+  -- Type check
+  sem typeCheckExpr (env : TCEnv) =
+  | TmDiff t ->
+    let fn = typeCheckExpr env t.fn in
+    let arg = typeCheckExpr env t.arg in
+    let tyParam = newpolyvar env.currentLvl t.info in
+    let tyRes = newpolyvar env.currentLvl t.info in
+    unify env [infoTm t.fn] (ityarrow_ (infoTm fn) tyParam tyRes) (tyTm fn);
+    unify env [infoTm t.arg] tyParam (tyTm arg);
+    let argErrorMsg =
+      "* Cannot differentiate functions with a function as parameter type\n"
+    in
+    let resErrorMsg =
+      "* Cannot differentiate functions with a function as result type\n"
+    in
+    let endMsg = "* When type checking the expression\n" in
+    switch (inspectType tyParam, inspectType tyRes)
+    case (TyArrow _, TyArrow _) then
+      let msg = join [argErrorMsg, resErrorMsg, endMsg] in
+      errorSingle [t.info] msg
+    case (TyArrow _, _) then
+      let msg = join [argErrorMsg, endMsg] in
+      errorSingle [t.info] msg
+    case (_, TyArrow _) then
+      let msg = join [resErrorMsg, endMsg] in
+      errorSingle [t.info] msg
+    case _ then
+      let tyDiff = ityarrow_ t.info tyParam tyRes in
+      TmDiff { t with fn = fn, arg = arg, ty = tyDiff }
+    end
+
+  -- ANF
+  sem normalize (k : Expr -> Expr) =
+  | TmDiff t ->
+    normalizeName (lam fn.
+      normalizeName (lam arg.
+        k (TmDiff { t with fn = fn, arg = arg }))
+        t.arg)
+      t.fn
+
+  -- Type lift
+  sem typeLiftExpr (env : TypeLiftEnv) =
+  | TmDiff t ->
+    match typeLiftExpr env t.fn with (env, fn) in
+    match typeLiftExpr env t.arg with (env, arg) in
+    match typeLiftType env t.ty with (env, ty) in
+    (env, TmDiff { t with fn = fn, arg = arg, ty = ty })
+
+  -- Partial evaluation
+  sem pevalBindThis =
+  | TmDiff _ -> false
+
+  sem pevalEval ctx k =
+  | TmDiff r ->
+    pevalBind ctx (lam fn.
+      pevalBind ctx (lam arg.
+        k (TmDiff { r with fn = fn, arg = arg }))
+        r.arg)
+      r.fn
 end
 
 -----------------
@@ -971,6 +1080,9 @@ let cancel_ = use Cancel in
 
 let typruneint_ = use Prune in
   TyPruneInt {info = NoInfo ()}
+let diff_ = use Diff in
+   lam fn. lam arg.
+     TmDiff { fn = fn, arg = arg, ty = tyunknown_, info = NoInfo () }
 
 ---------------------------
 -- LANGUAGE COMPOSITIONS --
@@ -986,10 +1098,10 @@ let pplKeywords = [
   "Exponential", "Empirical", "Gaussian", "Binomial", "Wiener"
 ]
 
-lang CoreDPL = Ast + SolveODE end
+lang CoreDPL = Ast + SolveODE + Diff end
 
 let dplKeywords = [
-  "solveode"
+  "solveode", "diff"
 ]
 
 let mexprPPLKeywords = join [mexprKeywords, pplKeywords, dplKeywords]
@@ -1030,6 +1142,7 @@ let tmPruned = pruned_ tmPrune in
 let tmPruned2 = pruned_ tmPrune2 in
 let tmCancel = cancel_ (bern_ (float_ 0.7)) true_ in
 let tmCancel2 = cancel_ (bern_ (float_ 0.7)) false_  in
+let tmDiff = diff_ (ulam_ "x" (var_ "x")) (float_ 1.) in
 
 ------------------------
 -- PRETTY-PRINT TESTS --
@@ -1139,6 +1252,10 @@ utest tmCancel with tmCancel using eqExpr else _toStr in
 utest tmPrune with tmPrune2 using neqExpr else _toStr in
 utest tmPruned with tmPruned2 using neqExpr else _toStr in
 utest tmCancel with tmCancel2 using neqExpr else _toStr in
+utest tmDiff with tmDiff using eqExpr else _toStr in
+utest tmDiff with diff_ (ulam_ "x" (var_ "x")) (float_ 2.)
+  using neqExpr else _toStr
+in
 
 ----------------------
 -- SMAP/SFOLD TESTS --
@@ -1189,6 +1306,14 @@ with [ prune_ (categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2])) ] using e
 
 utest sfold_Expr_Expr foldToSeq [] tmCancel
 with [ bern_ (float_ 0.7), true_ ] using eqSeq eqExpr else _seqToStr in
+utest smap_Expr_Expr mapVar tmDiff
+  with diff_ tmVar tmVar
+  using eqExpr else _toStr
+in
+utest sfold_Expr_Expr foldToSeq [] tmDiff
+  with [ float_ 1., ulam_ "x" (var_ "x") ]
+  using eqSeq eqExpr else _seqToStr
+in
 
 ---------------------
 -- SYMBOLIZE TESTS --
@@ -1202,6 +1327,7 @@ utest symbolize tmSolveODE with tmSolveODE using eqExpr in
 utest symbolize tmPrune with tmPrune using eqExpr in
 utest symbolize tmPruned with tmPruned using eqExpr in
 utest symbolize tmCancel with tmCancel using eqExpr in
+utest symbolize tmDiff with tmDiff using eqExpr in
 
 
 ----------------------
@@ -1216,6 +1342,8 @@ utest tyTm (typeCheck tmSolveODE) with tyseq_ tyfloat_ using eqType in
 utest tyTm (typeCheck tmAssume) with tybool_ using eqType in
 utest tyTm (typeCheck tmPrune) with typruneint_ using eqType in
 utest tyTm (typeCheck tmCancel) with tyunit_ using eqType in
+utest tyTm (typeCheck tmDiff) with tyarrow_ tyfloat_ tyfloat_ using eqType in
+
 ---------------
 -- ANF TESTS --
 ---------------
@@ -1265,6 +1393,12 @@ utest _anf tmCancel with bindall_ [
   ulet_ "t1" (cancel_ (var_ "t") true_),
   var_ "t1"
 ] using eqExpr else _toStr in
+utest _anf tmDiff
+  with bindall_ [
+    ulet_ "t" tmDiff,
+    var_ "t"
+] using eqExpr else _toStr in
+
 ---------------------
 -- TYPE-LIFT TESTS --
 ---------------------
@@ -1277,5 +1411,6 @@ utest (typeLift tmSolveODE).1 with tmSolveODE using eqExpr in
 utest (typeLift tmPrune).1 with tmPrune using eqExpr in
 utest (typeLift tmPruned).1 with tmPruned using eqExpr in
 utest (typeLift tmCancel).1 with tmCancel using eqExpr in
+utest (typeLift tmDiff).1 with tmDiff using eqExpr in
 
 ()

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -165,7 +165,8 @@ lang Infer =
     let model = typeCheckExpr env t.model in
     let method = typeCheckInferMethod env t.info t.method in
     let tyRes = newvar env.currentLvl t.info in
-    unify env [infoTm model] (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
+    unify env [infoTm model]
+      (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
     TmInfer { t with model = model, method = method,
                      ty = TyDist {info = t.info, ty = tyRes} }
 
@@ -335,7 +336,8 @@ lang Observe =
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
     let tyDistRes = newvar env.currentLvl t.info in
-    unify env [infoTm dist] (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
+    unify env [infoTm dist]
+      (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
     unify env [infoTm value] tyDistRes (tyTm value);
     TmObserve {{{ t with value = value }
                     with dist = dist }
@@ -678,7 +680,7 @@ lang Prune =
     match unwrapType lhs with TyPruneInt _ then
       Some free
     else None ()
-  
+
   sem symbolizeExpr (env: SymEnv) =
   | TmPrune t ->
     TmPrune {{ t with dist = symbolizeExpr env t.dist}
@@ -843,11 +845,15 @@ lang Cancel = Observe
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmCancel t ->
     let i = pprintIncr indent in
-    match pprintCode i env (TmObserve {dist=t.dist,value=t.value,ty=t.ty,info=t.info}) with (env,args) then
+    match
+      pprintCode i env
+        (TmObserve {dist=t.dist,value=t.value,ty=t.ty,info=t.info})
+      with (env,args)
+    then
       (env, join ["cancel", pprintNewline i,
        "(", args ,")"])
     else never
-  
+
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmCancel r ->
     match lhs with TmCancel l then
@@ -869,7 +875,8 @@ lang Cancel = Observe
     let value = typeCheckExpr env t.value in
     let dist = typeCheckExpr env t.dist in
     let tyDistRes = newvar env.currentLvl t.info in
-    unify env [infoTm dist] (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
+    unify env [infoTm dist]
+      (TyDist { info = t.info, ty = tyDistRes }) (tyTm dist);
     unify env [infoTm value] tyDistRes (tyTm value);
     TmCancel {{{ t with value = value }
                     with dist = dist }
@@ -927,7 +934,7 @@ lang Cancel = Observe
 
   sem getValueCancel =
   | TmObserve t -> t.value
-  
+
   sem getDistCancel =
   | TmObserve t -> t.dist
 end
@@ -1089,13 +1096,15 @@ let diff_ = use Diff in
 ---------------------------
 
 lang CorePPL =
-  Ast + Assume + Observe + Weight + Infer + ObserveWeightTranslation + DistAll + Pruned + Cancel 
+  Ast + Assume + Observe + Weight + Infer + ObserveWeightTranslation + DistAll +
+  Pruned + Cancel
 end
 
 let pplKeywords = [
-  "assume", "observe", "weight", "resample", "prune", "pruned", "cancel", "Uniform", "Bernoulli",
-  "Poisson", "Beta", "Gamma", "Categorical", "Multinomial", "Dirichlet",
-  "Exponential", "Empirical", "Gaussian", "Binomial", "Wiener"
+  "assume", "observe", "weight", "resample", "prune", "pruned", "cancel",
+  "Uniform", "Bernoulli", "Poisson", "Beta", "Gamma", "Categorical",
+  "Multinomial", "Dirichlet", "Exponential", "Empirical", "Gaussian",
+  "Binomial", "Wiener"
 ]
 
 lang CoreDPL = Ast + SolveODE + Diff end
@@ -1136,8 +1145,12 @@ in
 let tmX0 = seq_ [float_ 1., float_ 0.] in
 let tmTEnd = float_ 1. in
 let tmSolveODE = solveode_ tmODE tmX0 tmTEnd in
-let tmPrune = prune_ (categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2])) in
-let tmPrune2 = prune_ (categorical_ (seq_ [float_ 0.4,float_ 0.4,float_ 0.2])) in
+let tmPrune =
+  prune_ (categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2]))
+in
+let tmPrune2 =
+  prune_ (categorical_ (seq_ [float_ 0.4,float_ 0.4,float_ 0.2]))
+in
 let tmPruned = pruned_ tmPrune in
 let tmPruned2 = pruned_ tmPrune2 in
 let tmCancel = cancel_ (bern_ (float_ 0.7)) true_ in
@@ -1299,10 +1312,14 @@ with [ tmTEnd, tmX0, tmODE, float_ 0.01 ] using eqSeq eqExpr else _seqToStr in
 
 
 utest sfold_Expr_Expr foldToSeq [] tmPrune
-with [ categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2]) ] using eqSeq eqExpr else _seqToStr in
+  with [ categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2]) ]
+  using eqSeq eqExpr else _seqToStr
+in
 
 utest sfold_Expr_Expr foldToSeq [] tmPruned
-with [ prune_ (categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2])) ] using eqSeq eqExpr else _seqToStr in
+  with [ prune_ (categorical_ (seq_ [float_ 0.5,float_ 0.3,float_ 0.2])) ]
+  using eqSeq eqExpr else _seqToStr
+in
 
 utest sfold_Expr_Expr foldToSeq [] tmCancel
 with [ bern_ (float_ 0.7), true_ ] using eqSeq eqExpr else _seqToStr in

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -70,7 +70,7 @@ type Options = {
 
   -- Size of fixed step-size ODE solvers
   stepSize: Float,
-  
+
   -- Whether to subsample the posterior distribution
   -- used in conjuction with smc-apf and smc-bpf and without no-print-samples
   subsample: Bool,

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -18,7 +18,9 @@ include "dppl-arg.mc"
 -- 4. inferMethodConfig
 -- 5. typeCheckInferMethod
 -- 6. inferSmapAccumL
-lang InferMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
+lang InferMethodBase =
+  PrettyPrint + TypeCheck + Sym + MethodHelper
+
   syn InferMethod =
   | Default { runs: Expr }
 
@@ -81,4 +83,8 @@ lang InferMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
   | Default r ->
     match f acc r.runs with (acc, runs) in (acc, Default {r with runs = runs})
   | m -> printLn (pprintInferMethod 0 pprintEnvEmpty m).1; error "fail"
+
+  sem inferSmap_Expr_Expr : all a. (Expr -> Expr) -> InferMethod -> InferMethod
+  sem inferSmap_Expr_Expr f =| m ->
+    (inferSmapAccumL_Expr_Expr (lam. lam tm. ((), f tm)) () m).1
 end

--- a/coreppl/src/ode-solver-method.mc
+++ b/coreppl/src/ode-solver-method.mc
@@ -4,6 +4,7 @@ include "mexpr/info.mc"
 include "mexpr/pprint.mc"
 include "mexpr/type-check.mc"
 include "mexpr/symbolize.mc"
+include "mexpr/eq.mc"
 
 include "method-helper.mc"
 include "dppl-arg.mc"
@@ -13,7 +14,7 @@ include "dppl-arg.mc"
 --
 -- To define a new ODE solver method constructor, the following semantic
 -- functions must be implemented for the constructor.
-lang ODESolverMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
+lang ODESolverMethodBase = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   syn ODESolverMethod =
   | ODESolverDefault { stepSize: Expr }
 
@@ -22,9 +23,10 @@ lang ODESolverMethodBase = PrettyPrint + TypeCheck + Sym + MethodHelper
   sem cmpODESolverMethod lhs =
   | rhs -> subi (constructorTag lhs) (constructorTag rhs)
 
-  sem eqODESolverMethod : ODESolverMethod -> ODESolverMethod -> Bool
-  sem eqODESolverMethod lhs =
-  | rhs -> eqi (cmpODESolverMethod lhs rhs) 0
+  sem eqODESolverMethod
+    : EqEnv -> EqEnv -> ODESolverMethod -> ODESolverMethod -> Option EqEnv
+  sem eqODESolverMethod env free =
+  | ODESolverDefault r -> eqExprH env free r.stepSize
 
   sem odeSolverMethodToString : ODESolverMethod -> String
   sem odeSolverMethodToString =

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -116,6 +116,7 @@ lang DPPLParser =
   | TmPrune _ -> true
   | TmPruned _ -> true
   | TmCancel _ -> true
+  | TmDiff _ -> true
 
   sem matchKeywordString (info: Info) =
   | "assume" -> Some (1, lam lst. TmAssume {dist = get lst 0,
@@ -169,7 +170,7 @@ lang DPPLParser =
                                         info = info})
   | "Binomial" -> Some (2, lam lst. TmDist {dist = DBinomial {n = get lst 0, p = get lst 1},
                                         ty = TyUnknown {info = info},
-                                         info = info})
+                                        info = info})
   | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {},
                                        ty = TyUnknown {info = info},
                                        info = info})
@@ -179,6 +180,10 @@ lang DPPLParser =
                                              endTime = get lst 3,
                                              ty = TyUnknown {info = info},
                                              info = info})
+  | "diff" -> Some (2, lam lst. TmDiff {fn = get lst 0,
+                                     arg = get lst 1,
+                                     ty = TyUnknown {info = info},
+                                     info = info})
   | "prune" -> Some (1, lam lst. TmPrune {dist = get lst 0,
                                           ty = TyUnknown {info = info},
                                           info = info})

--- a/coreppl/src/solveode/rk4.mc
+++ b/coreppl/src/solveode/rk4.mc
@@ -7,6 +7,9 @@ lang RK4Method = ODESolverMethodBase
   sem odeSolverMethodToString =
   | RK4 _ -> "RK4"
 
+  sem eqODESolverMethod env free =
+  | RK4 r -> eqExprH env free r.stepSize
+
   sem pprintODESolverMethod indent env =
   | RK4 { stepSize = stepSize } ->
     let i = pprintIncr indent in

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-confusion.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-confusion.mc
@@ -1,0 +1,28 @@
+include "../../../models/diff-confusion.mc"
+include "../../cppl-test.mc"
+include "../../test.mc"
+
+include "seq.mc"
+include "sys.mc"
+include "string.mc"
+include "common.mc"
+include "stats.mc"
+
+mexpr
+
+let s = 1e-9 in
+let e = eqDiffConf s in
+let rhs = diffConfTruth in
+let r = resDiffConf in
+let c = cpplResOfDist float2string in
+
+utest r (c 0   (infer (Default {}) model))                                              with rhs using e in
+utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
+utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
+utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+
+()

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-demo.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-demo.mc
@@ -1,0 +1,14 @@
+include "../../../models/diff-demo.mc"
+
+mexpr
+-- This model is deterministic and the tests consists of assertions in the model
+-- code. We simply want to make sure it compiles and runs with all inference
+-- algorithms.
+infer (Importance { particles = 10 }) model;
+infer (BPF { particles = 10 }) model;
+infer (APF { particles = 10 }) model;
+infer (PIMH { particles = 10, iterations = 10 }) model;
+infer (TraceMCMC { iterations = 10 }) model;
+infer (NaiveMCMC { iterations = 10 }) model;
+infer (LightweightMCMC { iterations = 10, globalProb = 0.1 }) model;
+()

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
@@ -1,0 +1,28 @@
+include "../../../models/diff-regression.mc"
+include "../../cppl-test.mc"
+include "../../test.mc"
+
+include "seq.mc"
+include "sys.mc"
+include "string.mc"
+include "common.mc"
+include "stats.mc"
+
+mexpr
+
+let s = 1e-1 in
+let e = eqDiffReg s in
+let rhs = diffRegTruth in
+let r = resDiffReg in
+let c = cpplResOfDist float2string in
+
+utest r (c 0   (infer (Default {}) model))                                              with rhs using e in
+utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
+utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
+utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+
+()

--- a/coreppl/test/cppl-test.mc
+++ b/coreppl/test/cppl-test.mc
@@ -4,7 +4,9 @@ include "test.mc"
 let cpplResOfDist: all a. (a -> String) -> Int -> Dist a -> CpplRes =
   lam f. lam burn. lam dist.
     match distEmpiricalSamples dist with (vs,ws) in
-    let samples = subsequence vs burn (length vs) in
-    let lweights =  subsequence ws burn (length ws) in
+    let nvs = length vs in
+    let samples = subsequence vs (mini nvs burn) nvs in
+    let nws = length ws in
+    let lweights =  subsequence ws (mini nws burn) nws in
     let nc = distEmpiricalNormConst dist in
     { samples = map f samples, lweights = lweights, extra = Some nc }

--- a/coreppl/test/test.mc
+++ b/coreppl/test/test.mc
@@ -196,3 +196,15 @@ let resODEHarmonic: CpplRes -> [Float] = lam cpplRes.
 let odeHarmonicTruth: [Float] = (lam t. [cos t, negf (sin t)]) tend
 let eqODEHarmonic: Float -> [Float] -> [Float] -> Bool =
   lam eps. eqSeq (eqfApprox eps)
+
+-- models/diff-regression.mc
+let resDiffReg: CpplRes -> Float = lam cpplRes.
+  logWeightedMean cpplRes.lweights (map string2float cpplRes.samples)
+let diffRegTruth: Float = 1.
+let eqDiffReg: Float -> Float -> Float -> Bool = eqfApprox
+
+-- models/diff-confusion.mc
+let resDiffConf: CpplRes -> Float = lam cpplRes.
+  logWeightedMean cpplRes.lweights (map string2float cpplRes.samples)
+let diffConfTruth: Float = 2.
+let eqDiffConf: Float -> Float -> Float -> Bool = eqfApprox

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -9,6 +9,9 @@ test-files+=coreppl/src/coreppl-to-mexpr/runtimes.mc
 test-files := $(filter-out coreppl/src/pgm.mc,$(test-files))
 test-files := $(filter-out coreppl/src/transformation.mc,$(test-files))
 
+# NOTE(oerikss, 2024-04-08): Filter out the main file as it it print to standard
+# out and it is compiled anyways when doing the inference tests.
+test-files := $(filter-out coreppl/src/cppl.mc,$(test-files))
 
 test-infer-files=$(shell find coreppl/test/coreppl-to-mexpr/infer -name "*.mc")
 test-cli-files=\
@@ -28,7 +31,6 @@ compiler: ${test-files}
 
 ${test-files}::
 	@./make test $@
-
 
 ###################
 ## CorePPL tests ##

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -16,7 +16,7 @@ test-cli-files=\
                coreppl/test/coreppl-to-rootppl/cli -name "*.mc")
 
 .PHONY: all
-all: cppl compiler
+all: compiler cppl
 
 
 ############################################


### PR DESCRIPTION
This PR mainly adds a new `diff t1 t2` that returns the total derivative of `t1` in the point `t2`. The implementation used nested forward-mode AD with dynamic tagging. See the file `coreppl/models/diff-demo.mc` for a demonstration. `diff t1 t2` can differentiate any function `t1 : T1 -> T2`, as long as `T1` and `T2` are `Float` or arbitrarily nested sequences and/or records with `Float`s in the leaves of the type (`coreppl/models/diff-demo.mc` should clarify this).

In addition, because the AD transform needs to reason about elementary functions this PR also extends the intrinsic of coredppl with `sin`, `cos`, `sqrt`, `exp`, and `log`. One problem is that these are shadowed by the externals in `math-ext.mc` in the Miking standard library, and it is hard to control what is included in a model due to the transitive nature of our includes. One solution could be to rename, e.g., `sin` in `math-ext.mc` to `mathSin`, but then a function defined in the standard library that uses these external math functions would not produce a correct derivative in `coredppl`. Instead, the solution in this PR is to map these particular externals to their corresponding intrinsic.

Minor additions and fixes in this PR includes:
- Makes cppl-test a bit more robust to errors by handling the case when the number of burnins is greater than the number of samples.
- Reduces the accuracy of the ODE solver in the ODE solver tests to speed up testing.
- Adds a make recepie to only run the unit tests for relevant files in the project.
- Move the unit tests before the inference tests when running `make test`.
- Adds some missing includes.
- Deletes some trialing whitespace and breaks lines larger than 80 characters.