### PR TITLE
.editorconfig should follow EditorConfig spec regarding inline comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,14 @@ root = true
 
 # Default rules
 [*]
-end_of_line = lf                # Use Unix line endings
+# Use Unix line endings
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 80            # A line should not have more than this amount
-                                # of chars (not supported by all plugins)
+# A line should not have more than this amount
+# of chars (not supported by all plugins)
+max_line_length = 80
 
 [*.mc]
 indent_style = space


### PR DESCRIPTION
## This is the same change as in Miking PR [#905](https://github.com/miking-lang/miking/pull/905).

The EditorConfig spec does not include inline comments since version 0.15.0.

See the relevant part of the spec [here](https://spec.editorconfig.org/#no-inline-comments).