### PR TITLE
More flexible mcmc lightweight config

### DIFF
--- a/coreppl/models/infer-test.mc
+++ b/coreppl/models/infer-test.mc
@@ -57,7 +57,7 @@ printDist dist;
 let dist = infer (APF {particles = p}) (lam. model alpha beta) in
 printDist dist;
 
-let dist = infer (LightweightMCMC {iterations = p}) (lam. model alpha beta) in
+let dist = infer (LightweightMCMC {countinue = (p, lam x. lam. (subi x 1, geqi x 0))}) (lam. model alpha beta) in
 printDist dist;
 
 let dist = infer (NaiveMCMC {iterations = p}) (lam. model alpha beta) in

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -90,7 +90,7 @@ lang DPPLExtract =
         inexpr = TmApp {
           lhs = TmApp {
             lhs = nvar_ runId,
-            rhs = withType (inferMethodConfigType t.info t.method) (inferMethodConfig t.info t.method),
+            rhs = inferMethodConfig t.info t.method,
             ty = tyunknown_,
             info = t.info},
           rhs = TmVar {ident = inferId, ty = t.ty, info = info, frozen = false},

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
@@ -20,7 +20,7 @@ type State = {
 
   -- The weight of the current execution
   weight: Ref Float,
-  -- 
+  --
   driftPrevValue: Ref (Any, Float),
   -- The Hasting ratio for the driftKernel call
   driftHastingRatio: Ref Float,
@@ -91,7 +91,7 @@ let newSample: all a. use RuntimeDistBase in Dist a -> (Any,Float) = lam dist.
 -- - we have access here to the driftScale parameter compileOptions.driftScale
 -- - modeled on reuseSample
 -- Call one time per run
-let moveSample: all a. use RuntimeDistBase in Dist a -> (Any, Float) = 
+let moveSample: all a. use RuntimeDistBase in Dist a -> (Any, Float) =
   lam dist.
   use RuntimeDistElementary in
 
@@ -227,14 +227,11 @@ let modTrace: Unknown -> () = lam config.
 let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
   lam config. lam model.
 
-  recursive let mh : [Float] -> [a] -> Int -> ([Float], [a]) =
-    lam weights. lam samples. lam iter.
-      if leqi iter 0 then (weights, samples)
-      else
+  recursive let mh : [a] -> Float -> (Unknown, Bool) -> Int -> [a] =
+    lam samples. lam prevWeight. lam continueState. lam iter.
+      match continueState with (continueState, true) then
         let prevAlignedTrace = deref state.alignedTrace in
         let prevUnalignedTraces = deref state.unalignedTraces in
-        let prevSample = head samples in
-        let prevWeight = head weights in
         modTrace config;
         modref state.weight 0.;
         modref state.driftHastingRatio 0.;
@@ -253,7 +250,7 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
         let weightReused = deref state.weightReused in
         let prevWeightReused = deref state.prevWeightReused in
         let logMhAcceptProb =
-          minf 0. (addf 
+          minf 0. (addf
                     (addf
                       (subf weight prevWeight)
                       (subf weightReused prevWeightReused))
@@ -265,51 +262,42 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
         -- print "weightReused: "; printLn (float2string (exp weightReused));
         -- print "prevWeightReused: "; printLn (float2string (exp prevWeightReused));
         -- printLn "-----";
-        let iter = subi iter 1 in
-        if bernoulliSample (exp logMhAcceptProb) then
-          mcmcAccept ();
-          mh
-            (cons weight weights)
-            (cons sample samples)
-            iter
-        else
-          -- NOTE(dlunde,2022-10-06): VERY IMPORTANT: Restore previous traces
-          -- as we reject and reuse the old sample.
-          modref state.alignedTrace prevAlignedTrace;
-          modref state.unalignedTraces prevUnalignedTraces;
-          mh
-            (cons prevWeight weights)
-            (cons prevSample samples)
-            iter
+        match
+          if bernoulliSample (exp logMhAcceptProb) then
+            mcmcAccept ();
+            (weight, sample)
+          else
+            -- NOTE(dlunde,2022-10-06): VERY IMPORTANT: Restore previous traces
+            -- as we reject and reuse the old sample.
+            modref state.alignedTrace prevAlignedTrace;
+            modref state.unalignedTraces prevUnalignedTraces;
+            (prevWeight, prevSample)
+        with (weight, sample) in
+        let samples = if config.keepSample iter then snoc samples sample else samples in
+        mh samples weight sample (config.continue.1 continueState sample) (addi iter 1)
+      else samples
   in
 
-  let runs = config.iterations in
-
   -- Used to keep track of acceptance ratio
-  mcmcAcceptInit runs;
+  mcmcAcceptInit ();
 
   -- First sample
   let sample = model state in
-  -- NOTE(dlunde,2022-08-22): Are the weights really meaningful beyond
-  -- computing the MH acceptance ratio?
   let weight = deref state.weight in
-  let iter = subi runs 1 in
 
   -- Set aligned trace length (a constant, only modified here)
   modref state.alignedTraceLength (length (deref state.alignedTrace));
 
-  -- Sample the rest
-  let res = mh [weight] [sample] iter in
+  let iter = 0 in
+  let samples = if config.keepSample iter then [sample] else [] in
 
-  -- Reverse to get the correct order
-  let res = match res with (weights,samples) in
-    (reverse weights, reverse samples)
-  in
+  -- Sample the rest
+  let samples = mh samples weight (config.continue.1 config.continue.0 sample) (addi iter 1) in
 
   -- printLn (join ["Number of reused aligned samples:", int2string (deref countReuse)]);
   -- printLn (join ["Number of reused unaligned samples:", int2string (deref countReuseUnaligned)]);
   -- Return
+  let numSamples = length samples in
   use RuntimeDist in
-  constructDistEmpirical res.1 (create runs (lam. 1.))
-    (EmpMCMC { acceptRate = mcmcAcceptRate () })
-
+  constructDistEmpirical samples (make numSamples 1.0)
+    (EmpMCMC {acceptRate = mcmcAcceptRate numSamples})

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/runtime.mc
@@ -40,7 +40,7 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
   let runs = config.iterations in
 
   -- Used to keep track of acceptance ratio
-  mcmcAcceptInit runs;
+  mcmcAcceptInit ();
 
   -- Draw an initial sample first
   let state = ref 0. in
@@ -58,4 +58,4 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
 
   -- Return
   constructDistEmpirical res.1 (create runs (lam. 1.))
-    (EmpMCMC { acceptRate = mcmcAcceptRate () })
+    (EmpMCMC { acceptRate = mcmcAcceptRate runs })

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/runtime.mc
@@ -104,7 +104,7 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
     let runs = config.iterations in
 
     -- Used to keep track of acceptance ratio
-    mcmcAcceptInit runs;
+    mcmcAcceptInit ();
 
     -- First sample
     let sample = model state in
@@ -122,4 +122,4 @@ let run : all a. Unknown -> (State -> a) -> use RuntimeDistBase in Dist a =
   -- Return
   constructDistEmpirical res.1 (create runs (lam. 1.))
     -- TODO(dlunde,2022-10-20): Add normconst
-    (EmpMCMC { acceptRate = mcmcAcceptRate () })
+    (EmpMCMC { acceptRate = mcmcAcceptRate runs })

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/runtime.mc
@@ -140,7 +140,7 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
   let runs = config.iterations in
 
   -- Used to keep track of acceptance ratio
-  mcmcAcceptInit runs;
+  mcmcAcceptInit ();
 
   -- Initial sample
   match runSMC () with (weights, samples) in
@@ -171,4 +171,4 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
 
   -- Return
   constructDistEmpirical samples weights
-    (EmpMCMC { acceptRate = mcmcAcceptRate () })
+    (EmpMCMC { acceptRate = mcmcAcceptRate runs })

--- a/coreppl/src/coreppl-to-mexpr/runtime-common.mc
+++ b/coreppl/src/coreppl-to-mexpr/runtime-common.mc
@@ -157,11 +157,11 @@ let printSamplesOption : all a. (a -> String) -> [Float] -> [Option a] -> () =
 
 -- MCMC acceptance rate
 let _mcmcAccepts = ref 0
-let _mcmcSamples = ref (negi 1)
-let mcmcAcceptInit = lam n. modref _mcmcSamples n; modref _mcmcAccepts 0
+let mcmcAcceptInit = lam. modref _mcmcAccepts 0
 let mcmcAccept = lam. modref _mcmcAccepts (addi (deref _mcmcAccepts) 1)
-let mcmcAcceptRate = lam.
-  divf (int2float (deref _mcmcAccepts)) (int2float (deref _mcmcSamples))
+let mcmcAcceptRate = lam numSamples.
+  divf (int2float (deref _mcmcAccepts)) (int2float numSamples)
+
 
 let seqToStr = lam elToStr. lam seq.
   join ["[", strJoin "," (map elToStr seq), "]"]

--- a/coreppl/src/coreppl.mc
+++ b/coreppl/src/coreppl.mc
@@ -177,10 +177,10 @@ lang Infer =
   sem typeCheckExpr (env : TCEnv) =
   | TmInfer t ->
     let model = typeCheckExpr env t.model in
-    let method = typeCheckInferMethod env t.info t.method in
     let tyRes = newvar env.currentLvl t.info in
     unify env [infoTm model]
       (ityarrow_ t.info (tyWithInfo t.info tyunit_) tyRes) (tyTm model);
+    let method = typeCheckInferMethod env t.info tyRes t.method in
     TmInfer { t with model = model, method = method,
                      ty = TyDist {info = t.info, ty = tyRes} }
 

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -66,8 +66,8 @@ lang InferMethodBase =
   -- Produces the expected type of `inferMethodConfig`
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
-  sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod : TCEnv -> Info -> Type -> InferMethod -> InferMethod
+  sem typeCheckInferMethod env info sampleType =
   | Default { runs = runs } ->
     let int = TyInt {info = info} in
     let runs = typeCheckExpr env runs in

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -64,10 +64,6 @@ lang InferMethodBase =
   | Default { runs = runs } -> fieldsToRecord info [("runs", runs)]
 
   -- Produces the expected type of `inferMethodConfig`
-  sem inferMethodConfigType : Info -> InferMethod -> Type
-  sem inferMethodConfigType info =
-  | Default _ -> tyRecord info [("runs", ityint_ info)]
-
   -- Type checks the inference method. This ensures that the provided arguments
   -- have the correct types.
   sem typeCheckInferMethod : TCEnv -> Info -> InferMethod -> InferMethod

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -27,10 +27,6 @@ lang ImportanceSamplingMethod = MExprPPL
   | Importance {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem inferMethodConfigType info =
-  | Importance _ ->
-    tyRecord info [("particles", ityint_ info)]
-
   sem typeCheckInferMethod env info =
   | Importance {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/is-lw.mc
+++ b/coreppl/src/inference/is-lw.mc
@@ -27,7 +27,7 @@ lang ImportanceSamplingMethod = MExprPPL
   | Importance {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | Importance {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -4,28 +4,38 @@ include "../dppl-arg.mc"
 lang LightweightMCMCMethod = MExprPPL
   syn InferMethod =
   | LightweightMCMC {
-      iterations : Expr, -- Type Int
+      keepSample : Expr, -- Type (Int -> Bool)
+      continue : Expr, -- Type (a, a -> r -> (a, Bool)) for some 'a'
       globalProb : Expr -- Type Float (range 0 to 1)
     }
 
   sem pprintInferMethod indent env =
   | LightweightMCMC t ->
     let i = pprintIncr indent in
-    match pprintCode i env t.iterations with (env, iterations) in
+    match pprintCode i env t.keepSample with (env, keepSample) in
+    match pprintCode i env t.continue with (env, continue) in
     match pprintCode i env t.globalProb with (env, globalProb) in
-    (env, join ["(LightweightMCMC {iterations = ", iterations,
-                "globalProb =", globalProb, "})"])
+    (env, join ["(LightweightMCMC {keepSample = ", keepSample,
+                ", continue = ", continue,
+                ", globalProb = ", globalProb, "})"])
 
   sem inferMethodFromCon info bindings =
   | "LightweightMCMC" ->
-    let expectedFields = [
-      ("iterations", int_ defaultArgs.particles),
-      ("globalProb", float_ defaultArgs.mcmcLightweightGlobalProb)
-    ] in
+    let expectedFields =
+      [ ( "continue"
+        , utuple_
+          [ int_ defaultArgs.particles
+          , ulam_ "remaining"
+            (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+          ]
+        )
+      , ("keepSample", ulam_ "" true_)
+      , ("globalProb", float_ defaultArgs.mcmcLightweightGlobalProb)
+      ] in
     match getFields info bindings expectedFields
-    with [iterations, globalProb] in
+    with [continue, keepSample, globalProb] in
     LightweightMCMC {
-      iterations = iterations, globalProb = globalProb
+      continue = continue, keepSample = keepSample, globalProb = globalProb
     }
 
   sem inferMethodFromOptions options =
@@ -33,38 +43,56 @@ lang LightweightMCMCMethod = MExprPPL
     LightweightMCMC {
       -- Reusing particles option for now for iterations, maybe we need a
       -- better name
-      iterations = int_ options.particles,
+      continue = utuple_
+        [ int_ defaultArgs.particles
+        , ulam_ "remaining"
+          (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+        ],
+      keepSample = ulam_ "" true_,
       globalProb = float_ options.mcmcLightweightGlobalProb
     }
 
   sem inferMethodConfig info =
   | LightweightMCMC t ->
     fieldsToRecord info [
-      ("iterations", t.iterations),
+      ("continue", t.continue),
+      ("keepSample", t.keepSample),
       ("globalProb", t.globalProb)
     ]
 
   sem typeCheckInferMethod env info sampleType =
   | LightweightMCMC t ->
-    let int = TyInt {info = info} in
     let bool = TyBool {info = info} in
     let float = TyFloat {info = info} in
-    let iterations = typeCheckExpr env t.iterations in
-    unify env [info, infoTm iterations] int (tyTm iterations);
+    let continueState = newmonovar env.currentLvl info in
+    let continue = typeCheckExpr env t.continue in
+    let continueType = tytuple_
+      [ continueState
+      , tyarrows_ [continueState, sampleType, tytuple_ [continueState, bool]]
+      ] in
+    unify env [info, infoTm continue] continueType (tyTm continue);
+    let keepSample = typeCheckExpr env t.keepSample in
+    unify env [info, infoTm keepSample] (tyarrow_ tyint_ bool) (tyTm keepSample);
     let globalProb = typeCheckExpr env t.globalProb in
     unify env [info, infoTm globalProb] float (tyTm globalProb);
     LightweightMCMC {
-      iterations = iterations,
+      continue = continue,
+      keepSample = keepSample,
       globalProb = globalProb
     }
 
   sem smapAccumL_InferMethod_Expr f acc =
   | LightweightMCMC r ->
-    match f acc r.iterations with (acc, iterations) in
+    match f acc r.continue with (acc, continue) in
+    match f acc r.keepSample with (acc, keepSample) in
     match f acc r.globalProb with (acc, globalProb) in
     (acc,
-     LightweightMCMC {r with iterations = iterations, globalProb = globalProb})
+     LightweightMCMC {r with continue = continue, keepSample = keepSample, globalProb = globalProb})
 
   sem setRuns expr =
-  | LightweightMCMC r -> LightweightMCMC {r with iterations = expr}
+  | LightweightMCMC r -> LightweightMCMC {r with continue = utuple_
+    [ expr
+    , ulam_ "remaining"
+      (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+    ] }
 end

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -44,13 +44,6 @@ lang LightweightMCMCMethod = MExprPPL
       ("globalProb", t.globalProb)
     ]
 
-  sem inferMethodConfigType info =
-  | LightweightMCMC _ ->
-    tyRecord info [
-      ("iterations", ityint_ info),
-      ("globalProb", ityfloat_ info)
-    ]
-
   sem typeCheckInferMethod env info =
   | LightweightMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -44,7 +44,7 @@ lang LightweightMCMCMethod = MExprPPL
       ("globalProb", t.globalProb)
     ]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | LightweightMCMC t ->
     let int = TyInt {info = info} in
     let bool = TyBool {info = info} in

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -25,8 +25,8 @@ lang LightweightMCMCMethod = MExprPPL
       [ ( "continue"
         , utuple_
           [ int_ defaultArgs.particles
-          , ulam_ "remaining"
-            (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+          , ulam_ "remaining" (ulam_ ""
+            (utuple_ [subi_ (var_ "remaining") (int_ 1), neqi_ (var_ "remaining") (int_ 0)]))
           ]
         )
       , ("keepSample", ulam_ "" true_)
@@ -45,8 +45,8 @@ lang LightweightMCMCMethod = MExprPPL
       -- better name
       continue = utuple_
         [ int_ defaultArgs.particles
-        , ulam_ "remaining"
-          (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+        , ulam_ "remaining" (ulam_ ""
+          (utuple_ [subi_ (var_ "remaining") (int_ 1), neqi_ (var_ "remaining") (int_ 0)]))
         ],
       keepSample = ulam_ "" true_,
       globalProb = float_ options.mcmcLightweightGlobalProb
@@ -92,7 +92,7 @@ lang LightweightMCMCMethod = MExprPPL
   sem setRuns expr =
   | LightweightMCMC r -> LightweightMCMC {r with continue = utuple_
     [ expr
-    , ulam_ "remaining"
-      (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])
+    , ulam_ "remaining" (ulam_ ""
+      (utuple_ [subi_ (var_ "remaining") (int_ 1), neqi_ (var_ "remaining") (int_ 0)]))
     ] }
 end

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -35,7 +35,7 @@ lang NaiveMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | NaiveMCMC t ->
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env t.iterations in

--- a/coreppl/src/inference/mcmc-naive.mc
+++ b/coreppl/src/inference/mcmc-naive.mc
@@ -35,12 +35,6 @@ lang NaiveMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
-  sem inferMethodConfigType info =
-  | NaiveMCMC _ ->
-    tyRecord info [
-      ("iterations", ityint_ info)
-    ]
-
   sem typeCheckInferMethod env info =
   | NaiveMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -35,7 +35,7 @@ lang TraceMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | TraceMCMC t ->
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env t.iterations in

--- a/coreppl/src/inference/mcmc-trace.mc
+++ b/coreppl/src/inference/mcmc-trace.mc
@@ -35,12 +35,6 @@ lang TraceMCMCMethod = MExprPPL
       ("iterations", t.iterations)
     ]
 
-  sem inferMethodConfigType info =
-  | TraceMCMC _ ->
-    tyRecord info [
-      ("iterations", ityint_ info)
-    ]
-
   sem typeCheckInferMethod env info =
   | TraceMCMC t ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -38,13 +38,6 @@ lang PIMHMethod = MExprPPL
   | PIMH {iterations = iterations, particles = particles} ->
     fieldsToRecord info [("iterations",iterations), ("particles", particles)]
 
-  sem inferMethodConfigType info =
-  | PIMH _ ->
-    tyRecord info [
-      ("iterations", ityint_ info),
-      ("particles", ityint_ info)
-    ]
-
   sem typeCheckInferMethod env info =
   | PIMH {iterations = iterations, particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/pmcmc-pimh.mc
+++ b/coreppl/src/inference/pmcmc-pimh.mc
@@ -38,7 +38,7 @@ lang PIMHMethod = MExprPPL
   | PIMH {iterations = iterations, particles = particles} ->
     fieldsToRecord info [("iterations",iterations), ("particles", particles)]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | PIMH {iterations = iterations, particles = particles} ->
     let int = TyInt {info = info} in
     let iterations = typeCheckExpr env iterations in

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -27,7 +27,7 @@ lang APFMethod = MExprPPL
   | APF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | APF {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -27,10 +27,6 @@ lang APFMethod = MExprPPL
   | APF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem inferMethodConfigType info =
-  | APF _ ->
-    tyRecord info [("particles", ityint_ info)]
-
   sem typeCheckInferMethod env info =
   | APF {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -27,10 +27,6 @@ lang BPFMethod = MExprPPL
   | BPF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem inferMethodConfigType info =
-  | BPF _ ->
-    tyRecord info [("particles", ityint_ info)]
-
   sem typeCheckInferMethod env info =
   | BPF {particles = particles} ->
     let int = TyInt {info = info} in

--- a/coreppl/src/inference/smc-bpf.mc
+++ b/coreppl/src/inference/smc-bpf.mc
@@ -27,7 +27,7 @@ lang BPFMethod = MExprPPL
   | BPF {particles = particles} ->
     fieldsToRecord info [("particles", particles)]
 
-  sem typeCheckInferMethod env info =
+  sem typeCheckInferMethod env info sampleType =
   | BPF {particles = particles} ->
     let int = TyInt {info = info} in
     let particles = typeCheckExpr env particles in

--- a/coreppl/src/method-helper.mc
+++ b/coreppl/src/method-helper.mc
@@ -1,5 +1,6 @@
 include "mexpr/info.mc"
 include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
 include "error.mc"
 include "seq.mc"
 include "set.mc"
@@ -48,10 +49,6 @@ lang MethodHelper = MExprAst
   -- Converts the provided sequence of string-expression tuples to a record
   -- expression, which is later passed to the runtime.
   sem fieldsToRecord : Info -> [(String, Expr)] -> Expr
-  sem fieldsToRecord info =
-  | fields ->
-    let bindings =
-      mapFromSeq cmpSID
-        (map (lam f. match f with (str, e) in (stringToSid str, e)) fields) in
-    TmRecord {bindings = bindings, ty = TyUnknown {info = info}, info = info}
+  sem fieldsToRecord info = | fields ->
+    withInfo info (autoty_record_ fields)
 end

--- a/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
+++ b/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
@@ -39,7 +39,7 @@ let d = infer (NaiveMCMC { iterations = 1000 }) model1 in
 utest expectation d with expected using eqfApprox 1e-1 in
 
 let d =
-  infer (LightweightMCMC { iterations = 100000, globalProb = 0.1 }) model1
+  infer (LightweightMCMC { continue = (100000, lam x. lam. (subi x 1, neqi x 0)), globalProb = 0.1 }) model1
 in
 utest expectation d with expected using eqfApprox 1e-1 in
 
@@ -62,9 +62,9 @@ let d = infer (NaiveMCMC { iterations = 1 }) model2 in
 utest expectation d with expected in
 
 let d =
-  infer (LightweightMCMC { iterations = 1, globalProb = 0.1 }) model2
+  infer (LightweightMCMC { continue = (1, lam x. lam. (subi x 1, neqi x 0)), globalProb = 0.1 }) model2
 in
-utest expectation d with expected in
+utest expectation d with expected using eqfApprox 1e-1 in
 
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/clads.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/clads.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 10000 }) model))                        with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/coin-iter.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/coin-iter.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/coin.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/coin.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/crbd.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/crbd.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 10000 }) model))                        with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 10000 }) model))                        with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-confusion.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-confusion.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-demo.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-demo.mc
@@ -10,5 +10,5 @@ infer (APF { particles = 10 }) model;
 infer (PIMH { particles = 10, iterations = 10 }) model;
 infer (TraceMCMC { iterations = 10 }) model;
 infer (NaiveMCMC { iterations = 10 }) model;
-infer (LightweightMCMC { iterations = 10, globalProb = 0.1 }) model;
+infer (LightweightMCMC { continue = (10, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model;
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/lda.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/lda.mc
@@ -31,6 +31,6 @@ utest r (c 500 (infer (NaiveMCMC { iterations = 50000 }) model))            with
 
 -- We need to increase the global step probability. Otherwise, lightweight MCMC
 -- easily gets stuck in a single mode.
-utest r (c 500 (infer (LightweightMCMC { iterations = 50000, globalProb = 0.7 }) model))  with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (50000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.7 }) model))  with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/ode-harmonic.mc
@@ -37,7 +37,7 @@ with rhs using e in
 utest r (c 0 (infer (NaiveMCMC { iterations = 1 }) _model))
 with rhs using e in
 utest r (c 0
-  (infer (LightweightMCMC { iterations = 1, globalProb = 0.1 }) _model))
+  (infer (LightweightMCMC { continue = (1, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) _model))
 with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/sprinkler.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/sprinkler.mc
@@ -23,6 +23,6 @@ utest r (c 0 (infer (APF { particles = 1000 }) model))                          
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))                                with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                                          with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                                          with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 2000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (2000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()

--- a/coreppl/test/coreppl-to-mexpr/infer/ssm.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/ssm.mc
@@ -23,6 +23,6 @@ utest r (c 0   (infer (APF { particles = 1000 }) model))                        
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))                                with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                                          with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                                          with rhs using e in
-utest r (c 500 (infer (LightweightMCMC { iterations = 1000, globalProb = 0.1 }) model)) with rhs using e in
+utest r (c 500 (infer (LightweightMCMC { continue = (1000, lam x. lam. (subi x 1, geqi x 0)), globalProb = 0.1 }) model)) with rhs using e in
 
 ()


### PR DESCRIPTION
This PR changes how `LightweightMCMC` is configured to make it more flexible. The configuration now takes two functions, `keepSample` and `continue`, which can be used to implement thinning and more arbitrary stopping criteria.

- `keepSample : Int -> Bool` is called once per iteration and gets the number of prior iterations. Returning `true` keeps the sample in the returned distribution, `false` discards it.
- `continue : (a, a -> r -> (a, Bool))`, where `r` is the return type of the model, is also called once per iteration, and a `false` return stops the inference, producing no new samples. The `a` type is arbitrary and intended for an accumulator, e.g., a sample count or data needed for computing some convergence criteria. 