### PR TITLE
Make SMC algorithms refuse to run if there are no resample points

### DIFF
--- a/coreppl/models/diff/confusion.mc
+++ b/coreppl/models/diff/confusion.mc
@@ -3,6 +3,11 @@ let model = lam.
   -- scalar differentiation
   let diff1 : (Float -> Float) -> Float -> Float = lam f. lam x. diff f x 1. in
 
+  -- NOTE(vipa, 2026-06-10): We insert a resample to allow SMC
+  -- algorithms to run this model, even though it doesn't matter at
+  -- all for this particular model
+  resample;
+
   -- Should be 2., pertubation confusion between the outer and inner derivative
   -- will instead result in 3.
   diff1 (lam x. mulf x (diff1 (lam y. mulf x y) 2.)) 1.

--- a/coreppl/models/diff/demo.mc
+++ b/coreppl/models/diff/demo.mc
@@ -11,6 +11,11 @@ let model : () -> () = lam.
     if x then () else error (concat "Assertion failed: " msg)
   in
 
+  -- NOTE(vipa, 2026-06-10): We insert a resample to allow SMC
+  -- algorithms to run this model, even though it doesn't matter at
+  -- all for this particular model
+  resample;
+
   -- ┌────────────────────┐
   -- │ Scalar Derivatives │
   -- └────────────────────┘

--- a/coreppl/models/ode/harmonic.mc
+++ b/coreppl/models/ode/harmonic.mc
@@ -13,6 +13,10 @@ let model: Method -> () -> [Float] = lam m. lam.
     [v, (negf x)]
   in
   let t0 = 0. in
+  -- NOTE(vipa, 2026-06-10): We insert a resample to allow SMC
+  -- algorithms to run this model, even though it doesn't matter at
+  -- all for this particular model
+  resample;
   let x0 = [1., 0.] in
   switch m
   case RungeKutta _ then

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/compile.mc
@@ -34,6 +34,15 @@ lang MExprPPLAPF =
     in
     endPhaseStatsExpr log "resample-one" t;
 
+    recursive let hasResample = lam acc. lam tm.
+      if acc then acc else
+      match tm with TmResample _ then true else
+      sfold_Expr_Expr hasResample false tm in
+    (if not (hasResample false t) then
+      error "A model compiled with smc-apf has no resample points, i.e., smc would be equivalent with importance sampling. Please explicitly use importance sampling if that is desired, or try a different 'resample' option."
+     else ());
+    endPhaseStatsExpr log "has-resample" t;
+
     -- Static analysis and CPS transformation
     let t =
       let nEnd = _getConExn "End" x.runtime.env in

--- a/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-bpf/compile.mc
@@ -66,6 +66,15 @@ lang MExprPPLBPF =
     in
     endPhaseStatsExpr log "resample-one" t;
 
+    recursive let hasResample = lam acc. lam tm.
+      if acc then acc else
+      match tm with TmResample _ then true else
+      sfold_Expr_Expr hasResample false tm in
+    (if not (hasResample false t) then
+      error "A model compiled with smc-bpf has no resample points, i.e., smc would be equivalent with importance sampling. Please explicitly use importance sampling if that is desired, or try a different 'resample' option."
+     else ());
+    endPhaseStatsExpr log "has-resample" t;
+
     -- Static analysis and CPS transformation
     let t =
       let cEnd = _getConExn "End" x.runtime.env in

--- a/coreppl/test/coreppl-to-mexpr/cli/biased-pick-pair.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/biased-pick-pair.mc
@@ -14,18 +14,18 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps full"                       ) with rhs using e in
 utest r (t 500 "-m mcmc-trace"                                  ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/clads.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/clads.mc
@@ -26,16 +26,16 @@ utest r (t 1000 0 "-m is-lw --cps partial"                         ) with rhs us
 utest r (t 1000 0 "-m is-lw --cps partial --no-early-stop"         ) with rhs using en in
 utest r (t 1000 0 "-m is-lw --cps full"                            ) with rhs using en in
 utest r (t 1000 0 "-m is-lw --cps full --no-early-stop"            ) with rhs using en in
-utest r (t 1000 0 "-m smc-bpf --cps partial --resample manual"     ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-bpf --cps partial --resample manual"     ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps partial --resample align"      ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps partial --resample likelihood" ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-bpf --cps full --resample manual"        ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-bpf --cps full --resample manual"        ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps full --resample align"         ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps full --resample likelihood"    ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-apf --cps partial --resample manual"     ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-apf --cps partial --resample manual"     ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps partial --resample align"      ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps partial --resample likelihood" ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-apf --cps full --resample manual"        ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-apf --cps full --resample manual"        ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps full --resample align"         ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps full --resample likelihood"    ) with rhs using lam. lam. true in
 utest r (t 1000 500 "-m pmcmc-pimh --cps partial"                  ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/coin-iter-alter.mc
@@ -17,16 +17,16 @@ let res: [(Int, String)]  = [
   (0  ,"-m 'is-lw' --cps partial --no-early-stop"),
   (0  ,"-m 'is-lw' --cps full"),
   (0  ,"-m 'is-lw' --cps full --no-early-stop"),
-  (0  ,"-m 'smc-bpf' --cps partial --resample manual"),
+  -- (0  ,"-m 'smc-bpf' --cps partial --resample manual"),
   (0  ,"-m 'smc-bpf' --cps partial --resample align"),
   (0  ,"-m 'smc-bpf' --cps partial --resample likelihood"),
-  (0  ,"-m 'smc-bpf' --cps full --resample manual"),
+  -- (0  ,"-m 'smc-bpf' --cps full --resample manual"),
   (0  ,"-m 'smc-bpf' --cps full --resample align"),
   (0  ,"-m 'smc-bpf' --cps full --resample likelihood"),
-  (0  ,"-m 'smc-apf' --cps partial --resample manual"),
+  -- (0  ,"-m 'smc-apf' --cps partial --resample manual"),
   (0  ,"-m 'smc-apf' --cps partial --resample align"),
   (0  ,"-m 'smc-apf' --cps partial --resample likelihood"),
-  (0  ,"-m 'smc-apf' --cps full --resample manual"),
+  -- (0  ,"-m 'smc-apf' --cps full --resample manual"),
   (0  ,"-m 'smc-apf' --cps full --resample align"),
   (0  ,"-m 'smc-apf' --cps full --resample likelihood"),
   (500,"-m 'pmcmc-pimh' --cps partial"),
@@ -41,11 +41,11 @@ let res: [(Int, String)]  = [
   (500, "-m 'mcmc-lightweight' --align --cps partial --kernel --drift 2. --mcmc-lw-gprob 0.")
 ] in
 -- these values come from outside calculation on a BetaBernouilli conjugate prior for alpha = 3, beta = 5 => Beta( 9, 9)
-let quantile: [(Float, Float, Float)] = [(0.2781183, 0.7218817, 0.95), 
-(0.3108296, 0.6891704, 0.9), 
-(0.3503948, 0.6496052, 0.8),  
-(0.4004409, 0.5995591, 0.6),  
-(0.4697533, 0.5302467, 0.2)]  
+let quantile: [(Float, Float, Float)] = [(0.2781183, 0.7218817, 0.95),
+(0.3108296, 0.6891704, 0.9),
+(0.3503948, 0.6496052, 0.8),
+(0.4004409, 0.5995591, 0.6),
+(0.4697533, 0.5302467, 0.2)]
 in
 
 iter (((testPattern t) eq) quantile) res

--- a/coreppl/test/coreppl-to-mexpr/cli/coin-iter.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/coin-iter.mc
@@ -18,16 +18,16 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/coin.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/coin.mc
@@ -18,16 +18,16 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/crbd.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/crbd.mc
@@ -26,16 +26,16 @@ utest r (t 1000 0 "-m is-lw --cps partial"                         ) with rhs us
 utest r (t 1000 0 "-m is-lw --cps partial --no-early-stop"         ) with rhs using en in
 utest r (t 1000 0 "-m is-lw --cps full"                            ) with rhs using en in
 utest r (t 1000 0 "-m is-lw --cps full --no-early-stop"            ) with rhs using en in
-utest r (t 1000 0 "-m smc-bpf --cps partial --resample manual"     ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-bpf --cps partial --resample manual"     ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps partial --resample align"      ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps partial --resample likelihood" ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-bpf --cps full --resample manual"        ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-bpf --cps full --resample manual"        ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps full --resample align"         ) with rhs using en in
 utest r (t 1000 0 "-m smc-bpf --cps full --resample likelihood"    ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-apf --cps partial --resample manual"     ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-apf --cps partial --resample manual"     ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps partial --resample align"      ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps partial --resample likelihood" ) with rhs using lam. lam. true in
-utest r (t 1000 0 "-m smc-apf --cps full --resample manual"        ) with rhs using en in
+-- utest r (t 1000 0 "-m smc-apf --cps full --resample manual"        ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps full --resample align"         ) with rhs using en in
 utest r (t 1000 0 "-m smc-apf --cps full --resample likelihood"    ) with rhs using lam. lam. true in
 utest r (t 1000 500 "-m pmcmc-pimh --cps partial"                  ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/gamma-poisson.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/gamma-poisson.mc
@@ -17,16 +17,16 @@ let res: [(Int, String)]  = [
   (0  ,"-m 'is-lw' --cps partial --no-early-stop"),
   (0  ,"-m 'is-lw' --cps full"),
   (0  ,"-m 'is-lw' --cps full --no-early-stop"),
-  (0  ,"-m 'smc-bpf' --cps partial --resample manual"),
+  -- (0  ,"-m 'smc-bpf' --cps partial --resample manual"),
   (0  ,"-m 'smc-bpf' --cps partial --resample align"),
   (0  ,"-m 'smc-bpf' --cps partial --resample likelihood"),
-  (0  ,"-m 'smc-bpf' --cps full --resample manual"),
+  -- (0  ,"-m 'smc-bpf' --cps full --resample manual"),
   (0  ,"-m 'smc-bpf' --cps full --resample align"),
   (0  ,"-m 'smc-bpf' --cps full --resample likelihood"),
-  (0  ,"-m 'smc-apf' --cps partial --resample manual"),
+  -- (0  ,"-m 'smc-apf' --cps partial --resample manual"),
   (0  ,"-m 'smc-apf' --cps partial --resample align"),
   (0  ,"-m 'smc-apf' --cps partial --resample likelihood"),
-  (0  ,"-m 'smc-apf' --cps full --resample manual"),
+  -- (0  ,"-m 'smc-apf' --cps full --resample manual"),
   (0  ,"-m 'smc-apf' --cps full --resample align"),
   (0  ,"-m 'smc-apf' --cps full --resample likelihood"),
   (500,"-m 'pmcmc-pimh' --cps partial"),
@@ -41,10 +41,10 @@ let res: [(Int, String)]  = [
   (500, "-m 'mcmc-lightweight' --align --cps partial --kernel --drift 0.05 --mcmc-lw-gprob 0.0")
 ] in
 -- these values come from outside calculation on a GammaPoisson conjugate prior for n = 100, alpha = 100, beta = 1, p = [obs] => Gamma(shape = alpha+sum(p), rate = beta+n)
-let quantile: [(Float, Float, Float)] = [(100.2653, 104.2089, 0.95), 
-(100.5786, 103.8882, 0.9), 
-(100.9405, 103.5191, 0.8),  
-(101.3801, 103.0735, 0.6),  
+let quantile: [(Float, Float, Float)] = [(100.2653, 104.2089, 0.95),
+(100.5786, 103.8882, 0.9),
+(100.9405, 103.5191, 0.8),
+(101.3801, 103.0735, 0.6),
 (101.9698, 102.4795, 0.2)]
 in
 

--- a/coreppl/test/coreppl-to-mexpr/cli/pick-pair.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/pick-pair.mc
@@ -14,18 +14,18 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps full"                       ) with rhs using e in
 utest r (t 500 "-m mcmc-trace"                                  ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/regression.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/regression.mc
@@ -19,16 +19,16 @@ utest r (t 1000  0 "-m is-lw --cps partial"                                     
 utest r (t 1000  0 "-m is-lw --cps partial --no-early-stop"                           ) with rhs using e in
 utest r (t 1000  0 "-m is-lw --cps full"                                              ) with rhs using e in
 utest r (t 1000  0 "-m is-lw --cps full --no-early-stop"                              ) with rhs using e in
-utest r (t 1000  0 "-m smc-bpf --cps partial --resample manual"                       ) with rhs using e in
+-- utest r (t 1000  0 "-m smc-bpf --cps partial --resample manual"                       ) with rhs using e in
 utest r (t 1000  0 "-m smc-bpf --cps partial --resample align"                        ) with rhs using e in
 utest r (t 1000  0 "-m smc-bpf --cps partial --resample likelihood"                   ) with rhs using e in
-utest r (t 1000  0 "-m smc-bpf --cps full --resample manual"                          ) with rhs using e in
+-- utest r (t 1000  0 "-m smc-bpf --cps full --resample manual"                          ) with rhs using e in
 utest r (t 1000  0 "-m smc-bpf --cps full --resample align"                           ) with rhs using e in
 utest r (t 1000  0 "-m smc-bpf --cps full --resample likelihood"                      ) with rhs using e in
-utest r (t 1000  0 "-m smc-apf --cps partial --resample manual"                       ) with rhs using e in
+-- utest r (t 1000  0 "-m smc-apf --cps partial --resample manual"                       ) with rhs using e in
 utest r (t 1000  0 "-m smc-apf --cps partial --resample align"                        ) with rhs using e in
 utest r (t 1000  0 "-m smc-apf --cps partial --resample likelihood"                   ) with rhs using e in
-utest r (t 1000  0 "-m smc-apf --cps full --resample manual"                          ) with rhs using e in
+-- utest r (t 1000  0 "-m smc-apf --cps full --resample manual"                          ) with rhs using e in
 utest r (t 1000  0 "-m smc-apf --cps full --resample align"                           ) with rhs using e in
 utest r (t 1000  0 "-m smc-apf --cps full --resample likelihood"                      ) with rhs using e in
 utest r (t 1000  500 "-m pmcmc-pimh"                                                  ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/sprinkler.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/sprinkler.mc
@@ -19,16 +19,16 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/cli/ssm.mc
+++ b/coreppl/test/coreppl-to-mexpr/cli/ssm.mc
@@ -18,16 +18,16 @@ utest r (t 0   "-m is-lw --cps partial"                         ) with rhs using
 utest r (t 0   "-m is-lw --cps partial --no-early-stop"         ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full"                            ) with rhs using e in
 utest r (t 0   "-m is-lw --cps full --no-early-stop"            ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-bpf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-bpf --cps full --resample likelihood"    ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps partial --resample manual"     ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample align"      ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps partial --resample likelihood" ) with rhs using e in
-utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
+-- utest r (t 0   "-m smc-apf --cps full --resample manual"        ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample align"         ) with rhs using e in
 utest r (t 0   "-m smc-apf --cps full --resample likelihood"    ) with rhs using e in
 utest r (t 500 "-m pmcmc-pimh --cps partial"                    ) with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/dppl/examples/bayesian-parameter-estimation.mc
+++ b/coreppl/test/coreppl-to-mexpr/dppl/examples/bayesian-parameter-estimation.mc
@@ -4,7 +4,7 @@ include "./bayesian-regression-model.mc"
 let z = lam #var"θ" : FloatP.
   map (lam x : FloatP. g (y #var"θ" (x0, y0) x)) times
 -- let z = lam #var"θ" : FloatA. map g (trace (y #var"θ") (x0, y0) times) -- slightly faster
-let #var"Dist_θ" = infer (APF { particles = 5000 }) (regressionModel data z)
+let #var"Dist_θ" = infer (APF { particles = 5000, resample = "likelihood" }) (regressionModel data z)
 
 mexpr
 

--- a/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
+++ b/coreppl/test/coreppl-to-mexpr/expectation/empirical.mc
@@ -24,11 +24,11 @@ let expected = foldl addf 0. [6., 0.5, 0.5, 1., 2.5] in
 let d = infer (Importance { particles = 1000 }) model1 in
 utest expectation d with expected using eqfApprox 1e-1 in
 
-let d = infer (BPF { particles = 1000 }) model1 in
-utest expectation d with expected using eqfApprox 1e-1 in
+-- let d = infer (BPF { particles = 1000, resample = "align" }) model1 in
+-- utest expectation d with expected using eqfApprox 1e-1 in
 
-let d = infer (APF { particles = 1000 }) model1 in
-utest expectation d with expected using eqfApprox 1e-1 in
+-- let d = infer (APF { particles = 1000, resample = "align" }) model1 in
+-- utest expectation d with expected using eqfApprox 1e-1 in
 
 let d = infer (PIMH { particles = 1000 }) model1 in
 utest expectation d with expected using eqfApprox 1e-1 in
@@ -47,11 +47,11 @@ utest expectation d with expected using eqfApprox 1e-1 in
 let d = infer (Importance { particles = 1 }) model2 in
 utest expectation d with expected in
 
-let d = infer (BPF { particles = 1 }) model2 in
-utest expectation d with expected in
+-- let d = infer (BPF { particles = 1, resample = "align" }) model2 in
+-- utest expectation d with expected in
 
-let d = infer (APF { particles = 2 }) model2 in
-utest expectation d with expected in
+-- let d = infer (APF { particles = 2, resample = "align" }) model2 in
+-- utest expectation d with expected in
 
 let d = infer (PIMH { particles = 1 }) model2 in
 utest expectation d with expected in

--- a/coreppl/test/coreppl-to-mexpr/infer/clads.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/clads.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                              with rhs using en in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using en in
-utest r (c 0   (infer (BPF { particles = 2000 }) model))                                with rhs using en in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using en in
+utest r (c 0   (infer (BPF { particles = 2000, resample = "align" }) model))            with rhs using en in
+utest r (c 0   (infer (APF { particles = 1000, resample = "align" }) model))            with rhs using en in
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 10000 }) model))                        with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/coin-iter.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/coin-iter.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                              with rhs using e in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using e in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using e in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000, resample = "align" }) model))            with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000, resample = "align" }) model))            with rhs using e in
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/coin.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/coin.mc
@@ -21,8 +21,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                              with rhs using e in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using e in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using e in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000, resample = "align" }) model))            with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000, resample = "align" }) model))            with rhs using e in
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/crbd.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/crbd.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                              with rhs using en in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using en in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using en in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using en in
+utest r (c 0   (infer (BPF { particles = 1000, resample = "align" }) model))            with rhs using en in
+utest r (c 0   (infer (APF { particles = 1000, resample = "align" }) model))            with rhs using en in
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 10000 }) model))                        with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 10000 }) model))                        with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/diff-regression.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                              with rhs using e in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                         with rhs using e in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))                                with rhs using e in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000, resample = "likelihood" }) model))       with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000, resample = "likelihood" }) model))       with rhs using e in
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))               with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                         with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                         with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/sprinkler.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/sprinkler.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0 (infer (Default {}) model))                                                                 with rhs using e in
 utest r (c 0 (infer (Importance { particles = 1000 }) model))                                            with rhs using e in
-utest r (c 0 (infer (BPF { particles = 1000 }) model))                                                   with rhs using e in
-utest r (c 0 (infer (APF { particles = 1000 }) model))                                                   with rhs using e in
+utest r (c 0 (infer (BPF { particles = 1000, resample = "align" }) model))                               with rhs using e in
+utest r (c 0 (infer (APF { particles = 1000, resample = "align" }) model))                               with rhs using e in
 utest r (c 500 (infer (PIMH { particles = 10, iterations = 100 }) model))                                with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                                          with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                                          with rhs using e in

--- a/coreppl/test/coreppl-to-mexpr/infer/ssm.mc
+++ b/coreppl/test/coreppl-to-mexpr/infer/ssm.mc
@@ -19,8 +19,8 @@ let rB = resampleBehavior 0.1 in
 
 utest r (c 0   (infer (Default {}) model))                                                               with rhs using e in
 utest r (c 0   (infer (Importance { particles = 1000 }) model))                                          with rhs using e in
-utest r (c 0   (infer (BPF { particles = 1000 }) model))                                                 with rhs using e in
-utest r (c 0   (infer (APF { particles = 1000 }) model))                                                 with rhs using e in
+utest r (c 0   (infer (BPF { particles = 1000, resample = "align" }) model))                             with rhs using e in
+utest r (c 0   (infer (APF { particles = 1000, resample = "align" }) model))                             with rhs using e in
 utest r (c 500 (infer (PIMH { particles = 2, iterations = 1000 }) model))                                with rhs using e in
 utest r (c 500 (infer (TraceMCMC { iterations = 1000 }) model))                                          with rhs using e in
 utest r (c 500 (infer (NaiveMCMC { iterations = 1000 }) model))                                          with rhs using e in


### PR DESCRIPTION
SMC algorithms degenerate into importance sampling if there are no resample points, which currently isn't surfaced to the user at all presently. This PR (similar to #229) makes it apparent, here by failing to compile the model.

The error message is currently not particularly friendly: `A model compiled with smc-bpf has no resample points, refusing to use it.`

This turns out to fire a bunch of times in the test suite, so this PR also:
- Turns off tests with `--resample manual` for models without explicit `resample`s.
- Adds `resample = "align"` or `resample = "likelihood"` for first-class `infer` tests.
- Adds explicit `resample`s for some non-probabilistic tests that are there purely to test compatibility between diff and probabilistic parts of the compiler.