### PR TITLE
Give the phase debugging stuff in `cppl.mc` actual ASTs to work with

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -208,7 +208,7 @@ lang CompileModels = ReplaceHigherOrderConstants + PhaseStats + MExprANFAll + DP
         match model with {extractAst = extractAst, method = method, params = params} in
         match mapLookup method runtimes with Some entry then
           let extractAst = lam f. transformModelAst envs options method (extractAst f) in
-          let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+          let log = mkPhaseLogState options.debugDumpPhases options.debugPhases options.invariantsToCheck in
           let ast = compileModel options lamliftSols envs entry id {model with extractAst = extractAst} in
           endPhaseStatsExpr log "compile-model-one" (bind_ ast unit_);
           let ast = smap_Decl_Expr removeModelDefinitions ast in
@@ -252,7 +252,7 @@ lang CompileModels = ReplaceHigherOrderConstants + PhaseStats + MExprANFAll + DP
     -> Decl
   sem compileModel options lamliftSols envs entry modelId =
   | {extractAst = extractAst, params = modelParams, method = method} ->
-    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases options.invariantsToCheck in
 
     -- ANF
     let extractAst = lam f. normalizeTerm (extractAst f) in
@@ -467,7 +467,7 @@ lang CPPLLoader
     let options = hook.options in
     let runtimes = deref hook.runtimes in
     let envs = hook.envs in
-    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases options.invariantsToCheck in
     let ast = removeMetaVarExpr ast in
     endPhaseStatsExpr log "remove-meta-var" ast;
     let runtimeRunNames = mapMap (lam entry. _getVarExn "run" entry.env) runtimes in

--- a/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
@@ -18,7 +18,7 @@ lang MExprPPLImportance =
   sem compile : ImportanceConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNormal (lam x. x) in
     endPhaseStatsExpr log "extract-normal-one" t;
 
@@ -138,7 +138,7 @@ lang MExprPPLImportance =
   sem compileCps : ImportanceConfig -> InferenceInterface -> Expr
   sem compileCps config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (lam x. x) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
@@ -32,7 +32,8 @@ lang MExprPPLLightweightMCMC
   sem compileAligned : LightweightMCMCConfig -> InferenceInterface -> Expr
   sem compileAligned config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
+
     let t = x.extractNormal (generateKernels config.driftScale) in
     endPhaseStatsExpr log "extract-normal-one" t;
 
@@ -87,7 +88,7 @@ lang MExprPPLLightweightMCMC
   sem compile : LightweightMCMCConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (lam x. x) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
@@ -409,7 +410,7 @@ lang MExprPPLLightweightMCMC
   sem compileAlignedCps : LightweightMCMCConfig -> InferenceInterface -> Expr
   sem compileAlignedCps config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (generateKernels config.driftScale) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
@@ -17,7 +17,7 @@ lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist + PhaseStats + Infe
   sem compile : NaiveMCMCConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNormal (lam x. x) in
     endPhaseStatsExpr log "extract-normal-one" t;
 

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
@@ -17,7 +17,7 @@ lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist + PhaseStats + Infe
   sem compile : TraceMCMCConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNormal (lam x. x) in
     endPhaseStatsExpr log "extract-normal-one" t;
 

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
@@ -13,7 +13,7 @@ lang MExprPPLPIMH =
   sem compile: PIMHConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (lam x. x) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
     -- Static analysis and CPS transformation

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
@@ -14,7 +14,7 @@ lang MExprPPLAPF =
   sem compile: APFConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (lam x. x) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -42,7 +42,7 @@ lang MExprPPLBPF =
   sem compile: BPFConfig -> InferenceInterface -> Expr
   sem compile config =
   | x ->
-    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases in
+    let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
     let t = x.extractNoHigherOrderConsts (lam x. x) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 

--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -36,6 +36,7 @@ lang CPPLLang = CorePPLFileTypeLoader
   + BPFCompilerPicker + APFCompilerPicker + ImportanceCompilerPicker
   + NaiveMCMCCompilerPicker + TraceMCMCCompilerPicker + PIMHCompilerPicker
   + LightweightMCMCCompilerPicker
+  + UnboundErrorAttr + DefinedAttr + WithoutInfoAttr
 end
 
 mexpr
@@ -51,7 +52,7 @@ let isFromModelFileOrStatic = lam x.
   then eqString x.filename filename
   else false in
 
-let log = mkPhaseLogState options.transformations.debugDumpPhases options.transformations.debugPhases in
+let log = mkPhaseLogState options.transformations.debugDumpPhases options.transformations.debugPhases options.transformations.invariantsToCheck in
 
 let loader = mkLoader symEnvDefault typcheckEnvDefault
   [ ODEHook ()
@@ -62,10 +63,10 @@ let loader = enableDefaultInferMethod options.defaultMethod loader in
 let loader = enableCPPLCompilation options.transformations loader in
 let loader = enableUtestGeneration (if options.frontend.test then isFromModelFileOrStatic else lam. false) loader in
 let loader = enablePprintGeneration loader in
-endPhaseStatsExpr log "mk-cppl-loader" unit_;
+endPhaseStatsProg log "mk-cppl-loader" {decls = getDecls loader, expr = unit_};
 
 let loader = (includeFileTypeExn (FCorePPL {isModel = true}) "." filename loader).1 in
-endPhaseStatsExpr log "include-file" unit_;
+endPhaseStatsProg log "include-file" {decls = getDecls loader, expr = unit_};
 
 let ast = buildFullAst loader in
 endPhaseStatsExpr log "build-full-ast" ast;

--- a/coreppl/src/dppl-arg.mc
+++ b/coreppl/src/dppl-arg.mc
@@ -2,6 +2,11 @@ include "optparse-applicative.mc"
 include "set.mc"
 include "infer-method.mc"
 
+include "mexpr/invariants.mc"
+include "mexpr/invariants/in-scope.mc"
+include "mexpr/invariants/definitions.mc"
+include "mexpr/invariants/info.mc"
+
 include "inference/is-lw.mc"
 include "inference/smc-bpf.mc"
 include "inference/smc-apf.mc"
@@ -36,6 +41,7 @@ type TransformationOptions =
   , debugPhases : Bool
   , printModel : Bool
   , seed : Option Int
+  , invariantsToCheck : use Invariant in () -> [Attr Loc]
   }
 
 type SeparatedOptions =
@@ -130,6 +136,17 @@ let transformationOptions : OptParser TransformationOptions =
     , debugPhases = debugPhases
     , debugDumpPhases = debugDumpPhases
     , seed = seed
+    , invariantsToCheck = lam.
+      use UnboundErrorAttr in
+      use WithoutInfoAttr in
+      use DefinedAttr in
+      let scope =
+        {_scopeEmpty () with tyConstructors = setOfSeq nameCmp (mapValues builtinTypeNames)} in
+      [ InScopeAttr (filledThunk scope)
+      , UnboundErrorAttr (mkThunk (lazyPure "UnboundErrorAttr#root"))
+      , WithoutInfoAttr (mkThunk (lazyPure "WithoutInfoAttr#root"))
+      , DefinedAttr (mkThunk (lazyPure "DefinedAttr#root"))
+      ]
     } in
   let printModel = optFlag
     { optFlagDef with long = "print-model"


### PR DESCRIPTION
This PR follows https://github.com/miking-lang/miking/pull/980, fixing the change in API for the phase stats machinery. It also makes the first few steps actually look at an AST (using the mlang part of the phase stats API), though that part still won't check the invariants due to limitations in phase-stats.