### PR TITLE
Remove excessive code duplication in dist.mc and add type information for inference methods 

### DIFF
--- a/coreppl/src/ad.mc
+++ b/coreppl/src/ad.mc
@@ -347,9 +347,9 @@ lang DualNumDist = Dist
   syn Dist =
   | DDual Dist
 
-  sem distSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_Dist_Expr f acc =
   | DDual d ->
-    match distSmapAccumL_Expr_Expr f acc d with (acc, d) in
+    match smapAccumL_Dist_Expr f acc d with (acc, d) in
     (acc, DDual d)
 
   sem distTy info =

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -722,16 +722,13 @@ lang Prune =
       else never
     else never
 
-  sem pevalIsValue =
-  | TmPrune _ -> false
+  sem pevalBindThis =
+  | TmPrune _ -> true
 
   sem pevalEval ctx k =
   | TmPrune r ->
     pevalBind ctx
       (lam dist. k (TmPrune { r with dist = dist})) r.dist
-  | TmPrune ( {dist = TmDist ({dist = dist} & td)} & t) ->
-    pevalDistEval ctx
-      (lam dist. k (TmPrune { t with dist= TmDist { td with dist = dist} } )) dist
 
 end
 
@@ -916,8 +913,8 @@ lang Cancel = Observe
     else never
 
   -- Partial evaluation
-  sem pevalIsValue =
-  | TmCancel _ -> false
+   sem pevalBindThis =
+  | TmCancel _ -> true
 
   sem pevalEval ctx k =
   | TmCancel r ->
@@ -1180,8 +1177,8 @@ lang Delay =
       else never
     else never
 
-  sem pevalIsValue =
-  | TmDelay _ -> false
+  sem pevalBindThis =
+  | TmDelay _ -> true
 
   sem pevalEval ctx k =
   | TmDelay r ->
@@ -1273,8 +1270,8 @@ lang Delayed = Delay
       else never
     else never
 
-  sem pevalIsValue =
-  | TmDelayed _ -> false
+  sem pevalBindThis =
+  | TmDelayed _ -> true
 
   sem pevalEval ctx k =
   | TmDelayed r ->
@@ -1433,15 +1430,13 @@ let _toStr = utestDefaultToString (lam x. x) (lam x. x) in
 utest mexprPPLToString tmAssume
 with strJoin "\n" [
   "assume",
-  "  (Bernoulli",
-  "     0.7)"
+  "  (Bernoulli 0.7)"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmObserve
 with strJoin "\n" [
   "observe",
-  "  1.5 (Beta",
-  "     1. 2.)"
+  "  1.5 (Beta 1. 2.)"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmWeight
@@ -1464,39 +1459,34 @@ with strJoin "\n" [
 utest mexprPPLToString tmPrune
 with strJoin "\n" [
   "prune",
-  "  (Categorical",
-  "     [ 0.5, 0.3, 0.2 ])"
+  "  (Categorical [ 0.5, 0.3, 0.2 ])"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmPruned
 with strJoin "\n" [
   "pruned",
   "  (prune",
-  "     (Categorical",
-  "        [ 0.5, 0.3, 0.2 ]))"
+  "     (Categorical [ 0.5, 0.3, 0.2 ]))"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmCancel
 with strJoin "\n" [
   "cancel",
   "  (observe",
-  "    true (Bernoulli",
-  "       0.7))"
+  "    true (Bernoulli 0.7))"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmDelay
 with strJoin "\n" [
   "delay",
-  "  (Categorical",
-  "     [ 0.5, 0.3, 0.2 ])"
+  "  (Categorical [ 0.5, 0.3, 0.2 ])"
 ] using eqString else _toStr in
 
 utest mexprPPLToString tmDelayed
 with strJoin "\n" [
   "delayed",
   "  (delay",
-  "     (Categorical",
-  "        [ 0.5, 0.3, 0.2 ]))"
+  "     (Categorical [ 0.5, 0.3, 0.2 ]))"
 ] using eqString else _toStr in
 
 --------------------

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -103,6 +103,14 @@ lang ElementaryFunctions =
 
   sem generateConstraintsConst graph info ident =
   | CSin _ | CCos _ | CSqrt _ | CExp _ | CLog _ | CPow _ -> graph
+
+  -- Builders
+  sem sin_ =| x -> app_ (uconst_ (CSin ())) x
+  sem cos_ =| x -> app_ (uconst_ (CCos ())) x
+  sem sqrt_ =| x -> app_ (uconst_ (CSqrt ())) x
+  sem exp_ =| x -> app_ (uconst_ (CExp ())) x
+  sem log_ =| x -> app_ (uconst_ (CLog ())) x
+  sem pow_ =| x -> app_ (uconst_ (CPow ())) x
 end
 
 

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -63,6 +63,11 @@ lang InferMethodBase =
   sem inferMethodConfig info =
   | Default { runs = runs } -> fieldsToRecord info [("runs", runs)]
 
+  -- Produces the expected type of `inferMethodConfig`
+  sem inferMethodConfigType : Info -> InferMethod -> Type
+  sem inferMethodConfigType info =
+  | Default _ -> tyRecord info [("runs", ityint_ info)]
+
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -27,6 +27,10 @@ lang ImportanceSamplingMethod = MExprPPL
   | Importance {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
+  sem inferMethodConfigType info =
+  | Importance _ ->
+    tyRecord info [("particles", ityint_ info)]
+
   sem typeCheckInferMethod env info =
   | Importance {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -44,6 +44,13 @@ lang LightweightMCMCMethod = MExprPPL
       ("globalProb", t.globalProb)
     ]
 
+  sem inferMethodConfigType info =
+  | LightweightMCMC _ ->
+    tyRecord info [
+      ("iterations", ityint_ info),
+      ("globalProb", ityfloat_ info)
+    ]
+
   sem typeCheckInferMethod env info =
   | LightweightMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -35,6 +35,12 @@ lang NaiveMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
+  sem inferMethodConfigType info =
+  | NaiveMCMC _ ->
+    tyRecord info [
+      ("iterations", ityint_ info)
+    ]
+
   sem typeCheckInferMethod env info =
   | NaiveMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -35,6 +35,12 @@ lang TraceMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
+  sem inferMethodConfigType info =
+  | TraceMCMC _ ->
+    tyRecord info [
+      ("iterations", ityint_ info)
+    ]
+
   sem typeCheckInferMethod env info =
   | TraceMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -38,6 +38,13 @@ lang PIMHMethod = MExprPPL
   | PIMH {iterations = iterations, particles = particles} ->
     fieldsToRecord info [("iterations",iterations), ("particles", particles)]
 
+  sem inferMethodConfigType info =
+  | PIMH _ ->
+    tyRecord info [
+      ("iterations",tyint_ info),
+      ("particles", ityint_ info)
+    ]
+
   sem typeCheckInferMethod env info =
   | PIMH {iterations = iterations, particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -27,6 +27,10 @@ lang APFMethod = MExprPPL
   | APF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
+  sem inferMethodConfigType info =
+  | APF _ ->
+    tyRecord info [("particles", ityint_ info)]
+
   sem typeCheckInferMethod env info =
   | APF {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -27,6 +27,10 @@ lang BPFMethod = MExprPPL
   | BPF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
+  sem inferMethodConfigType info =
+  | BPF _ ->
+    tyRecord info [("particles", ityint_ info)]
+
   sem typeCheckInferMethod env info =
   | BPF {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -173,7 +173,7 @@ lang DPPLParser =
   | "Binomial" -> Some (2, lam lst. TmDist {dist = DBinomial {n = get lst 0, p = get lst 1},
                                         ty = TyUnknown {info = info},
                                         info = info})
-  | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {},
+  | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {a = get lst 0},
                                        ty = TyUnknown {info = info},
                                        info = info})
   | "solveode" -> Some (4, lam lst. TmSolveODE {method = interpretODESolverMethod (get lst 0),


### PR DESCRIPTION
This PR refactors `dist.mc` to reduce boilerplate and simplify extending distributions. Previously, each distinct distribution was essentially treated as a unique term in the compiler. That meant that each distinct distribution had to implement `eq`, `anf`, `typeCheck`, etc. This is unnecessary because all have the same form, a symbol, a number of parameters, and the type of the parameters and support.  This PR changes `dist.mc` so that distributions are handled similarly to constants in the `mcore` compiler. For example, the uniform distribution is now added as

```
lang UniformDist = Dist
  syn Dist =
  | DUniform { a : Expr, b : Expr }

  sem distSmapAccumL_Expr_Expr f acc =
  | DUniform t ->
    match f acc t.a with (acc, a) in
    match f acc t.b with (acc, b) in
    (acc, DUniform { t with a = a, b = b })

  sem distTy info =
  | DUniform _ ->
    let f = ityfloat_ info in ([], [f, f], f)

  sem distName =
  | DUniform _ -> "Uniform"
end
``` 

Previously, it was instead added as

```
lang UniformDist = Dist + PrettyPrint + Eq + Sym + FloatTypeAst

  syn Dist =
  | DUniform { a: Expr, b: Expr }

  sem smapAccumLDist_Expr_Expr f acc =
  | DUniform t ->
    match f acc t.a with (acc,a) in
    match f acc t.b with (acc,b) in
    (acc, DUniform {{t with a = a} with b = b})

  -- Pretty printing
  sem pprintDist (indent: Int) (env: PprintEnv) =
  | DUniform t ->
    let i = pprintIncr indent in
    match printArgs i env [t.a, t.b] with (env,args) then
      (env, join ["Uniform", pprintNewline i, args])
    else never

  -- Equality
  sem eqExprHDist (env : EqEnv) (free : EqEnv) (lhs : Dist) =
  | DUniform r ->
    match lhs with DUniform l then
      match eqExprH env free l.a r.a with Some free then
        eqExprH env free l.b r.b
      else None ()
    else None ()

  -- Symbolize
  sem symbolizeDist (env: SymEnv) =
  | DUniform t -> DUniform {{ t with a = symbolizeExpr env t.a }
                                with b = symbolizeExpr env t.b }

  -- Type Check
  sem typeCheckDist (env: TCEnv) (info: Info) =
  | DUniform t ->
    let float = TyFloat { info = info } in
    unify env [info, infoTm t.a] float (tyTm t.a);
    unify env [info, infoTm t.b] float (tyTm t.b);
    float

  -- ANF
  sem normalizeDist (k : Dist -> Expr) =
  | DUniform ({ a = a, b = b } & t) ->
    normalizeName (lam a.
      normalizeName (lam b.
        k (DUniform {{ t with a = a } with b = b})) b) a

  -- Type lift
  sem typeLiftDist (env : TypeLiftEnv) =
  | DUniform ({ a = a, b = b } & t) ->
    match typeLiftExpr env a with (env, a) then
      match typeLiftExpr env b with (env, b) then
        (env, DUniform {{ t with a = a }
                            with b = b })
      else never
    else never

  -- Partial evaluation
  sem pevalDistEval ctx k =
  | DUniform t ->
    pevalBind ctx
      (lam a.
        pevalBind ctx
          (lam b. k (DUniform {t with a=a, b=b}))
          t.b)
      t.a

end
```

The base fragment documents the semantic function each distribution needs to extend. In addition, it fixes a bug where, previously, the type checker did not annotate distribution parameter expressions with their types.  

This PR also adds type information of inference methods and a few AST builder functions of elementary functions.