### PR TITLE
Remove RootPPL tests from `make test`.

### DIFF
--- a/coreppl/test/test.mc
+++ b/coreppl/test/test.mc
@@ -67,9 +67,8 @@ let testCpplMExpr: String -> Int -> Int -> String -> CpplRes =
   lam model. lam samples. lam burn. lam compileArgs.
     let m = join [dpplPath, "/coreppl/models/", model] in
     let wd = sysTempDirMake () in
-    let run = sysRunCommand [cppl, "--seed 0", compileArgs, m ] "" wd in
-    utest run.returncode with 0 using eqi else lam. lam. run.stderr in
-    let run = sysRunCommand [ "./out", (int2string samples) ] "" wd in
+    let run = sysRunCommandWithUtest [cppl, "--seed 0", compileArgs, m ] "" wd in
+    let run = sysRunCommandWithUtest [ "./out", (int2string samples) ] "" wd in
     sysDeleteDir wd;
     burnCpplRes burn (parseRun run.stdout)
 

--- a/coreppl/test/test.mc
+++ b/coreppl/test/test.mc
@@ -44,6 +44,18 @@ let parseRun: String -> CpplRes = lam output.
   in
   { samples = res.0, lweights = res.1, extra = extra }
 
+let sysRunCommandWithUtest = lam args. lam s. lam wd.
+  let run = sysRunCommand args s wd in
+  utest run.returncode with 0 using eqi else lam. lam. (strJoin "\n" [
+    join ["Command ", strJoin " " args, " failed with code ", int2string run.returncode],
+    "---------->> STDOUT <<----------",
+    run.stdout,
+    "---------->> STDERR <<----------",
+    run.stderr,
+    "--------------------------------"
+  ]) in
+  run
+
 let burnCpplRes: Int -> CpplRes -> CpplRes = lam burn. lam cpplRes.
   let samples = subsequence cpplRes.samples burn (length cpplRes.samples) in
   let lweights =  subsequence cpplRes.lweights burn (length cpplRes.lweights) in
@@ -67,13 +79,13 @@ let testCpplRootPPL: String -> Int -> Int -> String -> String -> CpplRes =
   lam model. lam samples. lam burn. lam cpplCompileArgs. lam rpplCompileArgs.
     let m = join [dpplPath, "/coreppl/models/", model] in
     let wd = sysTempDirMake () in
-    sysRunCommand [
+    sysRunCommandWithUtest [
         cppl, "--seed 0", "-t rootppl", "--skip-final", cpplCompileArgs, m
       ] "" wd;
-    sysRunCommand [
+    sysRunCommandWithUtest [
         rppl, "--seed 0", "--stack-size 10000", rpplCompileArgs, "out.cu"
       ] "" wd;
-    let run = sysRunCommand [ "./a.out", (int2string samples) ] "" wd in
+    let run = sysRunCommandWithUtest [ "./a.out", (int2string samples) ] "" wd in
     sysDeleteDir wd;
     burnCpplRes burn (parseRun run.stdout)
 

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -16,8 +16,11 @@ test-files := $(filter-out coreppl/src/cppl.mc,$(test-files))
 test-infer-files=$(shell find coreppl/test/coreppl-to-mexpr/infer -name "*.mc")
 test-staticdelay-files=$(shell find coreppl/test/coreppl-to-mexpr/static-delay -name "*.mc")
 test-cli-files=\
-  $(shell find coreppl/test/coreppl-to-mexpr/cli \
-               coreppl/test/coreppl-to-rootppl/cli -name "*.mc")
+  $(shell find coreppl/test/coreppl-to-mexpr/cli -name "*.mc")
+# NOTE(johnwikman, 2024-09-13): The RootPPL compilation is currently broken, so
+# leaving it commented out until someone has fixed RootPPL compilation.
+#test-cli-files+=\
+#  $(shell find coreppl/test/coreppl-to-rootppl/cli -name "*.mc")
 
 .PHONY: all
 all: compiler cppl


### PR DESCRIPTION
The RootPPL tests are broken. I get the error bellow when trying to compile RootPPL. There is no simple fix for this issue, and requires both fixing the C backend in the Miking compiler and the compilation to RootPPL.

Until that is fixed, I suggest that we remove RootPPL from `make test` such that we can run the miking-dppl test suite without errors.

```
 ** Unit test FAILED: </mntcopy/coreppl/test/test.mc 49:2-56:3> **
Command /mntcopy/rootppl/rppl --seed 0 --stack-size 10000  out.cu failed with code 1
---------->> STDOUT <<----------
g++ -I/mntcopy/rootppl/src -std=c++14 -O3 -D SEED=0 -D STACK_SIZE_PROGSTATE=10000 -xc++ out.cu -x none build/utils/math.o build/utils/misc.o build/inference/smc/smc_nested.o build/inference/smc/smc_kernels.o build/inference/smc/resample/systematic/systematic_gpu.o build/inference/smc/resample/systematic/kernels.o build/inference/smc/resample/systematic/systematic_cpu.o build/inference/smc/resample/common.o build/inference/smc/smc.o build/inference/smc/file_handler.o build/inference/smc/particles_memory_handler.o build/dists/delayed.o build/dists/dists.o build/dists/scores.o

---------->> STDERR <<----------
In file included from /mntcopy/rootppl/src/inference/smc/smc.cuh:11,
                 from out.cu:4:
out.cu:62:28: error: 'double nan' redeclared as different kind of entity
   62 | BBLOCK_DATA_MANAGED_SINGLE(nan, double)
      |                            ^~~
/mntcopy/rootppl/src/macros/macros.cuh:94:61: note: in definition of macro 'BBLOCK_DATA_MANAGED_SINGLE'
   94 | #define BBLOCK_DATA_MANAGED_SINGLE(name, type) MANAGED type name;
      |                                                             ^~~~
In file included from /usr/include/features.h:489,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-linux-gnu/12/include/stdint.h:9,
                 from out.cu:1:
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:203:1: note: previous declaration 'double nan(const char*)'
  203 | __MATHCALL (nan,, (const char *__tagb));
      | ^~~~~~~~~~
out.cu: In function 'void init(particles_t&, int, void*)':
out.cu:316:37: error: cannot convert 'double (*)(const char*) noexcept' {aka 'double (*)(const char*)'} to 'double'
  316 |   ((global->t) = BBLOCK_CALL(model, nan, data));
      |                                     ^~~
      |                                     |
      |                                     double (*)(const char*) noexcept {aka double (*)(const char*)}
/mntcopy/rootppl/src/macros/macros.cuh:66:1: note: in definition of macro 'BBLOCK_DEF'
   66 | body \
      | ^~~~
/mntcopy/rootppl/src/macros/macros.cuh:40:41: note: in expansion of macro 'BBLOCK_DEF_NO_TYPE'
   40 | #define GET_MACRO(_1, _2, _3, NAME,...) NAME
      |                                         ^~~~
out.cu:313:1: note: in expansion of macro 'BBLOCK'
  313 | BBLOCK(init, {
      | ^~~~~~
out.cu:316:18: note: in expansion of macro 'BBLOCK_CALL'
  316 |   ((global->t) = BBLOCK_CALL(model, nan, data));
      |                  ^~~~~~~~~~~
out.cu:312:19: note:   initializing argument 3 of 'double model(particles_t&, int, double, Seq)'
  312 | }, double, double nan7, Seq data2)
      |            ~~~~~~~^~~~
/mntcopy/rootppl/src/macros/macros.cuh:77:67: note: in definition of macro 'BBLOCK_HELPER'
   77 | DEV returnType funcName(BBLOCK_PARAMS(progStateTypeTopLevel_t), ##__VA_ARGS__) \
      |                                                                   ^~~~~~~~~~~
out.cu: In function 'int main(int, char**)':
out.cu:331:8: error: assignment of function 'double nan(const char*)'
  331 |   (nan = (0. * inf));
      |    ~~~~^~~~~~~~~~~~
/mntcopy/rootppl/src/macros/macros.cuh:132:5: note: in definition of macro 'MAIN'
  132 |     body \
      |     ^~~~

--------------------------------
    Using: eqi

 ** Unit test FAILED: </mntcopy/coreppl/test/test.mc 49:2-56:3> **
Command ./a.out 1000 failed with code 127
---------->> STDOUT <<----------

---------->> STDERR <<----------
sh: 1: ./a.out: not found

--------------------------------
    Using: eqi
Fatal error: exception Failure("float_of_ustring")
ERROR: compiled binary for coreppl/test/coreppl-to-rootppl/cli/ssm.mc exited with 2
make[1]: *** [test-coreppl.mk:59: coreppl/test/coreppl-to-rootppl/cli/ssm.mc] Error 1
make: *** [Makefile:62: test-coreppl] Error 2

```