### PR TITLE
DK 1: New type of functional test based on credible interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ test-coreppl: build/${CPPL_NAME}
 test-coreppl-compiler:
 	@$(MAKE) -s -f test-coreppl.mk compiler
 
+.PHONY: test-coreppl-coin-iter-alter
+test-coreppl-coin-iter-alter:
+	@$(MAKE) -s -f test-coreppl.mk coin-iter-alter
+
 #############
 ## RootPPL ##
 #############

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ test-coreppl: build/${CPPL_NAME}
 test-coreppl-compiler:
 	@$(MAKE) -s -f test-coreppl.mk compiler
 
-.PHONY: test-coreppl-coin-iter-alter
-test-coreppl-coin-iter-alter:
-	@$(MAKE) -s -f test-coreppl.mk coin-iter-alter
+.PHONY: test-coreppl-inference
+test-coreppl-inference:
+	@$(MAKE) -s -f test-coreppl.mk inference
 
 #############
 ## RootPPL ##

--- a/coreppl/models/coin-iter-alter.mc
+++ b/coreppl/models/coin-iter-alter.mc
@@ -1,0 +1,7 @@
+let model: () -> Float = lam.
+  let theta = assume (Beta 3.0 5.0) in
+  iter (lam obs. observe obs (Bernoulli theta)) [true, false, false, true, true, true, true, false, false, true];
+  theta
+
+mexpr
+model ()

--- a/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
@@ -1,0 +1,166 @@
+include "../../test.mc"
+
+include "seq.mc"
+include "sys.mc"
+include "string.mc"
+include "common.mc"
+include "stats.mc"
+
+-- Utilitaries
+recursive
+let quantile: Float -> Float -> [(Float, Float)] -> Float = lam inf. lam sup. lam cdf. 
+  if eqi (length cdf) 1 then
+    0.0
+  else
+    if gtf (head cdf).0 inf then
+      subf (quantile_sup sup (tail cdf)) (head cdf).1  
+    else
+      quantile inf sup (tail cdf)
+
+let quantile_sup: Float -> [(Float, Float)] -> Float = lam sup. lam cdf.
+  if eqi (length cdf) 1 then
+    1.0
+  else
+    if gtf (head cdf).0 sup then
+      (head cdf).1
+    else
+      quantile_sup sup (tail cdf)
+end
+
+recursive
+let cumul : [Float] -> Float = lam vec.
+  if neqi (length vec) 0 then
+    addf (head vec) (cumul (tail vec))
+  else
+    0.0
+end
+
+recursive
+let distrib: [Float] -> [Float] -> [(Float, Float)] = lam samp. lam weigh. 
+  if null samp then [] else 
+    concat [((head samp),(head weigh))] (distrib (tail samp) (tail weigh))
+end
+
+recursive
+let quickSort_distrib : all a. (a -> a -> Float) -> ([(a, a)] -> [(a,a)]) = lam cmp. lam seq.
+  if null seq then seq else
+    let hea: (a,a) = head seq in
+    let tai: [(a,a)]= tail seq in
+    let hea0:a = hea.0 in
+    let lr = partition (lam x:(a,a). ltf (cmp x.0 hea0) 0.0) tai in
+    concat (quickSort_distrib cmp lr.0) (cons hea (quickSort_distrib cmp lr.1))
+end
+
+recursive
+let revers_cdf: [(Float, Float)] -> [(Float, Float)] -> [(Float, Float)] = lam distrib. lam vecf.
+  let cumul = addf (head distrib).1 (head vecf).1 in
+  let vecf = concat [((head distrib).0, cumul)] vecf in
+  if neqi (length distrib) 1 then
+    revers_cdf (tail distrib) vecf
+  else
+    vecf
+end
+
+recursive
+let obs_cdf: [(Float, Float)] -> Int = lam distrib.
+  print (float2string (head distrib).0);
+  print ",";
+  print (float2string (head distrib).1);
+  print "\n";
+  if neqi (length distrib) 1 then
+    obs_cdf (tail distrib)
+  else
+    print "\n";
+    0
+end
+
+recursive
+let obs_distr: [Float] -> [Float] -> Int = lam samples. lam wei.
+  print (float2string (head samples));
+  print ",";
+  print (float2string (head wei));
+  print "\n";
+  if neqi (length samples) 1 then
+    obs_distr (tail samples) (tail wei)
+  else
+    print "\n";
+    0
+end
+
+recursive
+let obs_list: Int -> [Float] -> Int = lam ind. lam list.
+  print (int2string ind);
+  print ",";
+  printLn (float2string (head list));
+  if neqi (length list) 1 then
+    obs_list (addi 1 ind) (tail list)
+  else
+    0
+end
+
+mexpr
+
+utest (distrib [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] [0.1, 0.2, 1.3, 1.0, 1.1, 1.2]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
+
+utest (quickSort_distrib subf [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
+utest (quickSort_distrib subf [(1.0, 0.1), (3.0, 1.3), (2.0, 0.2), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
+utest (quickSort_distrib subf [(6.0, 1.2), (3.0, 1.3), (1.0, 0.1), (4.0, 1.0), (5.0, 1.1), (2.0, 0.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
+
+let s = 10e-3 in
+let eq = eqCoin s in
+let t = testCpplMExpr "coin-iter-alter.mc" 30000 in
+let res: [CpplRes]  = [t 0   "-m is-lw --cps none",
+  t 0   "-m is-lw --cps partial",
+  t 0   "-m is-lw --cps partial --no-early-stop",
+  t 0   "-m is-lw --cps full",
+  t 0   "-m is-lw --cps full --no-early-stop",
+  t 0   "-m smc-bpf --cps partial --resample manual",
+  t 0   "-m smc-bpf --cps partial --resample align",
+  t 0   "-m smc-bpf --cps partial --resample likelihood",
+  t 0   "-m smc-bpf --cps full --resample manual",
+  t 0   "-m smc-bpf --cps full --resample align",
+  t 0   "-m smc-bpf --cps full --resample likelihood",
+  t 0   "-m smc-apf --cps partial --resample manual",
+  t 0   "-m smc-apf --cps partial --resample align",
+  t 0   "-m smc-apf --cps partial --resample likelihood",
+  t 0   "-m smc-apf --cps full --resample manual",
+  t 0   "-m smc-apf --cps full --resample align",
+  t 0   "-m smc-apf --cps full --resample likelihood",
+  t 500 "-m pmcmc-pimh --cps partial",
+  t 500 "-m pmcmc-pimh --cps full",
+  t 500 "-m mcmc-trace",
+  t 500 "-m mcmc-naive",
+  t 500 "-m mcmc-lightweight --align --cps none",
+  t 500 "-m mcmc-lightweight --align --cps partial",
+  t 500 "-m mcmc-lightweight --align --cps full",
+  t 500 "-m mcmc-lightweight"
+] in
+
+recursive
+let testRec : [CpplRes] -> Int = lam resVec. 
+  let result = head(resVec) in
+  let weights = (map exp result.lweights) in
+  -- re normalize after truncature of burning
+  let acc = cumul weights in
+  let distr = distrib (map string2float result.samples) (map (mulf (divf 1.0 acc)) weights)  in
+  let sort = quickSort_distrib subf distr in
+  let temp = revers_cdf sort [(0.0, 0.0)] in
+  let cdf_dist = tail (reverse temp) in
+
+  utest (quantile 0.2781183 0.7218817 cdf_dist) with 0.95 using eq in
+  utest (quantile 0.3108296 0.6891704 cdf_dist) with 0.9 using eq in
+  utest (quantile 0.3503948 0.6496052 cdf_dist) with 0.8 using eq in
+  utest (quantile 0.4004409 0.5995591 cdf_dist) with 0.6 using eq in
+  utest (quantile 0.4697533 0.5302467 cdf_dist) with 0.2 using eq in
+  printLn " EoM";
+
+  if neqi (length (tail resVec)) 0 then
+    testRec (tail resVec)
+  else
+    print " EoT";
+    1
+in
+
+let u = testRec res in
+
+()

--- a/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
@@ -6,161 +6,43 @@ include "string.mc"
 include "common.mc"
 include "stats.mc"
 
--- Utilitaries
-recursive
-let quantile: Float -> Float -> [(Float, Float)] -> Float = lam inf. lam sup. lam cdf. 
-  if eqi (length cdf) 1 then
-    0.0
-  else
-    if gtf (head cdf).0 inf then
-      subf (quantile_sup sup (tail cdf)) (head cdf).1  
-    else
-      quantile inf sup (tail cdf)
-
-let quantile_sup: Float -> [(Float, Float)] -> Float = lam sup. lam cdf.
-  if eqi (length cdf) 1 then
-    1.0
-  else
-    if gtf (head cdf).0 sup then
-      (head cdf).1
-    else
-      quantile_sup sup (tail cdf)
-end
-
-recursive
-let cumul : [Float] -> Float = lam vec.
-  if neqi (length vec) 0 then
-    addf (head vec) (cumul (tail vec))
-  else
-    0.0
-end
-
-recursive
-let distrib: [Float] -> [Float] -> [(Float, Float)] = lam samp. lam weigh. 
-  if null samp then [] else 
-    concat [((head samp),(head weigh))] (distrib (tail samp) (tail weigh))
-end
-
-recursive
-let quickSort_distrib : all a. (a -> a -> Float) -> ([(a, a)] -> [(a,a)]) = lam cmp. lam seq.
-  if null seq then seq else
-    let hea: (a,a) = head seq in
-    let tai: [(a,a)]= tail seq in
-    let hea0:a = hea.0 in
-    let lr = partition (lam x:(a,a). ltf (cmp x.0 hea0) 0.0) tai in
-    concat (quickSort_distrib cmp lr.0) (cons hea (quickSort_distrib cmp lr.1))
-end
-
-recursive
-let revers_cdf: [(Float, Float)] -> [(Float, Float)] -> [(Float, Float)] = lam distrib. lam vecf.
-  let cumul = addf (head distrib).1 (head vecf).1 in
-  let vecf = concat [((head distrib).0, cumul)] vecf in
-  if neqi (length distrib) 1 then
-    revers_cdf (tail distrib) vecf
-  else
-    vecf
-end
-
-recursive
-let obs_cdf: [(Float, Float)] -> Int = lam distrib.
-  print (float2string (head distrib).0);
-  print ",";
-  print (float2string (head distrib).1);
-  print "\n";
-  if neqi (length distrib) 1 then
-    obs_cdf (tail distrib)
-  else
-    print "\n";
-    0
-end
-
-recursive
-let obs_distr: [Float] -> [Float] -> Int = lam samples. lam wei.
-  print (float2string (head samples));
-  print ",";
-  print (float2string (head wei));
-  print "\n";
-  if neqi (length samples) 1 then
-    obs_distr (tail samples) (tail wei)
-  else
-    print "\n";
-    0
-end
-
-recursive
-let obs_list: Int -> [Float] -> Int = lam ind. lam list.
-  print (int2string ind);
-  print ",";
-  printLn (float2string (head list));
-  if neqi (length list) 1 then
-    obs_list (addi 1 ind) (tail list)
-  else
-    0
-end
-
 mexpr
-
-utest (distrib [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] [0.1, 0.2, 1.3, 1.0, 1.1, 1.2]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
-
-utest (quickSort_distrib subf [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
-utest (quickSort_distrib subf [(1.0, 0.1), (3.0, 1.3), (2.0, 0.2), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
-utest (quickSort_distrib subf [(6.0, 1.2), (3.0, 1.3), (1.0, 0.1), (4.0, 1.0), (5.0, 1.1), (2.0, 0.2)]) with [(1.0, 0.1), (2.0, 0.2), (3.0, 1.3), (4.0, 1.0), (5.0, 1.1), (6.0, 1.2)] in
 
 let s = 10e-3 in
 let eq = eqCoin s in
 let t = testCpplMExpr "coin-iter-alter.mc" 30000 in
-let res: [CpplRes]  = [t 0   "-m is-lw --cps none",
-  t 0   "-m is-lw --cps partial",
-  t 0   "-m is-lw --cps partial --no-early-stop",
-  t 0   "-m is-lw --cps full",
-  t 0   "-m is-lw --cps full --no-early-stop",
-  t 0   "-m smc-bpf --cps partial --resample manual",
-  t 0   "-m smc-bpf --cps partial --resample align",
-  t 0   "-m smc-bpf --cps partial --resample likelihood",
-  t 0   "-m smc-bpf --cps full --resample manual",
-  t 0   "-m smc-bpf --cps full --resample align",
-  t 0   "-m smc-bpf --cps full --resample likelihood",
-  t 0   "-m smc-apf --cps partial --resample manual",
-  t 0   "-m smc-apf --cps partial --resample align",
-  t 0   "-m smc-apf --cps partial --resample likelihood",
-  t 0   "-m smc-apf --cps full --resample manual",
-  t 0   "-m smc-apf --cps full --resample align",
-  t 0   "-m smc-apf --cps full --resample likelihood",
-  t 500 "-m pmcmc-pimh --cps partial",
-  t 500 "-m pmcmc-pimh --cps full",
-  t 500 "-m mcmc-trace",
-  t 500 "-m mcmc-naive",
-  t 500 "-m mcmc-lightweight --align --cps none",
-  t 500 "-m mcmc-lightweight --align --cps partial",
-  t 500 "-m mcmc-lightweight --align --cps full",
-  t 500 "-m mcmc-lightweight"
+let res: [(Int, String)]  = [(0  ,"-m 'is-lw' --cps none"),
+  (0  ,"-m 'is-lw' --cps partial"),
+  (0  ,"-m 'is-lw' --cps partial --no-early-stop"),
+  (0  ,"-m 'is-lw' --cps full"),
+  (0  ,"-m 'is-lw' --cps full --no-early-stop"),
+  (0  ,"-m 'smc-bpf' --cps partial --resample manual"),
+  (0  ,"-m 'smc-bpf' --cps partial --resample align"),
+  (0  ,"-m 'smc-bpf' --cps partial --resample likelihood"),
+  (0  ,"-m 'smc-bpf' --cps full --resample manual"),
+  (0  ,"-m 'smc-bpf' --cps full --resample align"),
+  (0  ,"-m 'smc-bpf' --cps full --resample likelihood"),
+  (0  ,"-m 'smc-apf' --cps partial --resample manual"),
+  (0  ,"-m 'smc-apf' --cps partial --resample align"),
+  (0  ,"-m 'smc-apf' --cps partial --resample likelihood"),
+  (0  ,"-m 'smc-apf' --cps full --resample manual"),
+  (0  ,"-m 'smc-apf' --cps full --resample align"),
+  (0  ,"-m 'smc-apf' --cps full --resample likelihood"),
+  (500,"-m 'pmcmc-pimh' --cps partial"),
+  (500,"-m 'pmcmc-pimh' --cps full"),
+  (500,"-m 'mcmc-trace'"),
+  (500,"-m 'mcmc-naive'"),
+  (500,"-m 'mcmc-lightweight' --align --cps none"),
+  (500,"-m 'mcmc-lightweight' --align --cps partial"),
+  (500,"-m 'mcmc-lightweight' --align --cps full"),
+  (500,"-m 'mcmc-lightweight'")
 ] in
-
-recursive
-let testRec : [CpplRes] -> Int = lam resVec. 
-  let result = head(resVec) in
-  let weights = (map exp result.lweights) in
-  -- re normalize after truncature of burning
-  let acc = cumul weights in
-  let distr = distrib (map string2float result.samples) (map (mulf (divf 1.0 acc)) weights)  in
-  let sort = quickSort_distrib subf distr in
-  let temp = revers_cdf sort [(0.0, 0.0)] in
-  let cdf_dist = tail (reverse temp) in
-
-  utest (quantile 0.2781183 0.7218817 cdf_dist) with 0.95 using eq in
-  utest (quantile 0.3108296 0.6891704 cdf_dist) with 0.9 using eq in
-  utest (quantile 0.3503948 0.6496052 cdf_dist) with 0.8 using eq in
-  utest (quantile 0.4004409 0.5995591 cdf_dist) with 0.6 using eq in
-  utest (quantile 0.4697533 0.5302467 cdf_dist) with 0.2 using eq in
-  printLn " EoM";
-
-  if neqi (length (tail resVec)) 0 then
-    testRec (tail resVec)
-  else
-    print " EoT";
-    1
+-- these values come from outside calculation on a BetaBernouilli conjugate prior for alpha = 3, beta = 5 => Beta( 9, 9)
+let quantile: [(Float, Float, Float)] = [(0.2781183, 0.7218817, 0.95), 
+(0.3108296, 0.6891704, 0.9), 
+(0.3503948, 0.6496052, 0.8),  
+(0.4004409, 0.5995591, 0.6),  
+(0.4697533, 0.5302467, 0.2)]  
 in
 
-let u = testRec res in
-
-()
+iter (((testPattern t) eq) quantile) res

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -13,7 +13,10 @@ test-files := $(filter-out coreppl/src/transformation.mc,$(test-files))
 # out and it is compiled anyways when doing the inference tests.
 test-files := $(filter-out coreppl/src/cppl.mc,$(test-files))
 
-test-coin-iter-alter=$(shell find coreppl/test/coreppl-to-mexpr/cli -name "coin-iter-alter.mc")
+# NOTE(ThimotheeV, 2024-11-021): Filter out the inference test frame
+# from the main test frame because they can be pretty long to complite
+test-files := $(filter-out coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc,$(test-files))
+test-inference=$(shell find coreppl/test/coreppl-to-mexpr/cli -name "coin-iter-alter.mc")
 
 test-infer-files=$(shell find coreppl/test/coreppl-to-mexpr/infer -name "*.mc")
 test-staticdelay-files=$(shell find coreppl/test/coreppl-to-mexpr/static-delay -name "*.mc")
@@ -55,8 +58,8 @@ static-delay: ${test-staticdelay-files}
 .PHONY: expectation
 expectation: ${test-expectation-files}
 
-.PHONY: coin-iter-alter
-coin-iter-alter: ${test-coin-iter-alter}
+.PHONY: inference
+inference: ${test-inference}
 
 export CPPL_NAME
 export MIDPPL_PATH=${CURDIR}

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -13,6 +13,8 @@ test-files := $(filter-out coreppl/src/transformation.mc,$(test-files))
 # out and it is compiled anyways when doing the inference tests.
 test-files := $(filter-out coreppl/src/cppl.mc,$(test-files))
 
+test-coin-iter-alter=$(shell find coreppl/test/coreppl-to-mexpr/cli -name "coin-iter-alter.mc")
+
 test-infer-files=$(shell find coreppl/test/coreppl-to-mexpr/infer -name "*.mc")
 test-staticdelay-files=$(shell find coreppl/test/coreppl-to-mexpr/static-delay -name "*.mc")
 test-cli-files=\
@@ -52,6 +54,9 @@ static-delay: ${test-staticdelay-files}
 
 .PHONY: expectation
 expectation: ${test-expectation-files}
+
+.PHONY: coin-iter-alter
+coin-iter-alter: ${test-coin-iter-alter}
 
 export CPPL_NAME
 export MIDPPL_PATH=${CURDIR}


### PR DESCRIPTION
This PR is the first part of the Drift Kernel update for lightweight MCMC algorithm.  This PR is a proof of concept for a new type of functional test. This type of test is the basis for the empirical proof of good implementation for the DriftKernel.

 **Concept (thanks to Fredrick and Gizem) :**
 - The posterior probability distribution of a model with conjugate prior can be calculate analytically.
 - From a posterior probability distribution you can calculate the posterior cumulative distribution function (pcdf).
 - You can easily compare the density of the theoretical pcdf and the empirical pcdf (from your inference) for a certain credible interval.
 - Theoretically if your implementation is good and if the inference method is not bias, with a infinite number of sample/step your theoretical pcdf and your empirical pcdf will fit perfectly.
 
 **Implementation:**
 - Use the test system from the original coin model
 - Doesn't use the _infer_ keyworld because these tests need using exe flags on the next PR
 - Calculate the bounds for each credible interval externally (using R) 
 - Because we can't use a infinite number of sample (it will take forever to calculate), a precision threshold is use to compare the two pcdf. These tests are design as relatively fast so this threshold is high but can be lesser at the cost of a bigger set of sample.
 - I have create a temporary target entry in makefile to specifically launch these tests.
 `make test-coreppl-coin-iter-alter`  
  
 **Question:**
 - I have seen on the code base that some prior conjugate were already been implement in Miking/Miking-dppl, maybe I can get ride of the need to calculate the theoretical pcdf bounds externally.
 - I implement a certain number of utilities function, I don't how many of them are redundant with the code base.
 - Not sure if I need to keep these utilities function in coin-iter-alter.mc, in test.mc or in a new file.
 
 NB : I have seen a real decrease of efficiency between my dev version ([Miking](https://github.com/treeppl/miking) [Miking-dppl ](https://github.com/treeppl/miking-dppl)) and the current implementation of Miking. The time to do the testing when from around 30s to 75s in the same computer. This seem to be independent of the number of sample using during the test. I have see new "shadows test" (utest in the code base) were add, I don't know if these two fact are link.