### PR TITLE
Debug callback mcmc lightweight

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/config.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/config.mc
@@ -1,0 +1,15 @@
+-- NOTE(vipa, 2025-04-15): The contents of this file must be kept in
+-- sync with typeCheckInferMethod and inferMethodConfig of
+-- "inference/mcmc-lightweight.mc"
+
+type DebugInfo =
+  { accepted : Bool
+  }
+
+type Config a acc dAcc =
+  { continue : (acc, acc -> a -> (acc, Bool))
+  , keepSample : Int -> Bool
+  , debug : (dAcc, dAcc -> DebugInfo -> dAcc)
+  , globalProb : Float
+  , driftKernel : Bool
+  }


### PR DESCRIPTION
Includes #198 until it is merged.

This PR adds an additional function in the configuration for mcmc lightweight: `debug : (a, a -> DebugInfo -> a)` (for some arbitrary `a`, and with `DebugInfo` defined in the runtime for mcmc lightweight), which is called once per iteration. This is useful to get insight into the running inference, but does not actually affect inference; the produced `a` is only used to give state to the next call of `debug`, which happens after the next iteration.