### PR TITLE
Adds symbolization of included runtime files

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -78,7 +78,7 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
     else
       -- load ODE solver runtime
       let runtime =
-        symbolizeAllowFree (loadRuntime true "runtime-ode-wrapper.mc")
+        symbolizeAllowFree (loadRuntimeFile true "runtime-ode-wrapper.mc")
       in
 
       -- collect the names of used ODE solvers runtime names and make sure they
@@ -188,7 +188,7 @@ lang ADTransform =
     let runtimeFile = "runtime-ad-wrapper.mc" in
 
     -- load AD runtime
-    let runtime = symbolize (loadRuntime true runtimeFile) in
+    let runtime = symbolize (loadRuntimeFile true runtimeFile) in
 
     -- Define function that maps string identifiers to names
     let s2n = makeRuntimeNameMap runtime (_adTransformRuntimeIds ()) in
@@ -295,7 +295,7 @@ lang ElementaryFunctionsTransform = ElementaryFunctions + LoadRuntime
     let runtimeFile = "runtime-elementary-wrapper.mc" in
 
     -- load elementary functions runtime
-    let runtime = symbolize (loadRuntime true runtimeFile) in
+    let runtime = symbolize (loadRuntimeFile true runtimeFile) in
 
     -- Define function that maps string identifiers to names
     let stringToName =
@@ -556,7 +556,7 @@ lang MExprCompile =
   sem replaceHigherOrderConstants =
   | t ->
     let t = mapPre_Expr_Expr _replaceHigherOrderConstantExpr t in
-    let replacements = loadRuntime false "runtime-const.mc" in
+    let replacements = loadRuntimeFile false "runtime-const.mc" in
     let replacements = normalizeTerm replacements in
     let t = bind_ replacements t in
     let t = symbolizeExpr

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -117,8 +117,8 @@ lang LoadRuntime =
     let runtime = symbolizeAllowFree (loadRuntime false runtime) in
     match findRequiredRuntimeIds method runtime with (runId, stateId) in
     let stateType = findStateType method stateId runtime in
-    let pruningRuntime = loadRuntime false "pruning/runtime.mc" in
-    let delayedRuntime = loadRuntime false "delayed-sampling/runtime.mc" in
+    let pruningRuntime = symbolizeAllowFree (loadRuntime false "pruning/runtime.mc") in
+    let delayedRuntime = symbolizeAllowFree (loadRuntime false "delayed-sampling/runtime.mc") in
     let runtime = bindall_ [pruningRuntime, delayedRuntime, runtime] in
     match eliminateDuplicateCodeWithSummary runtime with (replacements, runtime) in
     { ast = runtime, runId = runId, stateType = stateType
@@ -232,6 +232,7 @@ lang LoadRuntime =
     -- Eliminate duplicate code in the combined AST of all runtimes, and update
     -- the symbolization environments of the individual runtimes accordingly.
     match eliminateDuplicateCodeWithSummary ast with (replacements, ast) in
+
     {entries = _updateRuntimeEntriesSymEnv replacements entries, ast = ast}
 
   sem _updateRuntimeEntriesSymEnv

--- a/coreppl/src/coreppl-to-mexpr/runtimes.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtimes.mc
@@ -75,8 +75,8 @@ lang LoadRuntime =
       mapInsert t.method (loadRuntimeEntry t.method runtime) acc
   | t -> sfold_Expr_Expr (loadRuntimesH options) acc t
 
-  sem loadRuntime : Bool -> String -> Expr
-  sem loadRuntime eliminateDeadCode =
+  sem loadRuntimeFile : Bool -> String -> Expr
+  sem loadRuntimeFile eliminateDeadCode =
   | runtime ->
     let parse = use BootParser in parseMCoreFile {
       defaultBootParserParseMCoreFileArg with
@@ -114,11 +114,11 @@ lang LoadRuntime =
   sem loadRuntimeEntry : InferMethod -> String -> InferRuntimeEntry
   sem loadRuntimeEntry method =
   | runtime ->
-    let runtime = symbolizeAllowFree (loadRuntime false runtime) in
+    let runtime = symbolizeAllowFree (loadRuntimeFile false runtime) in
     match findRequiredRuntimeIds method runtime with (runId, stateId) in
     let stateType = findStateType method stateId runtime in
-    let pruningRuntime = symbolizeAllowFree (loadRuntime false "pruning/runtime.mc") in
-    let delayedRuntime = symbolizeAllowFree (loadRuntime false "delayed-sampling/runtime.mc") in
+    let pruningRuntime = symbolizeAllowFree (loadRuntimeFile false "pruning/runtime.mc") in
+    let delayedRuntime = symbolizeAllowFree (loadRuntimeFile false "delayed-sampling/runtime.mc") in
     let runtime = bindall_ [pruningRuntime, delayedRuntime, runtime] in
     match eliminateDuplicateCodeWithSummary runtime with (replacements, runtime) in
     { ast = runtime, runId = runId, stateType = stateType


### PR DESCRIPTION
This PR fixes a bug that showed up when compiling models in ProbTime after the most recent updates. The issue in my case was that the delayed sampling runtime was not symbolized, which caused a misinterpretation of the `addn` function in [dualnum-lift.mc](https://github.com/miking-lang/miking-dppl/blob/e99ed26d0212cbd9a1dc298cd1a8c618fc6e441c/coreppl/src/coreppl-to-mexpr/ad/dualnum-lift.mc#L156-L166) (the pattern variables have the same name as the arguments), finally leading to a (very odd) type error in ProbTime.

The PR also includes renaming the `loadRuntime` function to `loadRuntimeFile` to avoid a conflict with a Miking function with the same name.