### PR TITLE
Control `smc-apf` number of propagation

### DIFF
--- a/coreppl/src/coreppl-to-mexpr/pval-graph/idealized-transformation.mc
+++ b/coreppl/src/coreppl-to-mexpr/pval-graph/idealized-transformation.mc
@@ -17,7 +17,7 @@
 -- passed between calls to `pure`, `map`, etc.
 
 include "these.mc"
-include "coreppl::parser.mc"
+include "../../parser.mc"
 include "mexpr/shallow-patterns.mc"
 include "mexpr/hoas.mc"
 include "mexpr/inline-single-use-simple.mc"

--- a/coreppl/src/coreppl-to-mexpr/pval-graph/remove-second-class-lambdas.mc
+++ b/coreppl/src/coreppl-to-mexpr/pval-graph/remove-second-class-lambdas.mc
@@ -11,7 +11,7 @@
 
 include "mexpr/ast.mc"
 include "mexpr/pprint.mc"
-include "coreppl::parser.mc"
+include "../../parser.mc"
 
 
 let _cmpSym : Symbol -> Symbol -> Int = lam l. lam r. subi (sym2hash l) (sym2hash r)

--- a/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
+++ b/coreppl/src/coreppl-to-mexpr/smc-apf/runtime.mc
@@ -78,8 +78,11 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
             } out)
           else never
       in
-      let resampled = systematicSample particles expWeights expWeightSum (subi particleCount index) in
-      propagateRecRec index resampled out
+      if gti propagations config.maxPropagations then
+        (toList [])
+      else
+        let resampled = systematicSample particles expWeights expWeightSum (subi particleCount index) in
+        propagateRecRec index resampled out
     in
     propagateRec 0 0 (toList [])
   in
@@ -95,7 +98,7 @@ let run : all a. Unknown -> (State -> Checkpoint a) -> use RuntimeDistBase in Di
   match runRec particles with (weights,samples) in
 
   -- Return
-  if config.subsample then
+  if (and config.subsample (neqi (length samples) 0)) then
     constructDistEmpiricalSubsample config.subsampleSize samples weights
       (EmpNorm {normConst = normConstant weights})
   else

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -87,6 +87,13 @@ let _resampleFrac : OptParser Float =
     , description = concat "Floating point number to trigger resampling for SMC-BPF when ESS is less than resampleFrac × particleCount. Default: " (float2string _resampleFracDefault)
     } in
   optOr opt (optPure _resampleFracDefault)
+let _maxPropagationsDefault : Int = 1000
+let _maxPropagations : OptParser Int =
+  let opt = optArg
+    { optArgDefInt with long = "max-propa"
+    , description = concat "The number of time smc-apf (at a specific resample step) will try to find a non-zero weight path for a particule. Default: " (int2string _maxPropagationsDefault)
+    } in
+  optOr opt (optPure _maxPropagationsDefault)
 let _subsampleDefault : Bool = false
 let _subsample : OptParser Bool = optMap (xor _subsampleDefault) (optFlag
   { optFlagDef with long = "subsample"

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -90,7 +90,7 @@ let _resampleFrac : OptParser Float =
 let _maxPropagationsDefault : Int = 1000
 let _maxPropagations : OptParser Int =
   let opt = optArg
-    { optArgDefInt with long = "max-propa"
+    { optArgDefInt with long = "max-propagations"
     , description = concat "The number of time smc-apf (at a specific resample step) will try to find a non-zero weight path for a particule. Default: " (int2string _maxPropagationsDefault)
     } in
   optOr opt (optPure _maxPropagationsDefault)

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -91,7 +91,7 @@ let _maxPropagationsDefault : Int = 1000
 let _maxPropagations : OptParser Int =
   let opt = optArg
     { optArgDefInt with long = "max-propagations"
-    , description = concat "The number of time smc-apf (at a specific resample step) will try to find a non-zero weight path for a particule. Default: " (int2string _maxPropagationsDefault)
+    , description = concat "The maximum number of attempts tried by smc-apf (at a given resample step) to find a non-zero weighted path for a particle. Default: " (int2string _maxPropagationsDefault)
     } in
   optOr opt (optPure _maxPropagationsDefault)
 let _subsampleDefault : Bool = false

--- a/coreppl/src/inference/smc-apf.mc
+++ b/coreppl/src/inference/smc-apf.mc
@@ -5,6 +5,7 @@ lang APFMethod = InferMethodBase
     { particles : Expr -- : Int
     , subsample : Expr -- : Bool
     , subsampleSize : Expr -- : Int
+    , maxPropagations : Expr -- : Int
     , resample : String
     , prune : Bool
     , cps : String
@@ -18,6 +19,7 @@ lang APFMethod = InferMethodBase
     match pprintCode i env x.particles with (env, particles) in
     match pprintCode i env x.subsample with (env, subsample) in
     match pprintCode i env x.subsampleSize with (env, subsampleSize) in
+    match pprintCode i env x.maxPropagations with (env, maxPropagations) in
     match pprintCode i env (str_ x.resample) with (env, resample) in
     match pprintCode i env (str_ x.cps) with (env, cps) in
     let prune = bool2string x.prune in
@@ -27,6 +29,7 @@ lang APFMethod = InferMethodBase
       , "{ particles = ", particles
       , ", subsample = ", subsample
       , ", subsampleSize = ", subsampleSize
+      , ", maxPropagations = ", maxPropagations
       , ", resample = ", resample
       , ", prune = ", prune
       , ", cps = ", cps
@@ -40,16 +43,18 @@ lang APFMethod = InferMethodBase
       [ ("particles", int_ _particlesDefault)
       , ("subsample", bool_ _subsampleDefault)
       , ("subsampleSize", int_ _subsampleSizeDefault)
+      , ("maxPropagations", int_ _maxPropagationsDefault)
       , ("resample", str_ _resampleDefault)
       , ("prune", bool_ _pruneDefault)
       , ("cps", str_ _cpsDefault)
       ] in
     match getFields info bindings expectedFields
-      with [particles, subsample, subsampleSize, resample, prune, cps] in
+      with [particles, subsample, subsampleSize, maxPropagations, resample, prune, cps] in
     APF
     { particles = particles
     , subsample = subsample
     , subsampleSize = subsampleSize
+    , maxPropagations = maxPropagations
     , resample = _exprAsStringExn resample
     , prune = _exprAsBoolExn prune
     , cps = _exprAsStringExn cps
@@ -60,6 +65,7 @@ lang APFMethod = InferMethodBase
     [ ("particles", x.particles)
     , ("subsample", x.subsample)
     , ("subsampleSize", x.subsampleSize)
+    , ("maxPropagations", x.maxPropagations)
     ]
 
   sem typeCheckInferMethod env info sampleType =
@@ -68,18 +74,21 @@ lang APFMethod = InferMethodBase
     let bool = TyBool {info = info} in
     let particles = typeCheckExpr env x.particles in
     unify env [info, infoTm particles] int (tyTm particles);
-    let subsampleSize = typeCheckExpr env x.subsampleSize in
-    unify env [info, infoTm subsampleSize] int (tyTm subsampleSize);
     let subsample = typeCheckExpr env x.subsample in
     unify env [info, infoTm subsample] bool (tyTm subsample);
-    APF {x with particles = particles, subsample = subsample, subsampleSize = subsampleSize}
+    let subsampleSize = typeCheckExpr env x.subsampleSize in
+    unify env [info, infoTm subsampleSize] int (tyTm subsampleSize);
+    let maxPropagations = typeCheckExpr env x.maxPropagations in
+    unify env [info, infoTm maxPropagations] int (tyTm maxPropagations);
+    APF {x with particles = particles, subsample = subsample, subsampleSize = subsampleSize, maxPropagations = maxPropagations}
 
   sem smapAccumL_InferMethod_Expr f acc =
   | APF r ->
     match f acc r.particles with (acc, particles) in
     match f acc r.subsample with (acc, subsample) in
     match f acc r.subsampleSize with (acc, subsampleSize) in
-    (acc, APF {r with particles = particles, subsample = subsample, subsampleSize = subsampleSize})
+    match f acc r.maxPropagations with (acc, maxPropagations) in
+    (acc, APF {r with particles = particles, subsample = subsample, subsampleSize = subsampleSize, maxPropagations = maxPropagations})
 
   sem setRuns expr =
   | APF r -> APF {r with particles = expr}
@@ -87,13 +96,14 @@ end
 
 let smcApfOptions : OptParser (use APFMethod in InferMethod) =
   use APFMethod in
-  let mk = lam particles. lam subsample. lam subsampleSize. lam resample. lam prune. lam cps. APF
+  let mk = lam particles. lam subsample. lam subsampleSize. lam maxPropagations. lam resample. lam prune. lam cps. APF
     { particles = int_ particles
     , subsample = bool_ subsample
     , subsampleSize = int_ subsampleSize
+    , maxPropagations = int_ maxPropagations
     , resample = resample
     , prune = prune
     , cps = cps
     } in
-  let method = optApply (optMap5 mk _particles _subsample _subsampleSize _resample _prune) _cps in
+  let method = optApply (optApply (optMap5 mk _particles _subsample _subsampleSize _maxPropagations _resample) _prune) _cps in
   optMap2 (lam. lam x. x) (_methodFlag false "smc-apf") method


### PR DESCRIPTION
`smc-apf` keep the number of particles along the inference process stable by redrawing a path for the particles with 0 weight, from the last resample point . This is called propagation (`smc-apf` try to use other particles to "fill the gap"). 

In some cases it has been shown that the `smc-apf` algorithm can end on a near infinite loop (i.e., very unlikely to have particles alive after a resample event).

By introducing a new options `--max-propagations INT` the purpose of this PR is to limit the amount of propagation the algorithm can do (returning a -inf if the number of propagation > `max-propagations`).

Base on [PR 224](https://github.com/miking-lang/miking-dppl/pull/244) 