### PR TITLE
Add expectation intrinsic

### DIFF
--- a/coreppl/src/cfa.mc
+++ b/coreppl/src/cfa.mc
@@ -48,6 +48,7 @@ lang ConstAllCFA = MExprCFA + MExprPPL + DualNumLift
     | CDistEmpiricalNormConst _
     | CDistEmpiricalAcceptRate _ ) ->
     errorSingle [info] "Constant not supported in CorePPL CFA"
+  | CDistExpectation _ -> graph
 
   sem addConstAllConstraints (graph: CFAGraphInit) =
   | t ->

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -17,6 +17,7 @@ lang TransformDist = MExprPPL + DualNumDist
       | CDistEmpiricalDegenerate _
       | CDistEmpiricalNormConst _
       | CDistEmpiricalAcceptRate _
+      | CDistExpectation _
       )
     } ->
     var_ (getConstStringCode 0 c)

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -50,6 +50,8 @@ lang RuntimeDistBase
 
   sem sample : all a. Dist a -> a
 
+  sem expectation : Dist Float -> Float
+
   sem logObserve : all a. Dist a -> (a -> Float)
 end
 
@@ -88,6 +90,24 @@ lang RuntimeDistElementary = RuntimeDistBase
   | DistLomax t -> unsafeCoerce (lomaxSample t.shape t.scale)
   | DistBetabin t -> unsafeCoerce (betabinSample t.n t.a t.b)
   | DistNegativeBinomial t -> unsafeCoerce (negativeBinomialSample t.n t.p)
+
+  -- Expectation of primitive distributions over real values
+  sem expectation =
+  | DistGamma t -> mulf t.shape t.scale
+  | DistExponential t -> divf 1. t.rate
+  | DistPoisson t -> t.lambda
+  | DistBinomial t -> mulf t.p (int2float t.n)
+  | DistBernoulli t -> t.p
+  | DistBeta t -> divf t.a (addf t.a t.b)
+  | DistGaussian t -> t.mu
+  | DistMultinomial t ->
+    error "expectation undefined for the multinomial distribution"
+  | DistCategorical t ->
+    error "expectation undefined for the categorical distribution"
+  | DistDirichlet t ->
+    error "expectation undefined for the Dirichlet distribution"
+  | DistUniform t -> divf (addf t.a t.b) 2.
+  | DistWiener _ -> error "expectation undefined for the Wiener process"
 
   sem logObserve =
   | DistGamma t -> unsafeCoerce (gammaLogPdf t.shape t.scale)
@@ -129,6 +149,9 @@ lang RuntimeDistElementaryDual = RuntimeDistElementary
     unsafeCoerce
       (let f = unsafeCoerce (sample d) in lam x. Primal (f (dualPrimalRec x)))
   | DistDual d -> sample d
+
+  sem expectation =
+  | DistDual d -> expectation d
 
   sem logObserve =
   | DistDual (d &
@@ -253,6 +276,13 @@ lang RuntimeDistEmpirical = RuntimeDistBase
     else
       error "Sampling from empirical distribution failed"
 
+  sem expectation =
+  | DistEmpirical t ->
+    let weights = map exp t.logWeights in
+    -- NOTE(oerikss, 2024-09-13): We assume that samples are floats. The
+    -- type-system should reject expectation of distributions over other types.
+    foldl addf 0. (zipWith mulf weights (unsafeCoerce t.samples))
+
   sem logObserve =
   -- TODO(dlunde,2022-10-18): Implement this?
   | DistEmpirical t -> error "Log observe not supported for empirical distribution"
@@ -302,6 +332,10 @@ let distEmpiricalAcceptRate : all a. use RuntimeDist in Dist a -> Float =
 let sample : all a. use RuntimeDist in Dist a -> a =
   use RuntimeDist in
   sample
+
+let expectation : all a. use RuntimeDist in Dist Float -> Float =
+  use RuntimeDist in
+  expectation
 
 let logObserve : all a. use RuntimeDist in Dist a -> a -> Float =
   use RuntimeDist in

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -180,12 +180,14 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval +
   | CDistEmpiricalDegenerate {}
   | CDistEmpiricalNormConst {}
   | CDistEmpiricalAcceptRate {}
+  | CDistExpectation {}
 
   sem getConstStringCode (indent : Int) =
   | CDistEmpiricalSamples _ -> "distEmpiricalSamples"
   | CDistEmpiricalDegenerate _ -> "distEmpiricalDegenerate"
   | CDistEmpiricalNormConst _ -> "distEmpiricalNormConst"
   | CDistEmpiricalAcceptRate _ -> "distEmpiricalAcceptRate"
+  | CDistExpectation _ -> "expectation"
 
   sem _tydist =
   | a -> TyDist {info = NoInfo (), ty = a}
@@ -197,12 +199,14 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift + PEval +
   | CDistEmpiricalDegenerate _ -> tyall_ "a" (tyarrow_ (_tydist (tyvar_ "a")) tybool_)
   | CDistEmpiricalNormConst _ -> tyall_ "a" (tyarrow_ (_tydist (tyvar_ "a")) tyfloat_)
   | CDistEmpiricalAcceptRate _ -> tyall_ "a" (tyarrow_ (_tydist (tyvar_ "a")) tyfloat_)
+  | CDistExpectation _ -> tyarrow_ (_tydist tyfloat_) tyfloat_
 
   sem constArity =
   | CDistEmpiricalSamples _ -> 1
   | CDistEmpiricalDegenerate _ -> 1
   | CDistEmpiricalNormConst _ -> 1
   | CDistEmpiricalAcceptRate _ -> 1
+  | CDistExpectation _ -> 1
 
 end
 

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -225,6 +225,7 @@ let builtin = use MExprPPL in concat
   , ("distEmpiricalDegenerate", CDistEmpiricalDegenerate ())
   , ("distEmpiricalNormConst", CDistEmpiricalNormConst ())
   , ("distEmpiricalAcceptRate", CDistEmpiricalAcceptRate ())
+  , ("expectation", CDistExpectation ())
     -- External elementary functions
   , ("sin", CSin ())
   , ("cos", CCos ())

--- a/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
+++ b/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
@@ -1,0 +1,70 @@
+include "math.mc"
+
+let model1 = lam.
+  let a = assume (Gamma 2. 3.) in
+  let b = assume (Exponential 2.) in
+  let c = assume (Beta 2. 2.) in
+  let d = assume (Gaussian 1. 2.) in
+  let e = assume (Uniform 2. 3.) in
+  foldl addf 0. [a, b, c, d, e]
+
+let model2 = lam.
+  let a = expectation (Gamma 2. 3.) in
+  let b = expectation (Exponential 2.) in
+  let c = expectation (Beta 2. 2.) in
+  let d = expectation (Gaussian 1. 2.) in
+  let e = expectation (Uniform 2. 3.) in
+  foldl addf 0. [a, b, c, d, e]
+
+mexpr
+
+let expected = foldl addf 0. [6., 0.5, 0.5, 1., 2.5] in
+
+let d = infer (Importance { particles = 1000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (BPF { particles = 1000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (APF { particles = 1000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (PIMH { particles = 1000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (TraceMCMC { iterations = 100000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (NaiveMCMC { iterations = 1000 }) model1 in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d =
+  infer (LightweightMCMC { iterations = 100000, globalProb = 0.1 }) model1
+in
+utest expectation d with expected using eqfApprox 1e-1 in
+
+let d = infer (Importance { particles = 1 }) model2 in
+utest expectation d with expected in
+
+let d = infer (BPF { particles = 1 }) model2 in
+utest expectation d with expected in
+
+let d = infer (APF { particles = 2 }) model2 in
+utest expectation d with expected in
+
+let d = infer (PIMH { particles = 1 }) model2 in
+utest expectation d with expected in
+
+let d = infer (TraceMCMC { iterations = 1 }) model2 in
+utest expectation d with expected in
+
+let d = infer (NaiveMCMC { iterations = 1 }) model2 in
+utest expectation d with expected in
+
+let d =
+  infer (LightweightMCMC { iterations = 1, globalProb = 0.1 }) model2
+in
+utest expectation d with expected in
+
+
+()

--- a/coreppl/test/coreppl-to-mexpr/expectation/primitive.mc
+++ b/coreppl/test/coreppl-to-mexpr/expectation/primitive.mc
@@ -1,0 +1,19 @@
+mexpr
+
+-- NOTE(oerikss, 2024-09-14): We add this infer to prevent the backwards
+-- compatible part of coreppl to wrap this program in a top-level infer.
+infer (Default ()) (lam. ());
+
+utest expectation (Gamma 2. 3.) with 6. in
+utest expectation (Exponential 2.) with 0.5 in
+utest expectation (Beta 2. 2.) with 0.5 in
+utest expectation (Gaussian 1. 2.) with 1. in
+utest expectation (Uniform 2. 3.) with 2.5 in
+
+-- NOTE(oerikss, 2024-09-14): These expectations are supported in the runtime
+-- but the type restriction `expectation : Dist Float -> Float` forbids them.
+-- utest expectation (Poisson 2.) with 2. in
+-- utest expectation (Binomial 0.5 2) with 1. in
+-- utest expectation (Bernoulli 0.5) with 0.5 in
+
+()

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -21,6 +21,7 @@ test-cli-files=\
 # leaving it commented out until someone has fixed RootPPL compilation.
 #test-cli-files+=\
 #  $(shell find coreppl/test/coreppl-to-rootppl/cli -name "*.mc")
+test-expectation-files=$(shell find coreppl/test/coreppl-to-mexpr/expectation -name "*.mc")
 
 .PHONY: all
 all: compiler cppl
@@ -41,10 +42,16 @@ ${test-files}::
 ###################
 
 .PHONY: cppl
-cppl: ${test-staticdelay-files} ${test-infer-files} ${test-cli-files} 
+cppl: ${test-staticdelay-files} ${test-infer-files} ${test-cli-files} ${test-expectation-files}
+
+.PHONY: infer
+infer: ${test-infer-files}
 
 .PHONY: static-delay
 static-delay: ${test-staticdelay-files}
+
+.PHONY: expectation
+expectation: ${test-expectation-files}
 
 export CPPL_NAME
 export MIDPPL_PATH=${CURDIR}
@@ -64,3 +71,7 @@ ${test-cli-files}::
 # Static delay tests
 ${test-staticdelay-files}::
 	@./make test $@
+
+# Expectation tests
+${test-expectation-files}::
+	@./make test-cppl $@ "build/${CPPL_NAME}"


### PR DESCRIPTION
This PR adds an expectation intrinsic to cdppl with the following signature:
```
expectation : Dist Float -> Float
```
For primitive distributions with type `Dist Float`, `expectation` returns the analytic expectation. For inferred distributions, `expectation` approximates the expected value by a weighted sum over the underlying empirical distribution.

Its allowed to use `expectation` both inside and outside models. E.g., a program with the following tests should pass

```
utest expectation (Gaussian 1. 2.) with 1.

let d1 = infer (Default {}) (lam. assume (Gaussian 1. 2.))
utest expectation d1 with 1. using eqfApprox

let d2 = infer (Default {}) (lam. addf (assume (Gaussian 2. 2.)) (expectation d1))
utest expectation d2 with 3. using eqfApprox
```

`expectation` is restricted to distributions over floating-point numbers because it is currently not possible to implement it for distributions of arbitrary type. Given something like type classes, we could extend it to types `a` where it makes sense to define an addition operation `a -> a -> a`, scalar multiplication `Float -> a -> a`, and an addition identity element `a` (E.g., if we can interpret the type `a` as a vector).   