### PR TITLE
Add prevWeight and proposalWeight to debug-mcmc

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/config.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/config.mc
@@ -4,6 +4,8 @@
 
 type DebugInfo =
   { accepted : Bool
+  , prevWeight : Float
+  , proposalWeight : Float
   }
 
 type SampleInfo =

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned-cps.mc
@@ -321,7 +321,6 @@ let runNext: all acc. all dAcc. Config Result acc dAcc -> (State Result -> Resul
   -- printLn (join ["Aligned trace length: ", int2string (length (deref state.alignedTrace))]);
   -- printLn (join ["Unaligned traces length: ", int2string (length (deref state.unalignedTraces))]);
   -- printLn (join ["The invalid index is: ", int2string invalidIndex]);
-
   (acc, (rec invalidIndex (deref state.alignedTrace) (deref state.unalignedTraces)
     (emptyList ()) (emptyList ())) unalignedResamp)
 
@@ -342,19 +341,19 @@ let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) 
         -- print "alignedTrace: ["; print (strJoin ", " (map (lam tup. float2string tup.1) (deref state.alignedTrace))); printLn "]";
         -- print "prevUnalignedTraces: ["; print (strJoin ", " (map (lam ls. join ["[", strJoin "," (map (lam tup. float2string tup.1) ls), "]"]) prevUnalignedTraces)); printLn "]";
         -- print "unalignedTraces: ["; print (strJoin ", " (map (lam ls. join ["[", strJoin "," (map (lam tup. float2string tup.1) ls), "]"]) (deref state.unalignedTraces))); printLn "]";
-        let weight = deref state.weight in
+        let proposalWeight = deref state.weight in
         let priorWeight = deref state.priorWeight in
         let driftHastingRatio = deref state.driftHastingRatio in
         let weightReused = deref state.weightReused in
         let prevWeightReused = deref state.prevWeightReused in
         -- Calculate the Hastings ratio.
         let logMhAcceptProb = minf 0. (addf
-                    (addf 
-                      (mulf beta (subf weight prevWeight))
+                    (addf
+                      (mulf beta (subf proposalWeight prevWeight))
                       (subf weightReused prevWeightReused))
                     driftHastingRatio)
         in
-        -- print "weight: "; printLn (float2string weight);
+        -- print "proposalWeight: "; printLn (float2string proposalWeight);
         -- print "prevWeight: "; printLn (float2string prevWeight);
         -- print "weightReused: "; printLn (float2string weightReused);
         -- print "prevWeightReused: "; printLn (float2string prevWeightReused);
@@ -362,7 +361,7 @@ let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) 
         match
           if bernoulliSample (exp logMhAcceptProb) then
             mcmcAccept ();
-            (true, weight, priorWeight, sample)
+            (true, proposalWeight, priorWeight, sample)
           else
           -- NOTE(dlunde,2022-10-06): VERY IMPORTANT: Restore previous traces
           -- as we reject and reuse the old sample.
@@ -373,6 +372,8 @@ let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) 
         let keptSamples = if config.keepSample iter then snoc keptSamples sample else keptSamples in
         let debugInfo =
           { accepted = accepted
+          , prevWeight = prevWeight
+          , proposalWeight = proposalWeight
           } in
         let debugState = config.debug.1 debugState debugInfo in
         let sampleInfo =
@@ -397,11 +398,11 @@ let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) 
         -- printLn (join ["Try ", int2string i, " at sampling positive prob. sample. Sample weight: ", float2string (weight)]);
         firstSample model state (addi i 1)
       else sample
-    in 
+    in
 
   -- Used to keep track of acceptance ratio
   mcmcAcceptInit ();
- 
+
   let sample = firstSample model state 1 in
   let weight = deref state.weight in
   let priorWeight = deref state.priorWeight in
@@ -431,6 +432,8 @@ let run : all acc. all dAcc. Config Result acc dAcc -> (State Result -> Result) 
   -- Set up debug and continue states
   let debugInfo =
     { accepted = true
+    , prevWeight = negf inf
+    , proposalWeight = weight
     } in
   let debugState = config.debug.1 config.debug.0 debugInfo in
 

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime-aligned.mc
@@ -226,16 +226,16 @@ let modTrace: all a. all acc. all dAcc.
       else acc
   in
 
-  let alignedTraceLength: Int = deref state.alignedTraceLength in  
+  let alignedTraceLength: Int = deref state.alignedTraceLength in
   let resBehav = config.resampleBehavior acc alignedTraceLength in
   -- Enable global modifications with probability gProb
   match resBehav with (acc, (unalignedResamp, invalidIndex)) in
   if lti invalidIndex 0 then
-    let oldUnalignedTraces = 
+    let oldUnalignedTraces =
       zipWith (lam t. lam b. if b then t else []) (deref state.oldUnalignedTraces) unalignedResamp in
     let oldAlignedTrace = deref state.oldAlignedTrace in
     modref state.oldAlignedTrace (emptyList ());
-    (if eqi invalidIndex (negi 1) then 
+    (if eqi invalidIndex (negi 1) then
       modref state.oldAlignedTrace oldAlignedTrace else ());
     modref state.oldUnalignedTraces oldUnalignedTraces;
     acc
@@ -249,7 +249,7 @@ let modTrace: all a. all acc. all dAcc.
     modref state.oldUnalignedTraces (mapReverse (lam trace.
       reverse trace ) (deref state.unalignedTraces));
     -- correct the trace accordeling to unalignedResamp
-    let oldUnalignedTraces = zipWith (lam t. lam b. if b then t else []) 
+    let oldUnalignedTraces = zipWith (lam t. lam b. if b then t else [])
       (deref state.oldUnalignedTraces) (mapReverse (lam trace. trace) unalignedResamp) in
     modref state.oldUnalignedTraces oldUnalignedTraces;
     acc
@@ -279,19 +279,19 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
         -- print "alignedTrace: ["; print (strJoin ", " (map (lam tup. float2string tup.1) (deref state.alignedTrace))); printLn "]";
         -- print "prevUnalignedTraces: ["; print (strJoin ", " (map (lam ls. join ["[", strJoin "," (map (lam tup. float2string tup.1) ls), "]"]) prevUnalignedTraces)); printLn "]";
         -- print "unalignedTraces: ["; print (strJoin ", " (map (lam ls. join ["[", strJoin "," (map (lam tup. float2string tup.1) ls), "]"]) (deref state.unalignedTraces))); printLn "]";
-        let weight = deref state.weight in
+        let proposalWeight = deref state.weight in
         let priorWeight = deref state.priorWeight in
         let driftHastingRatio = deref state.driftHastingRatio in
         let weightReused = deref state.weightReused in
         let prevWeightReused = deref state.prevWeightReused in
         let logMhAcceptProb = minf 0. (addf
                     (addf
-                      (mulf beta (subf weight prevWeight))
+                      (mulf beta (subf proposalWeight prevWeight))
                       (subf weightReused prevWeightReused))
                     driftHastingRatio)
         in
         -- print "logMhAcceptProb: "; printLn (float2string (exp logMhAcceptProb));
-        -- print "weight: "; printLn (float2string (exp  weight));
+        -- print "proposalWeight: "; printLn (float2string (exp proposalWeight));
         -- print "prevWeight: "; printLn (float2string (exp prevWeight));
         -- print "weightReused: "; printLn (float2string (exp weightReused));
         -- print "prevWeightReused: "; printLn (float2string (exp prevWeightReused));
@@ -299,7 +299,7 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
         match
           if bernoulliSample (exp logMhAcceptProb) then
             mcmcAccept ();
-            (true, weight, priorWeight, sample)
+            (true, proposalWeight, priorWeight, sample)
           else
             -- NOTE(dlunde,2022-10-06): VERY IMPORTANT: Restore previous traces
             -- as we reject and reuse the old sample.
@@ -310,6 +310,8 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
         let samples = if config.keepSample iter then snoc samples sample else samples in
         let debugInfo =
           { accepted = accepted
+          , prevWeight = prevWeight
+          , proposalWeight = proposalWeight
           } in
         let debugState = config.debug.1 debugState debugInfo in
         let sampleInfo =
@@ -324,7 +326,7 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
   -- First sample -- call the model until we get a non-zero weight
   recursive let firstSample : (State -> a) -> State -> Int -> a =
     lam model. lam state. lam i.
-      let sample = model state in 
+      let sample = model state in
       let weight = deref state.weight in
       let weightReused = deref state.weightReused in
       let priorWeight = deref state.priorWeight in
@@ -334,7 +336,7 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
         -- printLn (join ["Try ", int2string i, " at sampling positive prob. sample. Sample weight: ", float2string (weight)]);
         firstSample model state (addi i 1)
       else sample
-  in 
+  in
 
   -- Used to keep track of acceptance ratio
   mcmcAcceptInit ();
@@ -354,6 +356,8 @@ let run : all a. all acc. all dAcc. Config a acc dAcc -> (State -> a) -> use Run
   -- Set up debug and continue states
   let debugInfo =
     { accepted = true
+    , prevWeight = negf inf
+    , proposalWeight = weight
     } in
 
   let debugState = config.debug.1 config.debug.0 debugInfo in

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/runtime.mc
@@ -175,18 +175,18 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
         modref state.traceLength 0;
         let sample = model state in
         let traceLength = deref state.traceLength in
-        let weight = deref state.weight in
+        let proposalWeight = deref state.weight in
         let priorWeight = deref state.priorWeight in
         let weightReused = deref state.weightReused in
         let prevWeightReused = deref state.prevWeightReused in
         let logMhAcceptProb = minf 0. (addf (addf
-                    (mulf beta (subf weight prevWeight))
+                    (mulf beta (subf proposalWeight prevWeight))
                     (subf weightReused prevWeightReused))
                     (subf (log (int2float prevTraceLength))
                               (log (int2float traceLength))))
         in
         -- print "logMhAcceptProb: "; printLn (float2string logMhAcceptProb);
-        -- print "weight: "; printLn (float2string weight);
+        -- print "proposalWeight: "; printLn (float2string proposalWeight);
         -- print "prevWeight: "; printLn (float2string prevWeight);
         -- print "weightReused: "; printLn (float2string weightReused);
         -- print "prevWeightReused: "; printLn (float2string prevWeightReused);
@@ -195,7 +195,7 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
         match
           if bernoulliSample (exp logMhAcceptProb) then
             mcmcAccept ();
-            (true, weight, priorWeight, sample)
+            (true, proposalWeight, priorWeight, sample)
           else
           -- NOTE(dlunde,2022-10-06): VERY IMPORTANT: Restore previous database
           -- and trace length as we reject and reuse the old sample.
@@ -206,6 +206,8 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
         let samples = if config.keepSample iter then snoc samples sample else samples in
         let debugInfo =
           { accepted = accepted
+          , proposalWeight = proposalWeight
+          , prevWeight = prevWeight
           } in
         let debugState = config.debug.1 debugState debugInfo in
         let sampleInfo =
@@ -220,7 +222,7 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
   -- First sample -- call the model until we get a non-zero weight
   recursive let firstSample : (State -> a) -> State -> Int -> a =
     lam model. lam state. lam i.
-      let sample = model state in 
+      let sample = model state in
       let weight = deref state.weight in
       let weightReused = deref state.weightReused in
       let priorWeight = deref state.priorWeight in
@@ -230,7 +232,7 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
         -- printLn (join ["Try ", int2string i, " at sampling positive prob. sample. Sample weight: ", float2string (weight)]);
         firstSample model state (addi i 1)
       else sample
-    in 
+    in
 
   -- Used to keep track of acceptance ratio
   mcmcAcceptInit ();
@@ -245,6 +247,8 @@ let run : all acc. all dAcc. all a. Config a acc dAcc -> (State -> a) -> use Run
   -- Set up debug and continue states
   let debugInfo =
     { accepted = true
+    , prevWeight = negf inf
+    , proposalWeight = weight
     } in
   let debugState = config.debug.1 config.debug.0 debugInfo in
   let continueState = config.continue.0 () in

--- a/coreppl/src/inference/mcmc-lightweight.mc
+++ b/coreppl/src/inference/mcmc-lightweight.mc
@@ -62,7 +62,7 @@ lang LightweightMCMCMethod = InferMethodBase + Assume
       , ("debug", utuple_ [unit_, ulam_ "" (ulam_ "" unit_)])
       , ("resampleBehavior"
         , ulam_ "acc" (ulam_ "length"(
-        ( utuple_ 
+        ( utuple_
           [var_ "acc"
           , if_ (assume_ (bern_ (float_ _mcmcLightweightGlobalProbDefault)))
           (utuple_  [(create_ (var_ "length") (ulam_ "" (bool_ false))) ,(negi_ (int_ 2))])
@@ -71,7 +71,7 @@ lang LightweightMCMCMethod = InferMethodBase + Assume
           ]
         )))
         )
-      --need to build a lambda as current behavior of MCMC lightweight 
+      --need to build a lambda as current behavior of MCMC lightweight
       , ("driftKernel", bool_ _driftKernelDefault)
       , ("driftScale", float_ _driftScaleDefault)
       , ("cps", str_ _cpsDefault)
@@ -117,8 +117,8 @@ lang LightweightMCMCMethod = InferMethodBase + Assume
     let float = TyFloat {info = info} in
     let continueState = newmonovar env.currentLvl info in
     let continue = typeCheckExpr env t.continue in
-    let sampleInfo = tyrecord_ 
-      [ ("weight", float) 
+    let sampleInfo = tyrecord_
+      [ ("weight", float)
       , ("priorWeight", float)
       ] in
     let continueType = tytuple_
@@ -126,13 +126,15 @@ lang LightweightMCMCMethod = InferMethodBase + Assume
       , tyarrows_ [continueState, sampleInfo, sampleType, tytuple_ [continueState, bool]]
       ] in
     unify env [info, infoTm continue] continueType (tyTm continue);
-    let temperature = typeCheckExpr env t.temperature in 
+    let temperature = typeCheckExpr env t.temperature in
     let temperatureType = tyarrow_ continueState float in
     unify env [info, infoTm temperature] temperatureType (tyTm temperature);
     let debugState = newmonovar env.currentLvl info in
     let debug = typeCheckExpr env t.debug in
     let debugInfo = tyrecord_
       [ ("accepted", bool)
+      , ("prevWeight", float)
+      , ("proposalWeight", float)
       ] in
     let debugType = tytuple_
       [ debugState
@@ -142,7 +144,7 @@ lang LightweightMCMCMethod = InferMethodBase + Assume
     let keepSample = typeCheckExpr env t.keepSample in
     unify env [info, infoTm keepSample] (tyarrow_ int bool) (tyTm keepSample);
     let resampleBehavior = typeCheckExpr env t.resampleBehavior in
-    let resampleBehaviorType = tyarrows_ 
+    let resampleBehaviorType = tyarrows_
       [continueState, int, tytuple_ [continueState, tytuple_[tyseq_ bool, int]]]
     in
     unify env [info, infoTm resampleBehavior] resampleBehaviorType (tyTm resampleBehavior);
@@ -182,9 +184,9 @@ let mcmcLightweightOptions : OptParser (use LightweightMCMCMethod in InferMethod
         (utuple_ [subi_ (var_ "remaining") (int_ 1), eqi_ (var_ "remaining") (int_ 0)])))
       ]
     , temperature = ulam_ "" (float_ 1.0)
-    , resampleBehavior = 
+    , resampleBehavior =
         ulam_ "acc" (ulam_ "length"(
-        ( utuple_ 
+        ( utuple_
           [var_ "acc"
           , if_ (assume_ (bern_ (float_ globalProb)))
           (utuple_  [(create_ (var_ "length") (ulam_ "" (bool_ false))) ,(negi_ (int_ 2))])


### PR DESCRIPTION
This PR makes it possible to track weights when using `--debug-mcmc` in mcmc-lightweight by outputting the weight of the previous sample as well as the new proposal (regardless of whether it was accepted or not).