### PR TITLE
Refactor, rename, bugfix, and add integration method

### DIFF
--- a/coreppl/src/ad.mc
+++ b/coreppl/src/ad.mc
@@ -371,24 +371,24 @@ lang DualNumAst =
   sem dualnumLiftExprH : Expr -> Expr
 end
 
-lang DualNumDist = Dist + DualNumAst
+lang LiftedDist = Dist + DualNumAst
   syn Dist =
-  | DDual Dist
+  | LDist Dist
 
   sem smapAccumL_Dist_Expr f acc =
-  | DDual d ->
+  | LDist d ->
     match smapAccumL_Dist_Expr f acc d with (acc, d) in
-    (acc, DDual d)
+    (acc, LDist d)
 
   sem distTy info =
-  | DDual d ->
+  | LDist d ->
     match distTy info d with (vars, paramTys, ty) in
     -- NOTE(oerikss, 2024-11-04): We lift the support and instead make sure that
     -- TmDist unboxes its parameters.
     (vars, paramTys, dualnumLiftType ty)
 
   sem distName =
-  | DDual d -> join ["Dual<", distName d, ">"]
+  | LDist d -> join ["L<", distName d, ">"]
 end
 
 
@@ -424,7 +424,7 @@ end
 
 
 lang DualNumLift =
-  MExprPPL + DualNumAst + ElementaryFunctions + Diff + DualNumDist + TyConst
+  MExprPPL + DualNumAst + ElementaryFunctions + Diff + LiftedDist + TyConst
 
   sem tyConstBase d =
   -- NOTE(oerikss, 2024-04-25): The type of a lifted constant is its type lifted
@@ -530,7 +530,7 @@ lang DualNumLift =
           (lam. dualnumLiftExprH tm)
           (lam unbox. unbox (dualnumLiftExprH tm))
           (dualnumUnboxTypeDirected (tyTm tm)))
-      (TmDist { r with dist = DDual r.dist })
+      (TmDist { r with dist = LDist r.dist })
   | TmWeight r -> TmWeight {
     r with weight = dualnumPrimalRec r.info (dualnumLiftExprH r.weight)
   }

--- a/coreppl/src/ad.mc
+++ b/coreppl/src/ad.mc
@@ -311,7 +311,7 @@ lang DualNumAst =
   | CPertubation _ -> graph
 
   sem getConstStringCode (indent : Int) =
-  | CLifted const -> join ["L(", getConstStringCode indent const, ")"]
+  | CLifted const -> join ["L<", getConstStringCode indent const, ">"]
   | CGenEpsilon _ -> "genEpsilon"
   | CLtEpsilon _ -> "ltEpsilon"
   | CCreatePrimal _ -> "createPrimal"

--- a/coreppl/src/ad.mc
+++ b/coreppl/src/ad.mc
@@ -369,8 +369,8 @@ lang DualNumDist = Dist + DualNumAst
     match distTy info d with (vars, paramTys, ty) in
     (vars, map dualnumLiftType paramTys, dualnumLiftType ty)
 
-  sem distNameToString =
-  | DDual d -> join ["Dual<", distNameToString d, ">"]
+  sem distName =
+  | DDual d -> join ["Dual<", distName d, ">"]
 end
 
 

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -426,7 +426,7 @@ lang MExprCompile =
 
     -- Transform diff terms and lift to dual numbers if necessary.
     let corepplAst =
-      if hasDiff then dualnumLiftExpr corepplAst
+      if hasDiff then typeCheck (dualnumLiftExpr corepplAst)
       else corepplAst
     in
 

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -112,6 +112,7 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
   sem odeODESolverMethodToRuntimeName =
   | RK4 _ -> "odeSolverRK4Solve"
   | EF _ -> "odeSolverEFSolve"
+  | EFA _ -> "odeSolverEFASolve"
   | method -> error (join [
     nameGetStr (odeSolverMethodName method),
     " does not have an implementation in the ODE solver runtime"
@@ -121,6 +122,7 @@ lang ODETransform = DPPLParser + MExprSubstitute + MExprFindSym + LoadRuntime
   sem odeODESolverMethodToSolverArgs : ODESolverMethod -> [Expr]
   sem odeODESolverMethodToSolverArgs =
   | ODESolverDefault r | RK4 r | EF r -> [r.add, r.smul, r.stepSize]
+  | EFA r -> [r.add, r.smul, r.stepSize, r.n]
 end
 
 lang DPPLTransformCancel = DPPLParser

--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -165,7 +165,9 @@ lang ADTransform =
   DPPLParser +
   LoadRuntime +
   DualNumRuntimeBase +
-  DualNumLift
+  DualNumLift +
+  LiftedDist +
+  TransformDistBase
 
   sem adHasDiff : Expr -> Bool
   sem adHasDiff =| tm -> adHasDiffExpr false tm

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -92,9 +92,10 @@ lang TransformDist = TransformDistBase + LiftedDist
     i (conapp_
         "RuntimeDistElementary_DistUniform"
          (i (urecord_ [("a", a), ("b", b)])))
-  | DWiener {} ->
+  | DWiener { cps = cps, a = a } ->
     i (conapp_
-         "RuntimeDistElementary_DistWiener" (i unit_))
+         "RuntimeDistElementary_DistWiener"
+         (i (urecord_ [("cps", if cps then i true_ else i false_), ("a", a)])))
   | DEmpirical { samples = samples } ->
     i (app_ (var_ "vRuntimeDistEmpirical_constructDistEmpiricalHelper") samples)
   | DLifted d ->

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -8,7 +8,7 @@ include "mexpr/ast-builder.mc"
 
 -- TODO(dlunde,2022-05-11): The common case where the user writes, e.g., assume
 -- (Bernoulli x), can also be optimized to not create an intermediate record.
-lang TransformDist = MExprPPL + DualNumDist
+lang TransformDist = MExprPPL + LiftedDist
   sem transformTmDist: Expr -> Expr
   sem transformTmDist =
   | TmDist t -> transformDist (withInfo t.info) t.dist
@@ -77,7 +77,7 @@ lang TransformDist = MExprPPL + DualNumDist
          "RuntimeDistElementary_DistWiener" (i unit_))
   | DEmpirical { samples = samples } ->
     i (app_ (var_ "vRuntimeDistEmpirical_constructDistEmpiricalHelper") samples)
-  | DDual d ->
+  | LDist d ->
     i (conapp_ "RuntimeDistElementaryDual_DistDual" (transformDist i d))
 
   -- We need to replace occurrences of TyDist after transforming to MExpr

--- a/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
@@ -56,6 +56,15 @@ lang MExprPPLImportance =
     TmLet { t with inexpr = exprCps env k t.inexpr }
   | TmLet ({ body = TmDist _ } & t) ->
     TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmDist (d & { dist = DWiener w })} & t) ->
+    if not (transform env t.ident) then
+      TmLet { t with inexpr = exprCps env k t.inexpr }
+    else
+      TmLet {
+        t with
+        body = TmDist { d with dist = DWiener { w with cps = true }},
+        inexpr = exprCps env k t.inexpr
+      }
 
   -- This is where we use the continuation (weight and observe)
   | TmLet { ident = ident, body = TmWeight { weight = weight },

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
@@ -296,6 +296,15 @@ lang MExprPPLLightweightMCMC =
     TmLet { t with inexpr = exprCps env k t.inexpr }
   | TmLet ({ body = TmDist _ } & t) ->
     TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmDist (d & { dist = DWiener w })} & t) ->
+    if not (transform env t.ident) then
+      TmLet { t with inexpr = exprCps env k t.inexpr }
+    else
+      TmLet {
+        t with
+        body = TmDist { d with dist = DWiener { w with cps = true }},
+        inexpr = exprCps env k t.inexpr
+      }
   | TmLet ({ body = TmWeight _ } & t) ->
     TmLet { t with inexpr = exprCps env k t.inexpr }
   | TmLet ({ body = TmObserve _ } & t) ->

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
@@ -5,52 +5,8 @@ include "mexpr/ast-builder.mc"
 include "mexpr/cps.mc"
 
 lang MExprPPLPIMH =
-  MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll + MExprPPLCFA
-
-  -- CPS compile
-  sem exprCps env k =
-  | TmLet ({ body = TmAssume _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmObserve _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmWeight _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmDist _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet { ident = ident, body = TmResample {},
-            inexpr = inexpr } & t ->
-    let i = withInfo (infoTm t) in
-    let k =
-      if tailCall t then
-        match k with Some k then
-          k
-        else
-          error "Something went wrong with partial CPS transformation"
-      else
-        i (nulam_ ident (exprCps env k inexpr))
-    in
-      i (appf1_ (i (var_ "resample")) k)
-
-  -- NOTE(2023-08-08,dlunde): Many TmTypes are shared with non-PPL code and
-  -- transformed versions are removed when removing duplicate code.
-  -- Therefore, we have to simply replace TyCon and TyApp with Unknown here.
-  sem tyCps env =
-  | (TyCon { info = info } | TyApp { info = info } ) ->
-    let i = tyWithInfo info in i tyunknown_
-
-  sem transformProb =
-  | TmAssume t ->
-    let i = withInfo t.info in
-    i (app_ (i (var_ "sample")) t.dist)
-  | TmResample t -> errorSingle [t.info] "Impossible"
-  | TmObserve t ->
-    let i = withInfo t.info in
-    let weight = i (appf2_ (i (var_ "logObserve")) t.dist t.value) in
-    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
-  | TmWeight t ->
-    let i = withInfo t.info in
-    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
-  | t -> t
+  MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll + MExprPPLCFA +
+  SMCCommon
 
   sem compile: Options -> (Expr,Expr) -> Expr
   sem compile options =

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -44,6 +44,16 @@ let wienerSample : () -> Float -> Float = lam.
       t
       tr
 
+-- Fast version of `wienerSample` that assumes the sampled Wiener realization is
+-- evaluated at increasing positive times.
+let wienerSampleUnsafe : () -> Float -> Float = lam.
+  let state = ref (0., 0.) in
+  lam t2.
+    match deref state with (w, t1) in
+    if eqf t2 t1 then w else
+      let w = (gaussianSample w (sqrt (subf t2 t1))) in
+      modref state (w, t2); w
+
 -- Base interface
 lang RuntimeDistBase
   syn Dist a =
@@ -354,9 +364,10 @@ let logObserve : all a. use RuntimeDist in Dist a -> a -> Float =
 
 mexpr
 
+let randomTimes = create 10 (lam. gaussianSample 0. 1.) in
 let w = wienerSample () in
-utest w 0. with w 0. in
-utest w 1. with w 1. in
-utest w -1. with w -1. in
+utest map w randomTimes with map w randomTimes in
+utest map w randomTimes with map w randomTimes in
+utest map w randomTimes with map w randomTimes in
 
 ()

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -8,7 +8,7 @@ include "ext/dist-ext.mc"
 include "ad/dualnum.mc"
 
 -- Weiner process
-let wienerSample : () -> (Float -> Float) = lam.
+let wienerSample : () -> Float -> Float = lam.
   -- TODO(oerikss, 2024-03-20): We save the observed trace of the process in a
   -- map. This is ofcourse limiting in the sense that we need to keep the
   -- observed traces of all Wiener process in memory. In the futurue we want to
@@ -35,7 +35,7 @@ let wienerSample : () -> (Float -> Float) = lam.
                  (mulf (subf t t1) (divf (subf b a) (subf t2 t1))))
             in
             let sigma =
-              sqrt (mulf (subf t2 t) (divf (subf t1 t) (subf t2 t1)))
+              sqrt (divf (mulf (subf t2 t) (subf t t1)) (subf t2 t1))
             in
             gaussianSample mu sigma
           end
@@ -351,3 +351,12 @@ let expectation : all a. use RuntimeDist in Dist a -> a =
 let logObserve : all a. use RuntimeDist in Dist a -> a -> Float =
   use RuntimeDist in
   logObserve
+
+mexpr
+
+let w = wienerSample () in
+utest w 0. with w 0. in
+utest w 1. with w 1. in
+utest w -1. with w -1. in
+
+()

--- a/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-dists.mc
@@ -69,7 +69,7 @@ lang RuntimeDistElementary = RuntimeDistBase
   | DistCategorical {p : [Float]}
   | DistDirichlet {a : [Float]}
   | DistUniform {a : Float, b : Float}
-  | DistWiener {}
+  | DistWiener {cps : Bool, a : ()}
   | DistLomax {scale: Float, shape : Float}
   | DistBetabin {n:Int, a: Float, b: Float}
   | DistNegativeBinomial {n:Int, p: Float}
@@ -86,7 +86,9 @@ lang RuntimeDistElementary = RuntimeDistBase
   | DistCategorical t -> unsafeCoerce (categoricalSample t.p)
   | DistDirichlet t -> unsafeCoerce (dirichletSample t.a)
   | DistUniform t -> unsafeCoerce (uniformContinuousSample t.a t.b)
-  | DistWiener _ -> unsafeCoerce (wienerSample ())
+  | DistWiener {cps = false, a = a} -> unsafeCoerce (wienerSample a)
+  | DistWiener {cps = true, a = a} ->
+    unsafeCoerce (let w = wienerSample a in lam k. lam x. k (w x))
   | DistLomax t -> unsafeCoerce (lomaxSample t.shape t.scale)
   | DistBetabin t -> unsafeCoerce (betabinSample t.n t.a t.b)
   | DistNegativeBinomial t -> unsafeCoerce (negativeBinomialSample t.n t.p)

--- a/coreppl/src/coreppl-to-mexpr/runtime-ode-wrapper.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-ode-wrapper.mc
@@ -5,5 +5,6 @@ mexpr
 -- to keep. The downside is that we get an ugly printout when we test this file.
 dprint (
   odeSolverRK4Solve,
-  odeSolverEFSolve
+  odeSolverEFSolve,
+  odeSolverEFASolve
   )

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
@@ -8,51 +8,6 @@ lang MExprPPLAPF =
   MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll + MExprPPLCFA
   + SMCCommon
 
-  -- CPS compile
-  sem exprCps env k =
-  | TmLet ({ body = TmAssume _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmObserve _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmWeight _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmDist _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet { ident = ident, body = TmResample {},
-            inexpr = inexpr } & t ->
-    let i = withInfo (infoTm t) in
-    let k =
-      if tailCall t then
-        match k with Some k then
-          k
-        else
-          error "Something went wrong with partial CPS transformation"
-      else
-        i (nulam_ ident (exprCps env k inexpr))
-    in
-      i (appf1_ (i (var_ "resample")) k)
-
-  -- NOTE(2023-08-08,dlunde): Many TmTypes are shared with non-PPL code and
-  -- transformed versions are removed when removing duplicate code.
-  -- Therefore, we have to simply replace TyCon and TyApp with Unknown here.
-  sem tyCps env =
-  | (TyCon { info = info } | TyApp { info = info } ) ->
-    let i = tyWithInfo info in i tyunknown_
-
-  sem transformProb =
-  | TmAssume t ->
-    let i = withInfo t.info in
-    i (app_ (i (var_ "sample")) t.dist)
-  | TmResample t -> errorSingle [t.info] "Impossible"
-  | TmObserve t ->
-    let i = withInfo t.info in
-    let weight = i (appf2_ (i (var_ "logObserve")) t.dist t.value) in
-    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
-  | TmWeight t ->
-    let i = withInfo t.info in
-    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
-  | t -> t
-
   sem compile: Options -> (Expr,Expr) -> Expr
   sem compile options =
   | (_,t) ->

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -8,37 +8,6 @@ lang MExprPPLBPF =
   MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll + MExprPPLCFA
   + SMCCommon
 
-  -- CPS compile
-  sem exprCps env k =
-  | TmLet ({ body = TmAssume _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmObserve _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmWeight _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmDist _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet { ident = ident, body = TmResample {},
-            inexpr = inexpr } & t ->
-    let i = withInfo (infoTm t) in
-    let k =
-      if tailCall t then
-        match k with Some k then
-          k
-        else
-          error "Something went wrong with partial CPS transformation"
-      else
-        i (nulam_ ident (exprCps env k inexpr))
-    in
-      i (appf1_ (i (var_ "resample")) k)
-
-  -- NOTE(2023-08-08,dlunde): Many TmTypes are shared with non-PPL code and
-  -- transformed versions are removed when removing duplicate code.
-  -- Therefore, we have to simply replace TyCon and TyApp with Unknown here.
-  sem tyCps env =
-  | (TyCon { info = info } | TyApp { info = info } ) ->
-    let i = tyWithInfo info in i tyunknown_
-
   sem transformStopFirstAssume: Expr -> Option Expr
   sem transformStopFirstAssume =
 
@@ -80,20 +49,6 @@ lang MExprPPLBPF =
     Some (i (appf2_ (i (var_ "stopFirstAssume")) r.dist (i (nulam_ ident inexpr))))
 
   | t -> None ()
-
-  sem transformProb =
-  | TmAssume t ->
-    let i = withInfo t.info in
-    i (app_ (i (var_ "sample")) t.dist)
-  | TmResample t -> errorSingle [t.info] "Impossible"
-  | TmObserve t ->
-    let i = withInfo t.info in
-    let weight = i (appf2_ (i (var_ "logObserve")) t.dist t.value) in
-    i (appf2_ (i (var_ "updateWeight")) weight (i (var_ "state")))
-  | TmWeight t ->
-    let i = withInfo t.info in
-    i (appf2_ (i (var_ "updateWeight")) t.weight (i (var_ "state")))
-  | t -> t
 
   sem compile: Options -> (Expr,Expr) -> Expr
   sem compile options =

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -143,7 +143,12 @@ lang Infer =
 
   sem smapAccumL_Expr_Expr f acc =
   | TmInfer t ->
-    match inferSmapAccumL_Expr_Expr f acc t.method with (acc,method) in
+    -- NOTE(oerikss, 2024-11-07): We shallow recurse through method expressions
+    -- by default. This is more convenient than requiring each semantic function
+    -- that nees to map/recurse through all expressions in an AST to manually
+    -- call `smapAccumL_InferMethod_Expr`. If you want to avoid this behaviour
+    -- you can instead manually match on `TmInfer` and do something different.
+    match smapAccumL_InferMethod_Expr f acc t.method with (acc,method) in
     match f acc t.model with (acc,model) in
     (acc, TmInfer { t with method = method, model = model })
 
@@ -524,8 +529,13 @@ lang SolveODE =
 
   sem smapAccumL_Expr_Expr f acc =
   | TmSolveODE t ->
+    -- NOTE(oerikss, 2024-11-07): We shallow recurse through method expressions
+    -- by default. This is more convenient than requiring each semantic function
+    -- that nees to map/recurse through all expressions in an AST to manually
+    -- call `smapAccumL_InferMethod_Expr`. If you want to avoid this behaviour
+    -- you can instead manually match on `TmSolve` and do something different.
     match
-      odeSolverMethodSmapAccumL_Expr_Expr f acc t.method with (acc, method)
+      smapAccumL_ODESolverMethod_Expr f acc t.method with (acc, method)
     in
     match f acc t.model with (acc, model) in
     match f acc t.init with (acc, init) in

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -81,6 +81,11 @@ lang Dist = PrettyPrint + Eq + Sym + TypeCheck + ANF + TypeLift +
 
   sem smapAccumL_Expr_Expr f acc =
   | TmDist t ->
+    -- NOTE(oerikss, 2024-11-07): We shallow recurse through dist expressions by
+    -- default. This is more convenient than requiring each semantic function
+    -- that nees to map/recurse through all expressions in an AST to manually
+    -- call `smapAccumL_InferMethod_Expr`. If you want to avoid this behaviour
+    -- you can instead manually match on `TmDist` and do something different.
     match smapAccumL_Dist_Expr f acc t.dist with (acc, dist) in
     (acc, TmDist { t with dist = dist })
 

--- a/coreppl/src/dist.mc
+++ b/coreppl/src/dist.mc
@@ -460,7 +460,7 @@ end
 
 lang WienerDist = Dist
   syn Dist =
-  | DWiener { a : Expr }
+  | DWiener { a : Expr, cps : Bool }
 
   sem smapAccumL_Dist_Expr f acc =
   | DWiener t ->
@@ -522,7 +522,7 @@ let gaussian_ = use GaussianDist in
 let binomial_ = use BinomialDist in
   lam n. lam p. dist_ (DBinomial {n = n, p = p})
 
-let wiener_ = use WienerDist in dist_ (DWiener { a = unit_ })
+let wiener_ = use WienerDist in dist_ (DWiener { cps = false, a = unit_ })
 
 ---------------------------
 -- LANGUAGE COMPOSITIONS --

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -82,18 +82,18 @@ lang InferMethodBase =
   sem setRuns : Expr -> InferMethod -> InferMethod
 
   -- Map/Accum over expressions in inference method
-  sem inferSmapAccumL_Expr_Expr
+  sem smapAccumL_InferMethod_Expr
     : all a. (a -> Expr -> (a, Expr)) -> a -> InferMethod -> (a, InferMethod)
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | Default r ->
     match f acc r.runs with (acc, runs) in (acc, Default {r with runs = runs})
   | m -> printLn (pprintInferMethod 0 pprintEnvEmpty m).1; error "fail"
 
   sem inferSmap_Expr_Expr : (Expr -> Expr) -> InferMethod -> InferMethod
   sem inferSmap_Expr_Expr f =| m ->
-    (inferSmapAccumL_Expr_Expr (lam. lam tm. ((), f tm)) () m).1
+    (smapAccumL_InferMethod_Expr (lam. lam tm. ((), f tm)) () m).1
 
   sem inferSfold_Expr_Expr : all a. (a -> Expr -> a) -> a -> InferMethod -> a
   sem inferSfold_Expr_Expr f acc =| m ->
-    (inferSmapAccumL_Expr_Expr (lam acc. lam tm. (f acc tm, tm)) acc m).0
+    (smapAccumL_InferMethod_Expr (lam acc. lam tm. (f acc tm, tm)) acc m).0
 end

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -89,7 +89,11 @@ lang InferMethodBase =
     match f acc r.runs with (acc, runs) in (acc, Default {r with runs = runs})
   | m -> printLn (pprintInferMethod 0 pprintEnvEmpty m).1; error "fail"
 
-  sem inferSmap_Expr_Expr : all a. (Expr -> Expr) -> InferMethod -> InferMethod
+  sem inferSmap_Expr_Expr : (Expr -> Expr) -> InferMethod -> InferMethod
   sem inferSmap_Expr_Expr f =| m ->
     (inferSmapAccumL_Expr_Expr (lam. lam tm. ((), f tm)) () m).1
+
+  sem inferSfold_Expr_Expr : all a. (a -> Expr -> a) -> a -> InferMethod -> a
+  sem inferSfold_Expr_Expr f acc =| m ->
+    (inferSmapAccumL_Expr_Expr (lam acc. lam tm. (f acc tm, tm)) acc m).0
 end

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -38,7 +38,7 @@ lang ImportanceSamplingMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     Importance {particles = particles}
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | Importance r ->
     match f acc r.particles with (acc, particles) in
     (acc, Importance {r with particles = particles})

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -65,7 +65,7 @@ lang LightweightMCMCMethod = MExprPPL
       globalProb = globalProb
     }
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | LightweightMCMC r ->
     match f acc r.iterations with (acc, iterations) in
     match f acc r.globalProb with (acc, globalProb) in

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -50,7 +50,7 @@ lang NaiveMCMCMethod = MExprPPL
       iterations = iterations
     }
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | NaiveMCMC r ->
     match f acc r.iterations with (acc, iterations) in
     (acc, NaiveMCMC {r with iterations = iterations})

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -50,7 +50,7 @@ lang TraceMCMCMethod = MExprPPL
       iterations = iterations
     }
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | TraceMCMC r ->
     match f acc r.iterations with (acc, iterations) in
     (acc, TraceMCMC {r with iterations = iterations})

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -54,7 +54,7 @@ lang PIMHMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     PIMH {iterations = iterations, particles = particles}
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | PIMH r ->
     match f acc r.iterations with (acc, iterations) in
     match f acc r.particles with (acc, particles) in

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -38,7 +38,7 @@ lang APFMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     APF {particles = particles}
 
-  sem inferSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_InferMethod_Expr f acc =
   | APF r ->
     match f acc r.particles with (acc, particles) in
     (acc, APF {r with particles = particles})

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -38,7 +38,7 @@ lang BPFMethod = MExprPPL
     unify env [info, infoTm particles] int (tyTm particles);
     BPF {particles = particles}
 
-  sem inferSmapAccumL_Expr_Expr env =
+  sem smapAccumL_InferMethod_Expr env =
   | BPF r ->
     match f acc r.particles with (acc, particles) in
     (acc, BPF {r with particles = particles})

--- a/coreppl/src/inference/smc.mc
+++ b/coreppl/src/inference/smc.mc
@@ -103,6 +103,15 @@ lang SMCCommon = MExprPPL + Resample + MExprCPS
     TmLet { t with inexpr = exprCps env k t.inexpr }
   | TmLet ({ body = TmDist _ } & t) ->
     TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmDist (d & { dist = DWiener w })} & t) ->
+    if not (transform env t.ident) then
+      TmLet { t with inexpr = exprCps env k t.inexpr }
+    else
+      TmLet {
+        t with
+        body = TmDist { d with dist = DWiener { w with cps = true }},
+        inexpr = exprCps env k t.inexpr
+      }
   | TmLet { ident = ident, body = TmResample {},
             inexpr = inexpr } & t ->
     let i = withInfo (infoTm t) in

--- a/coreppl/src/ode-solver-method.mc
+++ b/coreppl/src/ode-solver-method.mc
@@ -14,6 +14,7 @@ include "dppl-arg.mc"
 let odeDefault = nameSym "Default"
 let odeRK4 = nameSym "RK4"
 let odeEF = nameSym "EF"
+let odeEFA = nameSym "EFA"
 
 -- Defines the basic components required in the implementation of an ODE solver
 -- method.
@@ -28,6 +29,7 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   | ODESolverDefault MethodArg
   | RK4 MethodArg
   | EF MethodArg
+  | EFA { n : Expr, stepSize : Expr, add : Expr, smul : Expr }
 
   -- Map/Accum over expressions in ODE solver method.
   sem smapAccumL_ODESolverMethod_Expr
@@ -42,6 +44,14 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   | EF r ->
     match _smapAccumL_ODESolverMethod_Expr f acc r with (acc, r) in
     (acc, EF r)
+  | EFA r ->
+    match f acc r.n with (acc, n) in
+    match
+      _smapAccumL_ODESolverMethod_Expr
+        f acc { stepSize = r.stepSize, add = r.add, smul = r.smul }
+      with (acc, rr)
+    in
+    (acc, EFA { n = n, stepSize = rr.stepSize, add = rr.add, smul = rr.smul })
 
   sem _smapAccumL_ODESolverMethod_Expr f acc =| r ->
     match f acc r.stepSize with (acc, stepSize) in
@@ -60,12 +70,14 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   | ODESolverDefault r
   | RK4 r
   | EF r -> optionFoldlM (eqExprH env) free [r.stepSize, r.add, r.smul]
+  | EFA r -> optionFoldlM (eqExprH env) free [r.n, r.stepSize, r.add, r.smul]
 
   sem odeSolverMethodName : ODESolverMethod -> Name
   sem odeSolverMethodName =
   | ODESolverDefault _ -> odeDefault
   | RK4 _ -> odeRK4
   | EF _ -> odeEF
+  | EFA _ -> odeEFA
 
   -- Constructs an ODE solver method as a TmConApp.
   sem odeSolverMethodToCon : Info -> ODESolverMethod -> Expr
@@ -76,18 +88,29 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   sem odeSolverMethodFromCon : Info -> Map SID Expr -> String -> ODESolverMethod
   sem odeSolverMethodFromCon info bindings =
   | "Default" ->
-    ODESolverDefault (_odeSolverMethodFromCon info bindings)
-  | "RK4" -> RK4 (_odeSolverMethodFromCon info bindings)
-  | "EF" -> EF (_odeSolverMethodFromCon info bindings)
+    ODESolverDefault (_odeSolverMethodFromCon1 info bindings)
+  | "RK4" -> RK4 (_odeSolverMethodFromCon1 info bindings)
+  | "EF" -> EF (_odeSolverMethodFromCon1 info bindings)
+  | "EFA" -> EFA (_odeSolverMethodFromCon2 info bindings)
   | s -> errorSingle [info] (concat "Unknown ODE solver method: " s)
 
-  sem _odeSolverMethodFromCon info =| bindings ->
+  sem _odeSolverMethodFromCon1 info =| bindings ->
     match getFields info bindings [
       ("stepSize", withInfo info (float_ 0.05)),
       ("add", withInfo info (uconst_ (CAddf ()))),
       ("smul", withInfo info (uconst_ (CMulf ())))
     ] with [stepSize, add, smul]
     then { stepSize = stepSize, add = add, smul = smul }
+    else error "impossible"
+
+  sem _odeSolverMethodFromCon2 info =| bindings ->
+    match getFields info bindings [
+      ("n", withInfo info (int_ 10)),
+      ("stepSize", withInfo info (float_ 0.05)),
+      ("add", withInfo info (uconst_ (CAddf ()))),
+      ("smul", withInfo info (uconst_ (CMulf ())))
+    ] with [n, stepSize, add, smul]
+    then { n = n, stepSize = stepSize, add = add, smul = smul }
     else error "impossible"
 
   -- Produces a record expression containing the configuration parameters of the
@@ -102,6 +125,12 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
     ("add", r.add),
     ("smul", r.smul)
   ]
+  | EFA r -> fieldsToRecord info [
+    ("n", r.n),
+    ("stepSize", r.stepSize),
+    ("add", r.add),
+    ("smul", r.smul)
+  ]
 
   -- Type checks the ODE solver method. This ensures that the provided arguments
   -- have the correct types.
@@ -112,6 +141,13 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
     ODESolverDefault (_typeCheckODESolverMethod env info tyState r)
   | RK4 r -> RK4 (_typeCheckODESolverMethod env info tyState r)
   | EF r -> EF (_typeCheckODESolverMethod env info tyState r)
+  | EFA r ->
+    let n = typeCheckExpr env r.n in
+    unify env [info, infoTm n] (TyInt {info = info}) (tyTm n);
+    let rr = _typeCheckODESolverMethod env info tyState {
+      stepSize = r.stepSize, add = r.add, smul = r.smul
+    } in
+    EFA { r with n = n, stepSize = rr.stepSize, add = rr.add, smul = rr.smul }
 
   sem _typeCheckODESolverMethod env info tyState =| r ->
     let float = TyFloat {info = info} in
@@ -120,9 +156,9 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
     let add = typeCheckExpr env r.add in
     let smul = typeCheckExpr env r.smul in
     unify env [info, infoTm stepSize] float (tyTm stepSize);
-    unify env [info, infoTm stepSize]
+    unify env [info, infoTm add]
       (arrow tyState (arrow tyState tyState)) (tyTm add);
-    unify env [info, infoTm stepSize]
+    unify env [info, infoTm smul]
       (arrow float (arrow tyState tyState)) (tyTm smul);
     { stepSize = stepSize, add = add, smul = smul }
 end

--- a/coreppl/src/ode-solver-method.mc
+++ b/coreppl/src/ode-solver-method.mc
@@ -30,20 +30,20 @@ lang ODESolverMethod = PrettyPrint + TypeCheck + Sym + Eq + MethodHelper
   | EF MethodArg
 
   -- Map/Accum over expressions in ODE solver method.
-  sem odeSolverMethodSmapAccumL_Expr_Expr
+  sem smapAccumL_ODESolverMethod_Expr
     : all a. (a -> Expr -> (a, Expr)) -> a -> ODESolverMethod -> (a, ODESolverMethod)
-  sem odeSolverMethodSmapAccumL_Expr_Expr f acc =
+  sem smapAccumL_ODESolverMethod_Expr f acc =
   | ODESolverDefault r ->
-    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    match _smapAccumL_ODESolverMethod_Expr f acc r with (acc, r) in
     (acc, ODESolverDefault r)
   | RK4 r ->
-    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    match _smapAccumL_ODESolverMethod_Expr f acc r with (acc, r) in
     (acc, RK4 r)
   | EF r ->
-    match _odeSolverMethodSmapAccumL_Expr_Expr f acc r with (acc, r) in
+    match _smapAccumL_ODESolverMethod_Expr f acc r with (acc, r) in
     (acc, EF r)
 
-  sem _odeSolverMethodSmapAccumL_Expr_Expr f acc =| r ->
+  sem _smapAccumL_ODESolverMethod_Expr f acc =| r ->
     match f acc r.stepSize with (acc, stepSize) in
     match f acc r.add with (acc, add) in
     match f acc r.smul with (acc, smul) in

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -171,7 +171,7 @@ lang DPPLParser =
   | "Binomial" -> Some (2, lam lst. TmDist {dist = DBinomial {n = get lst 0, p = get lst 1},
                                         ty = TyUnknown {info = info},
                                         info = info})
-  | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {a = get lst 0},
+  | "Wiener" -> Some (1, lam lst. TmDist {dist = DWiener {cps = false, a = get lst 0},
                                        ty = TyUnknown {info = info},
                                        info = info})
   | "solveode" -> Some (4, lam lst. TmSolveODE {method = interpretODESolverMethod (get lst 0),


### PR DESCRIPTION
This PR is a collection of refactoring, renamings, and bugfixes. In summary, the minor changes are the following:
- Renaming to make names consistent.
- Make sure that the AST after lifting to dual numbers has correct type annotations.
- Adding a fast but unsafe Wiener process implementation for testing purposes.
- Adding a preliminary new averaged Euler integration method.
- Factoring out common code for the SMC inference methods into their common fragment.

A major bug fix addresses the issue that sampling from CPS transformed primitive distributions where the sample type of function type (e.g., the Wiener distribution) was incorrect. These samples would previously always be non-CPS. This PR changes this so that the relevant distribution keeps track of whether it should return samples in direct or CPS style.

This PR also fixes a bug, where the variance of a time-step was incorrect, in the Wiener runtime implementation.
