### PR TITLE
Fix pruning runtime

### DIFF
--- a/coreppl/models/tree-inference/gtr/automated-pruning/tree-inference-gtr-auto.mc
+++ b/coreppl/models/tree-inference/gtr/automated-pruning/tree-inference-gtr-auto.mc
@@ -34,20 +34,21 @@ let cluster = lam q. lam trees. lam maxAge. lam seqLen. lam n. lam pi:[Float].
   let t = assume (Exponential 10.0) in
   let age = addf t maxAge in
   let qts = map (lam c. matrixExponential (matrixMulFloat (subf age (getAge c)) q)) children in
+
+  resample;
   let seq:[PruneInt] = iid (lam p. prune (Categorical p)) pi seqLen in
   iteri (lam i. lam site:PruneInt.
     iter2 (lam child. lam qt.
       let p1 = ctmc (pruned site) qt in
       match child with Node n then
         let s = get n.seq i in
-        observe (pruned s) (Categorical p1);
-        cancel (observe (pruned s) (Categorical pi))
+        observe (pruned s) (Categorical p1)
       else match child with Leaf l in
         let s = get l.seq i in
-        (if lti s 4 then observe s (Categorical p1); cancel (observe s (Categorical pi)) else ())
+        (if lti s 4 then observe s (Categorical p1);cancel (observe s (Categorical pi)) else ())
     ) children qts
   ) seq;
-  resample;
+  (if eqi n 2 then () else iteri (lam i. lam site:PruneInt. cancel (observe (pruned site) (Categorical pi))) seq);
   let parent = Node {age=age, seq=seq,left=leftChild, right=rightChild} in
   let min = mini pairs.0 pairs.1 in
   let max = maxi pairs.0 pairs.1 in

--- a/coreppl/models/tree-inference/gtr/no-pruning/tree-inference-gtr.mc
+++ b/coreppl/models/tree-inference/gtr/no-pruning/tree-inference-gtr.mc
@@ -47,7 +47,7 @@ let cluster = lam q. lam trees. lam maxAge. lam seqLen. lam n. lam pi.
         (if lti s 4 then observe s (Categorical p1); cancel (observe s (Categorical pi)) else ())
     ) children qts
   ) seq;
-  (if eqi n 2 then () else iteri (lam i. lam site:PruneInt. cancel (observe (pruned site) (Categorical pi))) seq);
+  (if eqi n 2 then () else iteri (lam i. lam site. cancel (observe site (Categorical pi))) seq);
   let parent = Node {age=age, seq=seq,left=leftChild, right=rightChild} in
   let min = mini pairs.0 pairs.1 in
   let max = maxi pairs.0 pairs.1 in

--- a/coreppl/models/tree-inference/gtr/no-pruning/tree-inference-gtr.mc
+++ b/coreppl/models/tree-inference/gtr/no-pruning/tree-inference-gtr.mc
@@ -34,21 +34,20 @@ let cluster = lam q. lam trees. lam maxAge. lam seqLen. lam n. lam pi.
   let t = assume (Exponential 10.0) in
   let age = addf t maxAge in
   let qts = map (lam c. matrixExponential (matrixMulFloat (subf age (getAge c)) q)) children in
-
+  resample;
   let seq = iid (lam p. assume (Categorical p)) pi seqLen in
   iteri (lam i. lam site.
     iter2 (lam child. lam qt.
       let p1 = ctmc site qt in
       match child with Node n then
         let s = get n.seq i in
-        observe s (Categorical p1);
-        cancel (observe s (Categorical pi))
+        observe s (Categorical p1)
       else match child with Leaf l in
         let s = get l.seq i in
         (if lti s 4 then observe s (Categorical p1); cancel (observe s (Categorical pi)) else ())
     ) children qts
   ) seq;
-  resample;
+  (if eqi n 2 then () else iteri (lam i. lam site:PruneInt. cancel (observe (pruned site) (Categorical pi))) seq);
   let parent = Node {age=age, seq=seq,left=leftChild, right=rightChild} in
   let min = mini pairs.0 pairs.1 in
   let max = maxi pairs.0 pairs.1 in

--- a/coreppl/src/coreppl-to-mexpr/pruning/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/compile.mc
@@ -52,6 +52,12 @@ lang MExprPPLPruningCPS = MExprPPL + DPPLParser + MExprCPS
     match tyTm (t.body) with TyPruneInt _ then
       mapInsert t.ident (PrunedValue ()) env else env in
     createObsValue (createObsValue env t.body) t.inexpr
+  | TmLam t -> 
+    let env = match t.tyParam with TyInt _ then
+      mapInsert t.ident (IntValue ()) env else
+    match t.tyParam with TyPruneInt _ then
+      mapInsert t.ident (PrunedValue ()) env else env in
+    sfold_Expr_Expr createObsValue env (TmLam t)
   | t -> sfold_Expr_Expr createObsValue env t
 
   sem createDistEnv: Map Name Expr -> Expr -> Map Name Expr

--- a/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
@@ -29,15 +29,7 @@ lang PruneGraph
   | SeqFParam f -> range 0 (length f) 1
   | PruneFParam f -> match f with PruneFVar f in
       range 0 (length f.values) 1
-
-  sem zip x =
-  | y -> mapi (lam i. lam e. (get x i, e)) y
-
 end
-let transpose : all a. [[a]] -> [[a]]
-  = lam xs.
-    match xs with [x] ++ xs in
-    foldl (zipWith snoc) (map (lam x. [x]) x) xs
 
 lang PrunedSampling = PruneGraph
 

--- a/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
@@ -65,10 +65,10 @@ lang PrunedSampling = PruneGraph
   | (PruneFParam (PruneFVar v)) & d ->
     let likelihood = calculateObservedLH d value in -- likelihood of observed value
     let distMsg = calculateDistMsg cancel likelihood value d in -- L_{p,s} for a certain observe
-    (match value with PrunedValue (PruneRVar obs) then
+    /-(match value with PrunedValue (PruneRVar obs) then
       (match v.input with PruneRVar p in
         (if eqsym obs.identity p.identity then () else modref obs.likelihood (calculateObsLh cancel likelihood value d)))
-     else ()); -- L_{p,s} for a certain observe
+     else ());-/
     weightPrune distMsg value v.input
 
   sem calculateLogWeight distMsg value =
@@ -84,7 +84,7 @@ lang PrunedSampling = PruneGraph
   | PruneRVar p ->
     let uw = (negf (deref p.lastWeight)) in
     let w = (calculateLogWeight distMsg value (PruneRVar p)) in
-    let xw = match value with PrunedValue (PruneRVar obs) then let lw = (deref obs.lastWeight) in modref obs.lastWeight w;lw else 0. in
+    let xw = match value with PrunedValue (PruneRVar obs) then let lw = (deref obs.lastWeight) in /-modref obs.lastWeight w;-/lw else 0. in
     modref p.lastWeight w;
     subf (addf uw w) xw
 

--- a/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/pruning/runtime.mc
@@ -45,7 +45,7 @@ lang PrunedSampling = PruneGraph
   | PruneRVar p -> PruneFVar {values=map f p.states, input = (PruneRVar p)}
 
   sem calculateObservedLH d =
-  | PrunedValue (PruneRVar obs) -> (deref obs.likelihood)
+  | PrunedValue (PruneRVar obs) -> deref obs.likelihood
   | IntValue obs ->
     match d with PruneFParam (PruneFVar v) in
     let states = getStates d in
@@ -59,12 +59,13 @@ lang PrunedSampling = PruneGraph
     match value with PrunedValue (PruneRVar obs) in
     modref obs.likelihood obsLh;
     let logw = log (foldl (lam acc. lam x. addf acc (mulf x.0 x.1)) 0. (zip obsLh obs.dist)) in
-    let lastWeight = (deref obs.lastWeight) in
+    let lastWeight = deref obs.lastWeight in
     modref obs.lastWeight logw;
     subf logw lastWeight
   | (PruneFParam (PruneFVar v)) & d ->
     let likelihood = calculateObservedLH d value in -- likelihood of observed value
     let distMsg = calculateDistMsg cancel likelihood value d in -- L_{p,s} for a certain observe
+    -- Note: Commented out assuming that the pruned value does not live afterwards in a mixed observe
     /-(match value with PrunedValue (PruneRVar obs) then
       (match v.input with PruneRVar p in
         (if eqsym obs.identity p.identity then () else modref obs.likelihood (calculateObsLh cancel likelihood value d)))
@@ -84,6 +85,7 @@ lang PrunedSampling = PruneGraph
   | PruneRVar p ->
     let uw = (negf (deref p.lastWeight)) in
     let w = (calculateLogWeight distMsg value (PruneRVar p)) in
+    -- Note: Commented out assuming that the pruned value does not live afterwards in a mixed observe
     let xw = match value with PrunedValue (PruneRVar obs) then let lw = (deref obs.lastWeight) in /-modref obs.lastWeight w;-/lw else 0. in
     modref p.lastWeight w;
     subf (addf uw w) xw

--- a/coreppl/test/coreppl-to-mexpr/pruning/pruning.mc
+++ b/coreppl/test/coreppl-to-mexpr/pruning/pruning.mc
@@ -56,32 +56,32 @@ let modelNN = lam.
   let d = assume (Categorical [0.5, 0.5]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f d in
-  observe x (Categorical params);
-  observe x (Categorical [0.9, 0.1])
+  observe x (Categorical [0.9, 0.1]);
+  observe x (Categorical params)
 
 let modelNP = lam.
   let x = assume (Categorical [0.7, 0.3]) in
   let d = prune (Categorical [0.5, 0.5]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f (pruned d) in
-  observe x (Categorical params);
-  observe x (Categorical [0.9, 0.1])
+  observe x (Categorical [0.9, 0.1]);
+  observe x (Categorical params)
 
 let modelPN = lam.
   let x = prune (Categorical [0.7, 0.3]) in
   let d = assume (Categorical [0.5, 0.5]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f d in
-  observe (pruned x) (Categorical params);
-  observe (pruned x) (Categorical [0.9, 0.1])
+  observe (pruned x) (Categorical [0.9, 0.1]);
+  observe (pruned x) (Categorical params)
 
 let modelPP = lam.
   let x = prune (Categorical [0.7, 0.3]) in
   let d = prune (Categorical [0.5, 0.5]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f (pruned d) in
-  observe (pruned x) (Categorical params);
-  observe (pruned x) (Categorical [0.9, 0.1])
+  observe (pruned x) (Categorical [0.9, 0.1]);
+  observe (pruned x) (Categorical params)
 
 let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
 
@@ -320,17 +320,17 @@ let modelN = lam.
   let d = assume (Categorical [0.4, 0.6]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f d in
-  cancel (observe x (Categorical params));
   cancel (observe x (Categorical [0.9, 0.1]));
-  cancel (observe x (Categorical [0.5, 0.5]))
+  cancel (observe x (Categorical [0.5, 0.5]));
+  cancel (observe x (Categorical params))
 let modelP = lam.
   let x = prune (Categorical [0.7, 0.3]) in
   let d = prune (Categorical [0.4, 0.6]) in
   let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
   let params = f (pruned d) in
-  cancel (observe (pruned x) (Categorical params));
   cancel (observe (pruned x) (Categorical [0.9, 0.1]));
-  cancel (observe (pruned x) (Categorical [0.5, 0.5]))
+  cancel (observe (pruned x) (Categorical [0.5, 0.5]));
+  cancel (observe (pruned x) (Categorical params))
 let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
 
 let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP

--- a/coreppl/test/coreppl-to-mexpr/pruning/pruning.mc
+++ b/coreppl/test/coreppl-to-mexpr/pruning/pruning.mc
@@ -1,0 +1,385 @@
+-- Single observe --
+let modelNN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe x (Categorical params)
+
+let modelNP = lam. 
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe x (Categorical params)
+
+let modelPN = lam. 
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe (pruned x) (Categorical params)
+
+let modelPP = lam. 
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical params)
+
+let modelPPInCorrect = lam. 
+  let x = prune (Categorical [0.4, 0.6]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical params)
+
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelNP
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPN
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+let incorrectPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none",prune=true}) modelPPInCorrect)
+utest noPrunedResult with incorrectPrunedResult using (lam a. lam b. not (eqfApprox 1e-2 a b))
+
+-- Double observe on x --
+let modelNN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe x (Categorical params);
+  observe x (Categorical [0.9, 0.1])
+
+let modelNP = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe x (Categorical params);
+  observe x (Categorical [0.9, 0.1])
+
+let modelPN = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe (pruned x) (Categorical params);
+  observe (pruned x) (Categorical [0.9, 0.1])
+
+let modelPP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical params);
+  observe (pruned x) (Categorical [0.9, 0.1])
+
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelNP
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPN
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+-- Double observe on d --
+let modelNN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe x (Categorical params);
+  observe d (Categorical [0.9, 0.1])
+
+let modelNP = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe x (Categorical params);
+  observe (pruned d) (Categorical [0.9, 0.1])
+
+let modelPN = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe (pruned x) (Categorical params);
+  observe d (Categorical [0.9, 0.1])
+
+let modelPP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical params);
+  observe (pruned d) (Categorical [0.9, 0.1])
+
+
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelNP
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPN
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+-- Observe on both 'x' and 'd'
+let modelNN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5])  in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe x (Categorical [0.9, 0.1]);
+  observe x (Categorical params);
+  observe d (Categorical [0.9, 0.1])
+let modelNP = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe x (Categorical [0.9, 0.1]);
+  observe x (Categorical params);
+  observe (pruned d) (Categorical [0.9, 0.1])
+let modelPN = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  observe (pruned x) (Categorical [0.9, 0.1]);
+  observe (pruned x) (Categorical params);
+  observe d (Categorical [0.9, 0.1])
+let modelPP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical [0.9, 0.1]);
+  observe (pruned x) (Categorical params);
+  observe (pruned d) (Categorical [0.9, 0.1])
+let modelPPSwap = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.5, 0.5]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  observe (pruned x) (Categorical params);
+  observe (pruned x) (Categorical [0.9, 0.1]);
+  observe (pruned d) (Categorical [0.9, 0.1])
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelNP
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPN
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+let incorrectPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none",prune=true}) modelPPSwap)
+utest noPrunedResult with incorrectPrunedResult using (lam a. lam b. not (eqfApprox 1e-2 a b))
+
+-- Pruning on single variable, single observe
+let modelN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f x in
+  observe x (Categorical params)
+let modelP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned x) in
+  observe (pruned x) (Categorical params) 
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+-- Single variable, double observe
+let modelN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f x in
+  observe x (Categorical params);
+  observe x (Categorical [0.9, 0.1])
+let modelP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned x) in
+  observe (pruned x) (Categorical params);
+  observe (pruned x) (Categorical [0.9, 0.1])
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+let modelNN = lam.
+  let c = 1 in
+  let d = 0 in
+  let e = 1 in
+  let fun = lam x. get [[0.4,0.6],[0.2,0.8]] x in
+  let b = assume (Categorical [0.7,0.3]) in
+  let p = fun b in
+  observe c (Categorical p);
+  observe d (Categorical p);
+  let a = assume (Categorical [0.5,0.5]) in
+  let p = fun a in
+  cancel (observe b (Categorical [0.7,0.3]));
+  observe b (Categorical p);
+  observe e (Categorical p)
+let modelNP = lam.
+  let c = 1 in
+  let d = 0 in
+  let e = 1 in
+  let fun = lam x. get [[0.4,0.6],[0.2,0.8]] x in
+  let b = assume (Categorical [0.7,0.3]) in
+  let p = fun b in
+  observe c (Categorical p);
+  observe d (Categorical p);
+  let a = prune (Categorical [0.5,0.5]) in
+  let p = fun (pruned a) in
+  cancel (observe b (Categorical [0.7,0.3]));
+  observe b (Categorical p);
+  observe e (Categorical p)
+let modelPN = lam.
+  let c = 1 in
+  let d = 0 in
+  let e = 1 in
+  let fun = lam x. get [[0.4,0.6],[0.2,0.8]] x in
+  let b = prune (Categorical [0.7,0.3]) in
+  let p = fun (pruned b) in
+  observe c (Categorical p);
+  observe d (Categorical p);
+  let a = assume (Categorical [0.5,0.5]) in
+  let p = fun a in
+  cancel (observe (pruned b) (Categorical [0.7,0.3]));
+  observe (pruned b) (Categorical p);
+  observe e (Categorical p)
+let modelPP = lam.
+  let c = 1 in
+  let d = 0 in
+  let e = 1 in
+  let fun = lam x. get [[0.4,0.6],[0.2,0.8]] x in
+  let b = prune (Categorical [0.7,0.3]) in
+  let p = fun (pruned b) in
+  observe c (Categorical p);
+  observe d (Categorical p);
+  let a = prune (Categorical [0.5,0.5]) in
+  let p = fun (pruned a) in
+  cancel (observe (pruned b) (Categorical [0.7,0.3]));
+  observe (pruned b) (Categorical p);
+  observe e (Categorical p)
+let modelPPSwap = lam.
+  let c = 1 in
+  let d = 0 in
+  let e = 1 in
+  let fun = lam x. get [[0.4,0.6],[0.2,0.8]] x in
+  let b = prune (Categorical [0.7,0.3]) in
+  let p = fun (pruned b) in
+  observe c (Categorical p);
+  observe d (Categorical p);
+  let a = prune (Categorical [0.5,0.5]) in
+  let p = fun (pruned a) in
+  observe (pruned b) (Categorical p);
+  cancel (observe (pruned b) (Categorical [0.7,0.3]));
+  observe e (Categorical p)
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelNN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelNP
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPN
+              , infer (Importance {particles = 100000, cps = "none",prune=true}) modelPP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+let incorrectPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none",prune=true}) modelPPSwap)
+utest noPrunedResult with incorrectPrunedResult using (lam a. lam b. not (eqfApprox 1e-2 a b))
+
+
+let modelN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.4, 0.6]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+  cancel (observe x (Categorical params));
+  cancel (observe x (Categorical [0.9, 0.1]));
+  cancel (observe x (Categorical [0.5, 0.5]))
+let modelP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.4, 0.6]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+  cancel (observe (pruned x) (Categorical params));
+  cancel (observe (pruned x) (Categorical [0.9, 0.1]));
+  cancel (observe (pruned x) (Categorical [0.5, 0.5]))
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+
+let modelN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let d = assume (Categorical [0.4, 0.6]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f d in
+   (observe x (Categorical params));
+   (observe 1 (Categorical params));
+   (observe 0 (Categorical params))
+let modelP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let d = prune (Categorical [0.4, 0.6]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned d) in
+   (observe (pruned x) (Categorical params));
+   (observe 1 (Categorical params));
+   (observe 0 (Categorical params))
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+-- Single variable, double observe
+let modelN = lam.
+  let x = assume (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f x in
+  cancel (observe x (Categorical params));
+  observe x (Categorical [0.9, 0.1])
+let modelP = lam.
+  let x = prune (Categorical [0.7, 0.3]) in
+  let f = lam d. get [[0.9, 0.1], [0.2, 0.8]] d in
+  let params = f (pruned x) in
+  cancel (observe (pruned x) (Categorical params));
+  observe (pruned x) (Categorical [0.9, 0.1])
+let noPrunedResult = distEmpiricalNormConst (infer (Importance {particles = 100000, cps = "none"}) modelN)
+
+let results = [ infer (Importance {particles = 100000, cps = "none",prune=true}) modelP
+              ]
+
+let normConsts = map distEmpiricalNormConst results
+let x = iter (lam n. utest noPrunedResult with n using eqfApprox 1e-2 in ()) normConsts
+mexpr
+()
+
+

--- a/test-coreppl.mk
+++ b/test-coreppl.mk
@@ -18,6 +18,7 @@ test-cli-files=\
   $(shell find coreppl/test/coreppl-to-mexpr/cli -name "*.mc")
 test-expectation-files=$(shell find coreppl/test/coreppl-to-mexpr/expectation -name "*.mc")
 test-dppl-files=$(shell find coreppl/test/coreppl-to-mexpr/dppl -name "*.mc" -a ! -wholename "coreppl/test/coreppl-to-mexpr/dppl/examples/*")
+test-pruning-files=$(shell find coreppl/test/coreppl-to-mexpr/pruning -name "*.mc")
 
 test-inference-files=\
   $(shell find coreppl/test/coreppl-to-mexpr/inference-accuracy -name "*.mc")
@@ -47,6 +48,9 @@ infer: ${test-infer-files}
 
 .PHONY: static-delay
 static-delay: ${test-staticdelay-files}
+
+.PHONY: pruning
+pruning: ${test-pruning-files}
 
 .PHONY: expectation
 expectation: ${test-expectation-files}
@@ -89,3 +93,7 @@ ${test-expectation-files}::
 # DPPL tests
 ${test-dppl-files}::
 	@./make test-cdppl $@ "build/${CPPL_NAME}"
+
+# Pruning tests
+${test-pruning-files}::
+	@./make test-cppl $@ "build/${CPPL_NAME}"


### PR DESCRIPTION
This PR
- Corrects the pruning runtime and a small part of the pruning compile-time code. Noting that the pruning runtime here assumes that if a pruned value is used in a mixed observe, then it doesn't live anymore, since CPS cannot handle references. This holds for the tree inference models presented under `models/tree-inference`. However, commented-out code contains the rest of the algorithm for the general case where such an assumption is not made. Though currently that version only works with `--cps none` option.
- Add test cases for pruning 
- Rewrites the GTR model for it to run the algorithm with cps.