### PR TITLE
Reset mcmc-lw state when starting a run, to handle multiple runs in one program

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
@@ -330,6 +330,9 @@ let runNext: all acc. all dAcc. Config Result acc dAcc -> (State Result -> Resul
 let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) -> use RuntimeDistBase in Dist Result =
   lam config. lam model.
 
+  resetState state;
+  modref state.alignedTraceLength (negi 1);
+
   recursive let mh : [Result] -> Float -> Float -> Result -> dAcc -> (acc, Bool) -> Int -> [Result] =
     lam keptSamples. lam prevWeight. lam prevPriorWeight. lam prevSample. lam debugState. lam continueState. lam iter.
       match continueState with (continueState, true) then


### PR DESCRIPTION
The mcmc-lightweight mode uses some global state for its runtime which is in an appropriate state when a program starts, but isn't after inference has been run for some model. I was testing things with multiple `infer` expressions in one program, which made this break, so here's a fix.