### PR TITLE
Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ out.mc
 out.cu
 a.out
 tool
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ install-coreppl: build/${CPPL_NAME}
 	@echo 'export PATH=$$PATH:'"${BIN_PATH}"
 	@echo 'export MCORE_LIBS=$$MCORE_LIBS:coreppl='"${SRC_PATH}\n${RESET}"
 
+.PHONY: install-cppl
+install-cppl:
+	mkdir -p ${BIN_PATH}
+	cp build/${CPPL_NAME} ${BIN_PATH}/${EXEC_NAME}
+
 .PHONY: uninstall-coreppl
 uninstall-coreppl:
 	rm -f ${BIN_PATH}/${EXEC_NAME}

--- a/misc/direnv/nix.direnv
+++ b/misc/direnv/nix.direnv
@@ -1,0 +1,20 @@
+use flake ./misc/packaging/
+
+
+### For development against a local copy of miking ###
+
+if [ -d ../miking ]; then
+    echo "Found a local miking repository, using it:" $(expand_path ../miking)
+    # Add a locally built mi to the path
+    PATH_add ../miking/build
+    # Overwrite MCORE_LIBS to point only at the locally installed things
+    export MCORE_LIBS="stdlib=$(expand_path ../miking/src/stdlib/)"
+    # Add boot location to OCAMLPATH
+    path_add OCAMLPATH ../miking/build/lib
+fi
+
+
+### For development of CorePPL ###
+
+# Add the coreppl src location
+export MCORE_LIBS="${MCORE_LIBS-}${MCORE_LIBS:+:}coreppl=$(expand_path ./coreppl/src)"

--- a/misc/packaging/flake.lock
+++ b/misc/packaging/flake.lock
@@ -1,0 +1,133 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "miking": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "dir": "misc/packaging",
+        "lastModified": 1749648960,
+        "narHash": "sha256-PHZvE/e9MOdJVPwXtPnIR1w0e3ZywXyj0omRyKb+IKk=",
+        "owner": "elegios",
+        "repo": "miking",
+        "rev": "5c7e440e2c95721628e5864638f38ce11b7bdeda",
+        "type": "github"
+      },
+      "original": {
+        "dir": "misc/packaging",
+        "owner": "elegios",
+        "ref": "update-nix-packaging",
+        "repo": "miking",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "miking": "miking",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -1,0 +1,39 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    miking.url = "github:elegios/miking/update-nix-packaging?dir=misc/packaging";
+  };
+
+  outputs = { self, nixpkgs, miking, flake-utils }:
+    let
+      mkPkg = system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system}.pkgs;
+          mpkgs = miking.packages.${system};
+        in
+          rec {
+            packages.miking-dppl-lib = pkgs.callPackage ./miking-dppl-lib.nix {
+              inherit (mpkgs) miking-lib;
+            };
+            packages.miking-dppl-unwrapped = pkgs.callPackage ./miking-dppl-unwrapped.nix {
+              inherit (mpkgs) miking-lib miking-unwrapped;
+            };
+            # packages.miking-dppl = pkgs.callPackage ./miking-dppl.nix {
+            #   inherit (mpkgs) miking-lib;
+            #   inherit (packages) miking-dppl-lib miking-dppl-unwrapped;
+            # };
+            devShells.default = pkgs.mkShell {
+              name = "Miking dev shell";
+              inputsFrom = [ packages.miking-dppl-lib packages.miking-dppl-unwrapped ];
+            };
+          };
+    in flake-utils.lib.eachDefaultSystem mkPkg // rec {
+      overlays.miking = final: prev: {
+        # miking-dppl = final.callPackage ./miking-dppl.nix {};
+        miking-dppl-lib = final.callPackage ./miking-dppl-lib.nix {};
+        miking-dppl-unwrapped = final.callPackage ./miking-dppl-unwrapped.nix {};
+      };
+      overlays.default = overlays.miking;
+    };
+}

--- a/misc/packaging/miking-dppl-lib.nix
+++ b/misc/packaging/miking-dppl-lib.nix
@@ -1,0 +1,28 @@
+{ lib, runCommand, nix-gitignore,
+  miking-lib,
+}:
+
+let
+  args = {
+    propagatedNativeBuildInputs = [ miking-lib ];
+    meta = with lib; {
+      description     = "The DPPL fragments for the Miking framework";
+      homepage        = "https://miking.org";
+      license         = licenses.mit;
+      longDescription = ''
+        Miking (Meta vIKING) is a meta language system for creating
+        embedded domain-specific and general-purpose languages.  The
+        system features a polymorphic core calculus and a DSL definition
+        language where languages can be extended and composed from
+        smaller fragments.
+
+        This package contains the library adding support for DPPL constructs.
+      '';
+    };
+  };
+in
+
+runCommand "miking-lib" args ''
+  mkdir -p $out/lib/mcore
+  cp -r ${nix-gitignore.gitignoreSource [] ../..}/coreppl/src $out/lib/mcore/coreppl
+''

--- a/misc/packaging/miking-dppl-unwrapped.nix
+++ b/misc/packaging/miking-dppl-unwrapped.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, nix-gitignore,
+  ocamlPackages,
+  miking-lib, miking-unwrapped,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "miking-dppl-unwrapped";
+  version = "0.0.0+git";
+
+  src = nix-gitignore.gitignoreSource "/misc/packaging\n/result\n" ../..;
+
+  nativeBuildInputs = [
+    miking-unwrapped
+    miking-lib
+    ocamlPackages.findlib
+    ocamlPackages.ocaml
+    ocamlPackages.linenoise
+  ];
+
+  makeFlags = [ "BIN_PATH=$(out)/bin" ];
+
+  installTargets = [ "install-cppl" ];
+
+  meta = with lib; {
+    mainProgram     = "cpplc";
+    description     = "Meta language system for creating embedded DSLs";
+    homepage        = "https://miking.org";
+    license         = licenses.mit;
+    longDescription = ''
+      Miking (Meta vIKING) is a meta language system for creating
+      embedded domain-specific and general-purpose languages.  The
+      system features a polymorphic core calculus and a DSL definition
+      language where languages can be extended and composed from
+      smaller fragments.
+
+      Note: Depending on the target runtime, miking requires the presence of
+      additional packages within an environment, such as dune, ocaml, findlib
+      and a C compiler for native builds, node for javascript, and a suitable JDK
+      when targeting the JVM.
+    '';
+  };
+})


### PR DESCRIPTION
This PR adds nix packaging files and a direnv file, both mirroring the corresponding structure in the main miking repository. Because the primary _current_ purpose of this PR is to support TreePPL builds, there is currently no build for a wrapped `cppl` executable (i.e., one that known where to find all its dependencies without being in a nix build environment), I leave that for later, when/if it is needed.