### PR TITLE
Make solveode polymorfic in its state

### DIFF
--- a/coreppl/models/ode/harmonic.mc
+++ b/coreppl/models/ode/harmonic.mc
@@ -1,13 +1,29 @@
 include "common.mc"
+include "seq.mc"
 
-let model: () -> [Float] = lam.
+type Method
+con RungeKutta : () -> Method
+con EulerForward : () -> Method
+con Default : () -> Method
+
+let model: Method -> () -> [Float] = lam m. lam.
   let f = lam t. lam xs.
     let x = get xs 0 in
     let v = get xs 1 in
     [v, (negf x)]
   in
   let x0 = [1., 0.] in
-  solveode (RK4 { stepSize = 1e-3 }) f x0 3.
-
-mexpr
-model ()
+  switch m
+  case RungeKutta _ then
+    solveode
+      (RK4 { stepSize = 1e-3, add = zipWith addf, smul = lam s. map (mulf s) })
+      f x0 3.
+  case EulerForward _ then
+    solveode
+      (EF { stepSize = 1e-3, add = zipWith addf, smul = lam s. map (mulf s) })
+      f x0 3.
+  case _ then
+    solveode
+      (Default { stepSize = 1e-3, add = zipWith addf, smul = lam s. map (mulf s) })
+      f x0 3.
+  end

--- a/coreppl/models/ode/ode-common.mc
+++ b/coreppl/models/ode/ode-common.mc
@@ -39,7 +39,13 @@ let odeTrace : (Float -> [Float] -> [Float]) -> [Float] -> [Float] -> [[Float]] 
     reverse
       (foldl
          (lam trace. lam dt.
-           cons (solveode (RK4 { stepSize = 1e-3 }) f (head trace) dt) trace)
+           cons
+             (solveode (RK4 {
+               stepSize = 1e-3,
+               add = map2 addf,
+               smul = lam s. map (mulf s)
+             }) f (head trace) dt)
+             trace)
          [xs0] dts)
 
 -- `printSeq p xs` prints the sequence `xs` to standard out, printing each

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -96,7 +96,7 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
   | RK4 _ -> "odeSolverRK4Solve"
   | EF _ -> "odeSolverEFSolve"
   | method -> error (join [
-    odeSolverMethodToString method,
+    nameGetStr (odeSolverMethodName method),
     " does not have an implementation in the ODE solver runtime"
   ])
 
@@ -113,7 +113,7 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
         in
         optionMapOrElse
           (lam.
-            let name = nameSym (odeSolverMethodToString r.method) in
+            let name = odeSolverMethodName r.method in
             let acc = mapInsert r.method name acc in
             (acc, f name))
           (lam name. (acc, f name))

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -69,25 +69,42 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
     -- translate all Default { ... } ODE solve methods
     let tm = replaceDefaultODESolverMethod options tm in
 
-    -- extract ODE solve methods
-    match odeExtractSolve tm with (methods, tm) in
+    -- Extracts solver methods present in term
+    recursive let extractMethods = lam acc. lam tm.
+      match tm with TmSolveODE r then setInsert r.method acc
+      else sfold_Expr_Expr extractMethods acc tm
+    in
 
-    if mapIsEmpty methods then
+    let methods = setToSeq (extractMethods (setEmpty cmpODESolverMethod) tm) in
+
+    if null methods then
       -- There are no solveode terms in the term.
       (None (), tm)
     else
       -- load ODE solver runtime
-      let runtime =
-        symbolizeAllowFree (loadRuntimeFile true "runtime-ode-wrapper.mc")
+      let runtime = symbolize (loadRuntimeFile true "runtime-ode-wrapper.mc") in
+
+      -- collect the names of used ODE solvers runtime names
+      let names =
+        findNamesOfStringsExn (map odeODESolverMethodToRuntimeName methods)
+          runtime
+      in
+      let namesMap = mapFromSeq cmpODESolverMethod (zip methods names) in
+
+      -- replace solveode terms with applications of its runtime implementation.
+      recursive let applyRuntimeSolvers = lam tm.
+        match tm with TmSolveODE r then
+          let tm =
+            let solver = nvar_ (mapFindExn r.method namesMap) in
+            foldl (lam f. lam a.  withInfo r.info (app_ f a)) solver
+              (concat
+                 (odeODESolverMethodToSolverArgs r.method)
+                 [r.model, r.init, r.endTime])
+          in smap_Expr_Expr applyRuntimeSolvers tm
+        else smap_Expr_Expr applyRuntimeSolvers tm
       in
 
-      -- collect the names of used ODE solvers runtime names and make sure they
-      -- refer to their implementation.
-      match unzip (mapBindings methods) with (to, from) in
-      let to = map odeODESolverMethodToRuntimeName to in
-      let to = findNamesOfStringsExn to runtime in
-      let tm = substituteIdentifiers (mapFromSeq nameCmp (zip from to)) tm in
-      (Some runtime, tm)
+      (Some runtime, applyRuntimeSolvers tm)
 
   -- Maps ODE solver methods to the name bound to their implementation in
   -- the runtime.
@@ -100,27 +117,10 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
     " does not have an implementation in the ODE solver runtime"
   ])
 
-  -- Extracts solveode terms to a map from ODE solver methods to names. Each
-  -- solveode term is replaced by an application of an identifier the named
-  -- according to the returned map.
-  sem odeExtractSolve : Expr -> (Map ODESolverMethod Name, Expr)
-  sem odeExtractSolve =| tm ->
-    recursive let inner = lam acc. lam tm.
-      match tm with TmSolveODE r then
-        let f : Name -> Expr = lam name.
-          appf4_ (nvar_ name)
-            (odeSolverMethodConfig r.info r.method) r.model r.init r.endTime
-        in
-        optionMapOrElse
-          (lam.
-            let name = odeSolverMethodName r.method in
-            let acc = mapInsert r.method name acc in
-            (acc, f name))
-          (lam name. (acc, f name))
-          (mapLookup r.method acc)
-      else smapAccumL_Expr_Expr inner acc tm
-    in
-    inner (mapEmpty cmpODESolverMethod) tm
+  -- Maps ODE solver method to its method arguments.
+  sem odeODESolverMethodToSolverArgs : ODESolverMethod -> [Expr]
+  sem odeODESolverMethodToSolverArgs =
+  | ODESolverDefault r | RK4 r | EF r -> [r.add, r.smul, r.stepSize]
 end
 
 lang DPPLTransformCancel = DPPLParser

--- a/coreppl/src/coreppl-to-mexpr/ode-solver.mc
+++ b/coreppl/src/coreppl-to-mexpr/ode-solver.mc
@@ -1,11 +1,5 @@
+include "tuple.mc"
 include "math.mc"
-
-type ODEFnArg = {
-  t : Float,                    -- free variable t
-  xs : [Float],                 -- states x(t) ∈ ℝ^nx
-  us : [Float],                 -- inputs u(t) ∈ ℝ^nu
-  ps : [Float]                  -- parameters p ∈ ℝ^np
-}
 
 let _checkFinalTimeAndStepSize = lam tf. lam stepSize.
   if ltf tf 0. then
@@ -14,9 +8,6 @@ let _checkFinalTimeAndStepSize = lam tf. lam stepSize.
     if ltf stepSize 0. then
       error "odeSolver: negative step size"
     else ()
-
-let _map2 = lam f. lam seq1. lam seq2.
-  create (length seq1) (lam i. f (get seq1 i) (get seq2 i))
 
 recursive let _solveFixedH = lam step. lam stepSize. lam arg.
   if gtf (absf arg.t) 0. then
@@ -30,24 +21,17 @@ let _solveFixed = lam step. lam stepSize. lam arg.
   if eqf arg.t 0. then arg.xs else _solveFixedH step stepSize arg
 
 
--- ┌─────────┐
--- │ Solvers │
--- └─────────┘
-
-type ODESolve = (Float -> [Float] -> [Float]) -> [Float] -> Float -> [Float]
-
-
 -- ┌───────────────┐
 -- │ Euler-Forward │
 -- └───────────────┘
 
-let odeSolverEFSolve : { stepSize : Float } -> ODESolve =
+let odeSolverEFSolve =
   lam opt. lam f. lam x0. lam tf.
     _checkFinalTimeAndStepSize tf opt.stepSize;
     let integrate =
-      lam h. lam arg. _map2 addf arg.xs (map (mulf opt.stepSize) (f arg.t arg.xs))
+      lam h. lam arg. opt.add arg.xs (opt.smul opt.stepSize (f arg.t arg.xs))
     in
-    _solveFixed integrate opt.stepSize { t = tf, xs = x0, us = [], ps = [] }
+    _solveFixed integrate opt.stepSize { t = tf, xs = x0 }
 
 
 -- ┌──────────────────────────┐
@@ -59,74 +43,67 @@ let odeSolverEFSolve : { stepSize : Float } -> ODESolve =
 -- `f`    : function that computes x'(t) ∈ ℝ^nx
 -- `h`    : step-size of the integration
 -- `arg`  : Argument to `f`.
-let odeSolverRK4Integrate : (ODEFnArg -> [Float]) -> Float -> ODEFnArg -> [Float] =
-  lam f. lam h. lam arg.
+let odeSolverRK4Integrate =
+  lam opt. lam f. lam h. lam arg.
     match arg with { t = t, xs = xs } in
     let h2 = divf h 2. in
     let t2 = addf t h2 in
     let th = addf t h in
     let k1s = f arg in
-    let tmps = _map2 (lam x. lam k. addf x (mulf h2 k)) xs k1s in
+    let tmps = opt.add xs (opt.smul h2 k1s) in
     let k2s = f { arg with t = t2, xs = tmps } in
-    let tmps = _map2 (lam x. lam k. addf x (mulf h2 k)) xs k2s in
+    let tmps = opt.add xs (opt.smul h2 k2s) in
     let k3s = f { arg with t = t2, xs = tmps } in
-    let tmps = _map2 (lam x. lam k. addf x (mulf h k)) xs k3s in
+    let tmps = opt.add xs (opt.smul h k3s) in
     let k4s = f { arg with t = th, xs = tmps } in
-    mapi
-      (lam i. lam x.
-        let k1 = get k1s i in
-        let k2 = mulf 2. (get k2s i) in
-        let k3 = mulf 2. (get k3s i) in
-        let k4 = get k4s i in
-        addf x (mulf h (divf (addf k1 (addf k2 (addf k3 k4))) 6.)))
-      xs
+      opt.add
+        xs
+        (opt.smul
+           (divf h 6.)
+           (opt.add
+              k1s
+              (opt.add
+                 (opt.smul 2. k2s)
+                 (opt.add
+                    (opt.smul 2. k3s)
+                    k4s))))
 
-let odeSolverRK4Solve : { stepSize : Float } -> ODESolve =
+
+let odeSolverRK4Solve =
   lam opt. lam f. lam x0. lam tf.
     _checkFinalTimeAndStepSize tf opt.stepSize;
     _solveFixed
-      (odeSolverRK4Integrate (lam arg. f arg.t arg.xs))
+      (odeSolverRK4Integrate opt (lam arg. f arg.t arg.xs))
       opt.stepSize
-      { t = tf, xs = x0, us = [], ps = [] }
+      { t = tf, xs = x0 }
 
 mexpr
 
-recursive let eqSeq = lam eq. lam seq1. lam seq2.
-  switch (seq1, seq2)
-    case ([],[]) then true
-    case ([a] ++ seq1,[b] ++ seq2) then
-      if eq a b then eqSeq eq seq1 seq2
-      else false
-    case _ then false
-  end
-in
+let eq2 = lam eq. tupleEq2 eq eq in
 
 -- Harmonic oscillator
-let f = lam t. lam xs.
-  let x = get xs 0 in
-  let v = get xs 1 in
-  [
-    v,
-    (negf x)
-  ]
-in
+let f = lam t. lam xs. (xs.1, (negf xs.0)) in
 
-let x0 = [1., 0.] in
+let x0 = (1., 0.) in
 
 -- Analytical solution
-let xs = lam t. [cos t, negf (sin t)] in
+let xs = lam t. (cos t, negf (sin t)) in
 
-let eq = eqSeq (eqfApprox 1e-7) in
+let eq = eq2 (eqfApprox 1e-7) in
 utest xs 0. with x0 using eq in
+
+let opt = {
+  stepSize = 1e-4,
+  add = lam a. lam b. (addf a.0 b.0, addf a.1 b.1),
+  smul = lam s. lam a. (mulf s a.0, mulf s a.1)
+} in
 
 -- ┌───────────────────────────┐
 -- │ Test Euler Forward Solver │
 -- └───────────────────────────┘
 
-let eq = eqSeq (eqfApprox 1e-3) in
+let eq = eq2 (eqfApprox 1e-3) in
 utest xs 0. with x0 using eq in
-
-let opt = { stepSize = 1e-4 } in
 
 let xsHat = odeSolverEFSolve opt f x0 in
 utest xsHat 1. with xs 1. using eq in
@@ -138,10 +115,8 @@ utest xsHat 3. with xs 3. using eq in
 -- │ Test Runge-Kutta Fourth Order Solver │
 -- └──────────────────────────────────────┘
 
-let eq = eqSeq (eqfApprox 1e-7) in
+let eq = eq2 (eqfApprox 1e-7) in
 utest xs 0. with x0 using eq in
-
-let opt = { stepSize = 1e-4 } in
 
 let xsHat = odeSolverRK4Solve opt f x0 in
 utest xsHat 1. with xs 1. using eq in

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -66,12 +66,6 @@ type Options = {
   -- (temporary option, the end-goal is that we should only ever use peval)
   extractSimplification: String,
 
-  -- ODE solver algorithm
-  odeSolverMethod: String,
-
-  -- Size of fixed step-size ODE solvers
-  stepSize: Float,
-
   -- Whether to subsample the posterior distribution
   -- used in conjuction with smc-apf and smc-bpf and without no-print-samples
   subsample: Bool,
@@ -107,8 +101,6 @@ let default = {
   pmcmcParticles = 2,
   seed = None (),
   extractSimplification = "none",
-  odeSolverMethod = "rk4",
-  stepSize = 1e-3,
   subsample = false,
   subsampleSize = 1
 }
@@ -236,20 +228,6 @@ let config = [
     join ["Temporary flag that decides the simplification approach after extraction in the MExpr compiler backend. The supported options are: none, inline, and peval. Default: ", default.extractSimplification, ". Eventually, we will remove this option and only use peval."],
     lam p: ArgPart Options.
       let o: Options = p.options in {o with extractSimplification = argToString p}),
-  ([("--ode-solve-method", " ", "<method>")],
-    join [
-      "The selected ODE solving method. The supported methods are: rk4. Default: ",
-      default.odeSolverMethod
-    ],
-    lam p: ArgPart Options.
-      let o: Options = p.options in {o with odeSolverMethod = argToString p}),
-  ([("--ode-step-size", " ", "<value>")],
-   join [
-     "The step-size for fixed step-size ODE solvers. Default: ",
-     float2string default.stepSize, "."
-   ],
-   lam p : ArgPart Options. let o : Options = p.options in {o with stepSize = argToFloatMin p 0. }),
-
   ([("--subsample", "", "")],
     "Whether to subsample the posterior distribution. Use in conjuction with -m smc-apf or smc-bpf and without --no-print-samples",
     lam p: ArgPart Options.

--- a/coreppl/src/ode-solver-method.mc
+++ b/coreppl/src/ode-solver-method.mc
@@ -5,9 +5,15 @@ include "mexpr/pprint.mc"
 include "mexpr/type-check.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eq.mc"
+include "mexpr/ast-builder.mc"
 
 include "method-helper.mc"
 include "dppl-arg.mc"
+
+-- ODE solver method names
+let odeDefault = nameSym "Default"
+let odeRK4 = nameSym "RK4"
+let odeEF = nameSym "EF"
 
 -- Defines the basic components required in the implementation of an ODE solver
 -- method.
@@ -15,10 +21,33 @@ include "dppl-arg.mc"
 -- To define a new ODE solver method constructor, the following semantic
 -- functions must be implemented for the constructor.
 lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
+
+  type MethodArg = { stepSize : Expr, add : Expr, smul : Expr }
+
   syn ODESolverMethod =
-  | ODESolverDefault { stepSize: Expr }
-  | RK4 { stepSize: Expr }
-  | EF { stepSize: Expr }
+  | ODESolverDefault MethodArg
+  | RK4 MethodArg
+  | EF MethodArg
+
+  -- Map/Accum over expressions in ODE solver method.
+  sem odeSolverMethodSmapAccumL_Expr_Expr
+    : all a. (a -> Expr -> (a, Expr)) -> a -> ODESolverMethod -> (a, ODESolverMethod)
+  sem odeSolverMethodSmapAccumL_Expr_Expr f acc =
+  | ODESolverDefault r ->
+    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    (acc, ODESolverDefault r)
+  | RK4 r ->
+    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    (acc, RK4 r)
+  | EF r ->
+    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    (acc, EF r)
+
+  sem _odeSolverMethodSmapAccumL_Expr_Expr f acc =| r ->
+    match f acc r.stepSize with (acc, stepSize) in
+    match f acc r.add with (acc, add) in
+    match f acc r.smul with (acc, smul) in
+    (acc, { r with stepSize = stepSize, add = add, smul = smul })
 
   -- NOTE(oerikss, 2024-03-08): Compares the inference methods tags only.
   sem cmpODESolverMethod : ODESolverMethod -> ODESolverMethod -> Int
@@ -30,88 +59,70 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   sem eqODESolverMethod env free =
   | ODESolverDefault r
   | RK4 r
-  | EF r -> eqExprH env free r.stepSize
+  | EF r -> optionFoldlM (eqExprH env) free [r.stepSize, r.add, r.smul]
 
-  sem odeSolverMethodToString : ODESolverMethod -> String
-  sem odeSolverMethodToString =
-  | ODESolverDefault _ -> "Default"
-  | RK4 _ -> "RK4"
-  | EF _ -> "EF"
+  sem odeSolverMethodName : ODESolverMethod -> Name
+  sem odeSolverMethodName =
+  | ODESolverDefault _ -> odeDefault
+  | RK4 _ -> odeRK4
+  | EF _ -> odeEF
 
-  sem pprintODESolverMethod
-    : Int -> PprintEnv -> ODESolverMethod -> (PprintEnv, String)
-  sem pprintODESolverMethod indent env =
-  | m & (ODESolverDefault r
-       | RK4 r
-       | EF r) ->
-    _pprintODESolverStepSize1 (odeSolverMethodToString m) indent env r.stepSize
-
-  sem _pprintODESolverStepSize1 method indent env =| stepSize ->
-    let i = pprintIncr indent in
-    match pprintCode i env stepSize with (env, stepSize) in
-    (env, join ["(", method" {stepSize = ", stepSize,"})"])
+  -- Constructs an ODE solver method as a TmConApp.
+  sem odeSolverMethodToCon : Info -> ODESolverMethod -> Expr
+  sem odeSolverMethodToCon info =| m ->
+    (nconapp_ (odeSolverMethodName m) (odeSolverMethodConfig info m))
 
   -- Constructs an ODE solver method from the arguments of a TmConApp.
   sem odeSolverMethodFromCon : Info -> Map SID Expr -> String -> ODESolverMethod
   sem odeSolverMethodFromCon info bindings =
   | "Default" ->
-    ODESolverDefault (_odeSolverMethodExpectStepSize1 info bindings)
-  | "RK4" -> RK4 (_odeSolverMethodExpectStepSize1 info bindings)
-  | "EF" -> EF (_odeSolverMethodExpectStepSize1 info bindings)
+    ODESolverDefault (_odeSolverMethodFromCon info bindings)
+  | "RK4" -> RK4 (_odeSolverMethodFromCon info bindings)
+  | "EF" -> EF (_odeSolverMethodFromCon info bindings)
   | s -> errorSingle [info] (concat "Unknown ODE solver method: " s)
 
-  sem _odeSolverMethodExpectStepSize1 info =| bindings ->
-    let expectedFields = [
-      ("stepSize", float_ default.stepSize)
-    ] in
-    match getFields info bindings expectedFields with [stepSize] in
-    { stepSize = stepSize }
+  sem _odeSolverMethodFromCon info =| bindings ->
+    match getFields info bindings [
+      ("stepSize", withInfo info (float_ 0.05)),
+      ("add", withInfo info (uconst_ (CAddf ()))),
+      ("smul", withInfo info (uconst_ (CMulf ())))
+    ] with [stepSize, add, smul]
+    then { stepSize = stepSize, add = add, smul = smul }
+    else error "impossible"
 
   -- Produces a record expression containing the configuration parameters of the
-  -- ODE solver method. This record is passed to the inference runtime function.
+  -- ODE solver method. This record is passed to the ODE solver runtime
+  -- function.
   sem odeSolverMethodConfig : Info -> ODESolverMethod -> Expr
   sem odeSolverMethodConfig info =
   | ODESolverDefault r
   | RK4 r
-  | EF r ->
-    fieldsToRecord info [("stepSize", r.stepSize)]
-
-  -- Constructs a ODE solver method from command-line options.
-  sem odeSolverMethodFromOptions : Options -> Expr -> String -> ODESolverMethod
-  sem odeSolverMethodFromOptions options stepSize =
-  | "rk4" -> RK4 {stepSize = stepSize}
-  | "ef" -> EF {stepSize = stepSize}
-  | s -> error (concat "Unknown ODE solver method string: " s)
+  | EF r -> fieldsToRecord info [
+    ("stepSize", r.stepSize),
+    ("add", r.add),
+    ("smul", r.smul)
+  ]
 
   -- Type checks the ODE solver method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckODESolverMethod
-    : TCEnv -> Info -> ODESolverMethod -> ODESolverMethod
-  sem typeCheckODESolverMethod env info =
+    : TCEnv -> Info -> Type -> ODESolverMethod -> ODESolverMethod
+  sem typeCheckODESolverMethod env info tyState =
   | ODESolverDefault r ->
-    ODESolverDefault (_typeCheckODESolverStepSize1 env info r.stepSize)
-  | RK4 r ->
-    RK4 (_typeCheckODESolverStepSize1 env info r.stepSize)
-  | EF r ->
-    EF (_typeCheckODESolverStepSize1 env info r.stepSize)
+    ODESolverDefault (_typeCheckODESolverMethod env info tyState r)
+  | RK4 r -> RK4 (_typeCheckODESolverMethod env info tyState r)
+  | EF r -> EF (_typeCheckODESolverMethod env info tyState r)
 
-  sem _typeCheckODESolverStepSize1 env info =| stepSize ->
+  sem _typeCheckODESolverMethod env info tyState =| r ->
     let float = TyFloat {info = info} in
-    let stepSize = typeCheckExpr env stepSize in
+    let arrow = ityarrow_ info in
+    let stepSize = typeCheckExpr env r.stepSize in
+    let add = typeCheckExpr env r.add in
+    let smul = typeCheckExpr env r.smul in
     unify env [info, infoTm stepSize] float (tyTm stepSize);
-    { stepSize = stepSize }
-
-  -- Map/Accum over expressions in ODE solver method.
-  sem odeSolverMethodSmapAccumL_Expr_Expr
-    : all a. (a -> Expr -> (a, Expr)) -> a -> ODESolverMethod -> (a, ODESolverMethod)
-  sem odeSolverMethodSmapAccumL_Expr_Expr f acc =
-  | ODESolverDefault r ->
-    match f acc r.stepSize with (acc, stepSize) in
-    (acc, ODESolverDefault {r with stepSize = stepSize})
-  | RK4 r ->
-    match f acc r.stepSize with (acc, stepSize) in
-    (acc, RK4 {r with stepSize = stepSize})
-  | EF r ->
-    match f acc r.stepSize with (acc, stepSize) in
-    (acc, EF {r with stepSize = stepSize})
+    unify env [info, infoTm stepSize]
+      (arrow tyState (arrow tyState tyState)) (tyTm add);
+    unify env [info, infoTm stepSize]
+      (arrow float (arrow tyState tyState)) (tyTm smul);
+    { stepSize = stepSize, add = add, smul = smul }
 end

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -64,11 +64,9 @@ lang DPPLParser =
       match expr with TmSolveODE ({ method = ODESolverDefault d } & r) then
         TmSolveODE {
           r with
-          method =
-            odeSolverMethodFromOptions
-              options d.stepSize options.odeSolverMethod,
+          method = RK4 d,
           model = replaceDefaultODESolverMethod options r.model,
-          init = replaceDefaultODESolverMethod options r.model,
+          init = replaceDefaultODESolverMethod options r.init,
           endTime = replaceDefaultODESolverMethod options r.endTime
         }
       else expr

--- a/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
@@ -15,22 +15,31 @@ let f = lam sample: [Float].
 in
 let c = cpplResOfDist f in
 
-utest r (c 0   (infer (Default {}) model))
+let _model = lam. model (EulerForward ()) () in
+utest r (c 0 (infer (Importance { particles = 1 }) _model))
 with rhs using e in
-utest r (c 0   (infer (Importance { particles = 1000 }) model))
+
+let _model = lam. model (Default ()) () in
+utest r (c 0 (infer (Importance { particles = 1 }) _model))
 with rhs using e in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))
+
+let _model = lam. model (RungeKutta ()) () in
+utest r (c 0 (infer (Default {}) _model))
 with rhs using e in
-utest r (c 0   (infer (APF { particles = 1000 }) model))
+utest r (c 0 (infer (Importance { particles = 1 }) _model))
 with rhs using e in
-utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))
+utest r (c 0 (infer (BPF { particles = 1 }) _model))
 with rhs using e in
-utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))
+utest r (c 0 (infer (APF { particles = 2 }) _model))
 with rhs using e in
-utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))
+utest r (c 0 (infer (PIMH { particles = 2, iterations = 1 }) _model))
 with rhs using e in
-utest r (c 500
-  (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model))
+utest r (c 0 (infer (TraceMCMC { iterations = 1 }) _model))
+with rhs using e in
+utest r (c 0 (infer (NaiveMCMC { iterations = 1 }) _model))
+with rhs using e in
+utest r (c 0
+  (infer (LightweightMCMC { iterations = 1, globalProb = 0.1 }) _model))
 with rhs using e in
 
 ()


### PR DESCRIPTION
This PR change `solveode` to give more freedom in the choice of type for the state by passing addition and scalar multiplication functions to the solver method. For example, give `add : a -> a -> a` and `smul : Float -> a -> a` then in
```
solveode (Default { add = add, smul = smul }) f y0 x
```
- the ODE model `f` has the type `Float -> a -> a`;
- the initial values `y0` have type `a`;
- the time `x` is always of type `Float`;
- and the solution also have type `a`.

More concretely, `solveode Default { add = addf, smul = mulf } f y0 x` solves a scalar IVP and 
```
solveode (Default { add = zipWith addf, smul = lam s. map (mulf s) }) f y0 x
```
recovers the old version of `solveode`, where a sequence of floats represents the state.

This PR also fixes a bug where a distribution lifted to dual numbers would not report the correct lifted type.

This PR also includes and depends on https://github.com/miking-lang/miking-dppl/pull/183 and https://github.com/miking-lang/miking-dppl/pull/186.
