### PR TITLE
Handle TmOpaque

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -25,9 +25,10 @@ include "inference-interface.mc"
 include "pruning/compile.mc"
 include "delayed-sampling/compile.mc"
 
-lang DPPLReplace = Ast
+lang DPPLReplace = Ast + OpaqueAst
   sem replaceDpplKeywords : {path : String, env : SymEnv} -> Expr -> Expr
   sem replaceDpplKeywords distEnv =
+  | t & TmOpaque _ -> t
   | t ->
     let t = smap_Expr_Expr (replaceDpplKeywords distEnv) t in
     let t = smap_Expr_Type replaceDpplKeywordsType t in
@@ -88,7 +89,7 @@ lang DPPLDelayedReplace = DPPLReplace + DPPLParser
   | TyDelaySeqF t -> TySeq {info = t.info, ty = TyFloat {info = t.info}}
 end
 
-lang DPPLPrunedReplace = DPPLReplace + SymGetters + DPPLParser
+lang DPPLPrunedReplace = DPPLReplace + SymGetters + DPPLParser + OpaqueAst
   sem replaceCancel env =
   | (TmCancel t) ->
     let i = withInfo t.info in
@@ -96,6 +97,7 @@ lang DPPLPrunedReplace = DPPLReplace + SymGetters + DPPLParser
  t.dist t.value),
                info = t.info,
                ty = t.ty}
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr (replaceCancel env) t
 
   sem replaceDpplKeywords distEnv =
@@ -115,6 +117,7 @@ lang ElementaryFunctionsTransform = ElementaryFunctions
   sem elementaryFunctionsTransformExpr : (String -> Name) -> Expr -> Expr
   sem elementaryFunctionsTransformExpr stringToName =
   | tm & TmConst r -> elementaryFunctionsTransformConst stringToName tm r.val
+  | tm & TmOpaque _ -> tm
   | tm -> smap_Expr_Expr (elementaryFunctionsTransformExpr stringToName) tm
 
   sem elementaryFunctionsTransformConst : (String -> Name) -> Expr -> Const -> Expr
@@ -153,9 +156,10 @@ lang ReplaceHigherOrderConstants
   sem replaceHigherOrderConstants : {path : String, env : SymEnv} -> Expr -> Expr
 end
 
-lang ReplaceHigherOrderConstantsLoadedPreviously = ReplaceHigherOrderConstants + SymGetters
+lang ReplaceHigherOrderConstantsLoadedPreviously = ReplaceHigherOrderConstants + SymGetters + OpaqueAst
   sem replaceHigherOrderConstants env =
   | tm -> smap_Expr_Expr (replaceHigherOrderConstants env) tm
+  | tm & TmOpaque _ -> tm
   | tm & TmConst x ->
     match _replaceHigherOrderConstant x.val with Some name then
       withType x.ty (withInfo x.info (nvar_ (_getVarExn name env)))
@@ -169,7 +173,7 @@ end
 lang DPPLResymbolizeModel =
   Resymbolize + ResymbolizeVar + ResymbolizeLam + ResymbolizeMatch +
   ResymbolizeDecl + ResymbolizeLetDecl + ResymbolizeRecLetsDecl +
-  ResymbolizeNamedPat + ResymbolizeSeqEdgePat
+  ResymbolizeNamedPat + ResymbolizeSeqEdgePat + ResymbolizeOpaque
 
   sem resymbolizeExpr : Map Name Name -> Expr -> Expr
   sem resymbolizeExpr nameMap =
@@ -267,6 +271,12 @@ lang CompileModels = ReplaceHigherOrderConstants + PhaseStats + MExprANFAll + DP
     let interface =
       { extractNormal = lam f. extractAst f
       , extractNoHigherOrderConsts = lam f. extractAst (lam ast. replaceHigherOrderConstants envs.higherOrderSymEnv (f ast))
+      , stripOpaque =
+        recursive let work = lam tm.
+          match tm with TmOpaque x
+          then work x.body
+          else smap_Expr_Expr work tm
+        in work
       , options = options
       , runtime = {env = entry.env, lamliftSols = lamliftSols}
       , dists = {env = envs.distEnv, lamliftSols = lamliftSols}
@@ -307,6 +317,7 @@ lang CompileModels = ReplaceHigherOrderConstants + PhaseStats + MExprANFAll + DP
   | TmDecl (x & {decl = DeclType _}) -> removeModelDefinitions x.inexpr
   | TmDecl (x & {decl = DeclConDef _}) -> removeModelDefinitions x.inexpr
   | TmDecl (x & {decl = DeclExt _}) -> removeModelDefinitions x.inexpr
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr removeModelDefinitions t
 end
 

--- a/coreppl/src/coreppl-to-mexpr/dists.mc
+++ b/coreppl/src/coreppl-to-mexpr/dists.mc
@@ -105,6 +105,7 @@ lang TransformDist = TransformDistBase + InferenceInterface
   -- distributions.
   sem replaceTyDist: InferenceSymEnv -> Expr -> Expr
   sem replaceTyDist env =
+  | t & TmOpaque _ -> t
   | t ->
     let t = smap_Expr_Type (toRuntimeTyDist env) t in
     let t = smap_Expr_TypeLabel (toRuntimeTyDist env) t in

--- a/coreppl/src/coreppl-to-mexpr/extract.mc
+++ b/coreppl/src/coreppl-to-mexpr/extract.mc
@@ -117,6 +117,7 @@ lang DPPLExtract =
       (mapInsert inferId t.method acc, inferBinding)
     else
       errorSingle [t.info] "Missing infer runtime"
+  | t & TmOpaque _ -> (acc, t)
   | t -> smapAccumL_Expr_Expr (bindInferExpressionsH runtimes) acc t
 
   -- Extracts an AST consisting of the model whose binding has the provided

--- a/coreppl/src/coreppl-to-mexpr/inference-interface.mc
+++ b/coreppl/src/coreppl-to-mexpr/inference-interface.mc
@@ -19,6 +19,7 @@ lang InferenceInterface = Sym + SymGetters
     -- *entire* AST before extracting the model-relevant code
     , extractNormal : (Expr -> Expr) -> Expr
     , extractNoHigherOrderConsts : (Expr -> Expr) -> Expr
+    , stripOpaque : Expr -> Expr
     , stateName : Name
     }
 

--- a/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/is-lw/compile.mc
@@ -19,7 +19,7 @@ lang MExprPPLImportance =
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNormal (lam x. x) in
+    let t = x.extractNormal x.stripOpaque in
     endPhaseStatsExpr log "extract-normal-one" t;
 
     let t = switch (mapLookup "prune" x.extraEnvs, mapLookup "delayed-sampling" x.extraEnvs)
@@ -139,7 +139,7 @@ lang MExprPPLImportance =
   sem compileCps config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (lam x. x) in
+    let t = x.extractNoHigherOrderConsts x.stripOpaque in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
     -- printLn ""; printLn "--- INITIAL ANF PROGRAM ---";

--- a/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-lightweight/compile.mc
@@ -34,7 +34,7 @@ lang MExprPPLLightweightMCMC
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
 
-    let t = x.extractNormal (generateKernels config.driftScale) in
+    let t = x.extractNormal (lam tm. generateKernels config.driftScale (x.stripOpaque tm)) in
     endPhaseStatsExpr log "extract-normal-one" t;
 
     -- Alignment analysis
@@ -89,7 +89,7 @@ lang MExprPPLLightweightMCMC
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (lam x. x) in
+    let t = x.extractNoHigherOrderConsts x.stripOpaque in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
     -- Addressing transform combined with CorePPL->MExpr transform
@@ -411,7 +411,7 @@ lang MExprPPLLightweightMCMC
   sem compileAlignedCps config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (generateKernels config.driftScale) in
+    let t = x.extractNoHigherOrderConsts (lam tm. generateKernels config.driftScale (x.stripOpaque tm)) in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
     -- printLn ""; printLn "--- INITIAL ANF PROGRAM ---";

--- a/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-naive/compile.mc
@@ -18,7 +18,7 @@ lang MExprPPLNaiveMCMC = MExprPPL + Resample + TransformDist + PhaseStats + Infe
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNormal (lam x. x) in
+    let t = x.extractNormal x.stripOpaque in
     endPhaseStatsExpr log "extract-normal-one" t;
 
     -- Transform distributions to MExpr distributions

--- a/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/mcmc-trace/compile.mc
@@ -18,7 +18,7 @@ lang MExprPPLTraceMCMC = MExprPPL + Resample + TransformDist + PhaseStats + Infe
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNormal (lam x. x) in
+    let t = x.extractNormal x.stripOpaque in
     endPhaseStatsExpr log "extract-normal-one" t;
 
     -- Transform distributions to MExpr distributions

--- a/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/pmcmc-pimh/compile.mc
@@ -14,7 +14,7 @@ lang MExprPPLPIMH =
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (lam x. x) in
+    let t = x.extractNoHigherOrderConsts x.stripOpaque in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
     -- Static analysis and CPS transformation
     let t =

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
@@ -15,7 +15,7 @@ lang MExprPPLAPF =
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (lam x. x) in
+    let t = x.extractNoHigherOrderConsts x.stripOpaque in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
     -- Automatic resampling annotations

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -43,7 +43,7 @@ lang MExprPPLBPF =
   sem compile config =
   | x ->
     let log = mkPhaseLogState x.options.debugDumpPhases x.options.debugPhases (lam. []) in  -- NOTE(vipa, 2026-03-10): These fragments aren't built to be extended, meaning they won't get the fragments needed to process the invariants, thus we process no invariants here
-    let t = x.extractNoHigherOrderConsts (lam x. x) in
+    let t = x.extractNoHigherOrderConsts x.stripOpaque in
     endPhaseStatsExpr log "extract-no-higher-order-consts-one" t;
 
     -- printLn ""; printLn "--- INITIAL ANF PROGRAM ---";

--- a/coreppl/src/dppl-type-check.mc
+++ b/coreppl/src/dppl-type-check.mc
@@ -198,7 +198,7 @@ utest dtcMaxc (N ()) (N ()) with (N ())
 -- │ Annotated AST │
 -- └───────────────┘
 
-lang DTCAstBase = Ast + Eq
+lang DTCAstBase = Ast + Eq + OpaqueAst
   -- NOTE(oerikss, 2024-10-07): The semantic functions in this fragment assumes
   -- that types and terms have been symbolized. I.e., it relies on unique
   -- identifiers in types and terms.
@@ -226,8 +226,10 @@ lang DTCAstBase = Ast + Eq
 
   -- Drops decorations from terms
   sem eraseDecorations : Expr -> Expr
-  sem eraseDecorations =| tm ->
+  sem eraseDecorations =
+  | tm ->
     smap_Expr_Expr eraseDecorations (smap_Expr_Type eraseDecorationsType tm)
+  | tm & TmOpaque _ -> tm
 
   -- Subtyping and type promotion
   -- NOTE(oerikss, 2024-10-04): The defualt case only compares contructors of

--- a/coreppl/src/parser.mc
+++ b/coreppl/src/parser.mc
@@ -19,7 +19,7 @@ include "ode-solver-method.mc"
 
 lang DPPLParser =
   BootParser + MExprPrettyPrint + MExprPPL + Resample + DTCAst +
-  KeywordMaker +
+  KeywordMaker + KeywordMakerOpaque +
 
   ImportanceSamplingMethod + BPFMethod + APFMethod +
   LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod +


### PR DESCRIPTION
This is a followup to https://github.com/miking-lang/miking/pull/986, adding support in `cppl` as needed. Note that I'm not properly supporting `TmOpaque` in all passes used by `cppl`, that turned out to be a lot of very error-prone work that isn't _technically_ needed right now, instead I simply remove `TmOpaque` in the inference methods that currently work without it (which is all of them).

We might re-evaluate later if we want to support it properly everywhere, but `cps` in particular was very tricky to get _mostly_ right, and it still gave spurious and weird to understand errors.