### PR TITLE
Debug alignment mcmc lightweight

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
@@ -24,6 +24,7 @@ lang MExprPPLLightweightMCMC
   = MExprPPL + Resample + TransformDist + MExprCPS + MExprANFAll
   + MExprPPLCFA + MExprArity + PhaseStats + InferenceInterface
   + AutoDriftKernel + LightweightMCMCMethod
+  + AnnotateAlignmentResult + AnnotateSources + HtmlAnnotator
 
   -------------------------
   -- STATIC ALIGNED MCMC --
@@ -38,6 +39,10 @@ lang MExprPPLLightweightMCMC
     -- Alignment analysis
     let alignRes = alignCfa t in
     let unalignedNames: Set Name = extractUnaligned alignRes in
+
+    (match config.debugAlignment with Some path then
+      writeFile path (annotateAndReadSources (annotateAlignmentResult (extractGraphData alignRes) t))
+     else ());
 
     -- Transform distributions to MExpr distributions
     let t = mapPre_Expr_Expr (transformTmDist x.dists) t in
@@ -425,6 +430,10 @@ lang MExprPPLLightweightMCMC
     -- Alignment analysis
     let alignRes = alignCfa t in
     let unalignedNames: Set Name = extractUnaligned alignRes in
+
+    (match config.debugAlignment with Some path then
+      writeFile path (annotateAndReadSources (annotateAlignmentResult (extractGraphData alignRes) t))
+     else ());
 
     -- printLn ""; printLn "--- UNALIGNED NAMES ---";
     -- match mapAccumL pprintEnvGetStr env (setToSeq unalignedNames) with (env,strings) in

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -13,6 +13,11 @@ let _align : OptParser Bool = optMap (xor _alignDefault) (optFlag
   { optFlagDef with long = "align"
   , description = "Whether or not to align the model for certain inference algorithms."
   })
+let _debugAlignment : OptParser (Option String) = optOptional (optArg
+  { optArgDefString with long = "debug-alignment-html"
+  , description = "Output an interactive .html file showing alignment results to the given file."
+  , arg = "FILE"
+  })
 let _cpsDefault : String = "full"
 let _cps : OptParser String =
   let opt = optArg


### PR DESCRIPTION
Includes #200 until it is merged.

This PR adds a flag, currently only for `mcmc-lightweight`, that outputs the result of the alignment analysis to an interactive html file, using `annotate.mc`. It's placed inside an inference method because the alignment analysis is run only inside inference methods that make use of it, even though we could conceptually ask for alignment information for any program, whether it's used by the inference or not.