### PR TITLE
Actually honor the --print-mcore flag

### DIFF
--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -90,6 +90,10 @@ let hooks = mkEmptyHooks ocamlCompile in
 let ast = lowerAll ast in
 endPhaseStatsExpr log "lower-all" ast;
 
+(if options.frontend.printMCore then
+  printLn (expr2str ast)
+ else ());
+
 if options.frontend.exitBefore then exit 0 else
 
 let res = compileMCore ast hooks in


### PR DESCRIPTION
I realized that the `--print-mcore` flag wasn't ever looked at, and so didn't do anything.