### PR TITLE
Add .cppl extension, to enable explicit selection of which language we're compiling

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/compile.mc
@@ -65,7 +65,7 @@ lang DPPLKeywordReplace = DPPLReplace + DPPLParser + SymGetters
       ty = TyUnknown {info = info}, info = info}
 
   sem replaceDpplKeywords distEnv =
-  | TmAssume t -> 
+  | TmAssume t ->
     app_ (nvar_ (_getVarExn "sample" distEnv)) (replaceDpplKeywords distEnv t.dist)
   | TmObserve t -> _makeError t.info "observe"
   | TmWeight t -> _makeError t.info "weight"
@@ -964,6 +964,8 @@ lang CorePPLFileTypeLoader = CPPLLoader + GeneratePprintLoader + MExprGeneratePp
 
   syn Hook =
   | CorePPLFileHook {options : CPPLFileOptions, method : InferMethod}
+
+  sem _fileType = | _ ++ ".cppl" -> FCorePPL {isModel = false}
 
   sem _insertBackcompatInfer : CPPLFileOptions -> InferMethod -> Expr -> Loader -> Loader
   sem _insertBackcompatInfer options method modelBody = | loader ->


### PR DESCRIPTION
This PR makes the `loader.mc` interface try to parse `.cppl` files as CorePPL files, which is useful for TreePPL that would like to have some library functions implemented in not just MCore.

Handling of `.mc` files when calling the `cppl` compiler is unchanged, it will still treat `.mc` files as CorePPL files, i.e., you still cannot import a pure MCore file.