### PR TITLE
Path patch

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/pval-graph/idealized-transformation.mc
+++ b/coreppl/src/coreppl-to-mexpr/pval-graph/idealized-transformation.mc
@@ -17,7 +17,7 @@
 -- passed between calls to `pure`, `map`, etc.
 
 include "these.mc"
-include "coreppl::parser.mc"
+include "../../parser.mc"
 include "mexpr/shallow-patterns.mc"
 include "mexpr/hoas.mc"
 include "mexpr/inline-single-use-simple.mc"

--- a/coreppl/src/coreppl-to-mexpr/pval-graph/remove-second-class-lambdas.mc
+++ b/coreppl/src/coreppl-to-mexpr/pval-graph/remove-second-class-lambdas.mc
@@ -11,7 +11,7 @@
 
 include "mexpr/ast.mc"
 include "mexpr/pprint.mc"
-include "coreppl::parser.mc"
+include "../../parser.mc"
 
 
 let _cmpSym : Symbol -> Symbol -> Int = lam l. lam r. subi (sym2hash l) (sym2hash r)


### PR DESCRIPTION
Fast patch to make miking-dppl compile again.

"I think this is a conflict where some files import from the repository via a relative path and some import from [coreppl]::, i.e., what's installed" [@elegios]

A deeper review will be needed later, some `coreppl::` are still laying around but don't forbid the code to compile.
(pass make test locally)