### PR TITLE
Sync with more efficient runtime

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
@@ -4,7 +4,6 @@ lang PruneGraph
   syn PruneVar =
   | PruneRVar { dist: [Float]
               , likelihood: Ref ([Float])
-              , incomingMessages: Ref [[Float]]
               , states: [Int]
               , lastWeight: Ref Float
               }
@@ -21,14 +20,6 @@ lang PruneGraph
   | PrunedValue PruneVar
   | IntValue Int
 
-  sem getIncomingMsgs: PruneVar -> [[Float]]
-  sem getIncomingMsgs =
-  | PruneRVar v -> deref v.incomingMessages
-
-  sem addMsgToPruneVar: [Float] -> PruneVar -> ()
-  sem addMsgToPruneVar msg =
-  | PruneRVar v -> modref v.incomingMessages (cons msg (deref v.incomingMessages))
-
  sem getLikelihood =
   | PruneRVar v  -> deref v.likelihood
 
@@ -40,7 +31,6 @@ lang PruneGraph
   sem zip x =
   | y -> mapi (lam i. lam e. (get x i, e)) y
 
-
 end
 
 lang PrunedSampling = PruneGraph
@@ -49,7 +39,6 @@ lang PrunedSampling = PruneGraph
   sem initializePruneRVar =
   | d -> PruneRVar { dist = d
                    , likelihood = ref ((make (length d) 1.))
-                   , incomingMessages = ref []
                    , states = range 0 (length d) 1
                    , lastWeight = ref 0.}
 
@@ -72,19 +61,18 @@ lang PrunedSampling = PruneGraph
   | (PruneFParam (PruneFVar v)) & d ->
     let likelihood = calculateObservedLH d value in
     let msg = calculateMsg cancel likelihood (PruneFVar v) in
-    addMsgToPruneVar msg v.input;
-    weightPrune v.input
+    weightPrune msg v.input
 
-  sem calculateLogWeight =
-  | PruneRVar p -> match deref p.incomingMessages with msgs in
-    let msgMul = foldl (lam acc. lam m. map (lam m. mulf m.0 m.1) (zip acc m)) (head msgs) (tail msgs) in
+  sem calculateLogWeight msg =
+  | PruneRVar p -> 
+    let msgMul = map (lam m. mulf m.0 m.1) (zip (deref p.likelihood) msg) in
     modref p.likelihood (msgMul);
     let w = foldl (lam acc. lam x. addf acc (mulf x.0 x.1)) 0. (zip msgMul p.dist) in log w
 
-  sem weightPrune =
+  sem weightPrune msg =
   | PruneRVar p ->
     let uw = (negf (deref p.lastWeight)) in
-    let w = (calculateLogWeight (PruneRVar p)) in
+    let w = (calculateLogWeight msg (PruneRVar p)) in
     modref p.lastWeight w;
     addf uw w
 


### PR DESCRIPTION
This PR makes the likelihood calculation more efficient by accumulating 'incomingMessages' instead of multiplying them at each observe point for a pruned variable.