### PR TITLE
Phase stats and json-debug

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
@@ -2,8 +2,9 @@ include "../dists.mc"
 include "../../inference/smc.mc"
 include "../../dppl-arg.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/phase-stats.mc"
 
-lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist
+lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist + PhaseStats
 
   ----------------
   -- NAIVE MCMC --
@@ -15,12 +16,15 @@ lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist
   sem compile : Options -> (Expr,Expr) -> Expr
   sem compile options =
   | (t,_) ->
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
 
     -- Transform distributions to MExpr distributions
     let t = mapPre_Expr_Expr transformTmDist t in
+    endPhaseStatsExpr log "transform-tm-dist-one" t;
 
     -- Transform samples, observes, and weights to MExpr
     let t = mapPre_Expr_Expr transformProb t in
+    endPhaseStatsExpr log "transform-prob-one" t;
 
     t
 

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
@@ -2,8 +2,9 @@ include "../dists.mc"
 include "../../inference/smc.mc"
 include "../../dppl-arg.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/phase-stats.mc"
 
-lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist
+lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist + PhaseStats
 
   ----------------
   -- TRACE MCMC --
@@ -15,12 +16,15 @@ lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist
   sem compile : Options -> (Expr,Expr) -> Expr
   sem compile options =
   | (t,_) ->
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
 
     -- Transform distributions to MExpr distributions
     let t = mapPre_Expr_Expr transformTmDist t in
+    endPhaseStatsExpr log "transform-tm-dist-one" t;
 
     -- Transform samples, observes, and weights to MExpr
     let t = mapPre_Expr_Expr transformProb t in
+    endPhaseStatsExpr log "transform-prob-one" t;
 
     t
 

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -8,6 +8,7 @@ include "mexpr/anf.mc"
 include "mexpr/type-lift.mc"
 include "mexpr/const-arity.mc"
 include "mexpr/const-types.mc"
+include "mexpr/json-debug.mc"
 
 include "peval/peval.mc"
 
@@ -16,7 +17,7 @@ include "seq.mc"
 include "utest.mc"
 
 lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift +
-            TyConst + ConstPrettyPrint + ConstArity + PEval
+            TyConst + ConstPrettyPrint + ConstArity + PEval + AstToJson
 
   syn Expr =
   | TmDist { dist : Dist,
@@ -234,6 +235,21 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift +
   | CDistEmpiricalNormConst _ -> 1
   | CDistEmpiricalAcceptRate _ -> 1
   | CDistExpectation _ -> 1
+
+  sem exprToJson =
+  | TmDist x -> JsonObject (mapFromSeq cmpString
+    [ ("con", JsonString "TmDist")
+    , ("dist", JsonString (distName x.dist))
+    , ("ty", typeToJson x.ty)
+    , ("info", infoToJson x.info)
+    ] )
+
+  sem typeToJson =
+  | TyDist x -> JsonObject (mapFromSeq cmpString
+    [ ("con", JsonString "TyDist")
+    , ("ty", typeToJson x.ty)
+    , ("info", infoToJson x.info)
+    ] )
 
 end
 
@@ -838,4 +854,3 @@ utest (typeLift tmBinomial).1 with tmBinomial using eqExpr in
 utest (typeLift tmWiener).1 with tmWiener using eqExpr in
 
 ()
-

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -1,4 +1,5 @@
 include "arg.mc"
+include "set.mc"
 
 -- Options type
 type Options = {
@@ -22,6 +23,8 @@ type Options = {
   skipFinal: Bool,
   outputMc: Bool,
   output: String,
+  debugPhases: Bool,
+  debugDumpPhases: Set String,
 
   -- Apply static delayed sampling transformation
   staticDelay: Bool,
@@ -86,6 +89,8 @@ let default = {
   printMCore = false,
   exitBefore = false,
   skipFinal = false,
+  debugPhases = false,
+  debugDumpPhases = setEmpty cmpString,
   outputMc = false,
   output = "out",
   staticDelay = false,
@@ -159,6 +164,14 @@ let config = [
     "Do not perform the final compilation step (e.g., MExpr to OCaml).",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with skipFinal = true}),
+  ([("--debug-phases", "", "")],
+    "Show debug and profiling information about each pass",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugPhases = true}),
+  ([("--debug-phase", " ", "<phase>")],
+    "Print a json representation of the AST after the given pass. Can be given multiple times.",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugDumpPhases = setInsert (argToString p) o.debugDumpPhases}),
   ([("--output-mc", "", "")],
     "Write intermediate MCore output to file when compiling",
     lam p: ArgPart Options.


### PR DESCRIPTION
This is a follow-up of https://github.com/miking-lang/miking/pull/876 and adds copious use of `endPhaseStats` throughout the cppl pipeline (and adds support for `mexpr/json-debug.mc` for added constructs). I also add corresponding flags `--debug-phases` and `--debug-phase <phase>`, neither of which were present in the cppl compiler previously.